### PR TITLE
Add PR preview deployment and simplify pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,16 +6,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
   group: pages
   cancel-in-progress: false
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -44,21 +42,9 @@ jobs:
       - name: Build with Trunk
         run: trunk build --release --public-url /nexrad-workbench/
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: dist
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
       - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: dist
+          branch: gh-pages
+          clean-exclude: pr-preview/

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,45 @@
+name: Deploy PR Preview
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+concurrency: preview-${{ github.ref }}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        if: github.event.action != 'closed'
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Rust Cache
+        if: github.event.action != 'closed'
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install Trunk
+        if: github.event.action != 'closed'
+        uses: jetli/trunk-action@v0.5.0
+        with:
+          version: latest
+
+      - name: Build with Trunk
+        if: github.event.action != 'closed'
+        run: trunk build --release --public-url /nexrad-workbench/pr-preview/pr-${{ github.event.number }}/
+
+      - name: Deploy PR Preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: dist/
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview


### PR DESCRIPTION
## Summary
This PR adds automated preview deployments for pull requests and simplifies the GitHub Pages deployment workflow by consolidating it into a single job.

## Key Changes
- **New PR Preview Workflow**: Added `.github/workflows/pr-preview.yml` to automatically build and deploy previews for pull requests
  - Builds Rust/WASM project with Trunk for each PR
  - Deploys previews to `gh-pages` branch under `pr-preview/pr-{number}/` directory
  - Automatically cleans up previews when PRs are closed
  
- **Simplified Pages Workflow**: Refactored `.github/workflows/pages.yml`
  - Consolidated separate `build` and `deploy` jobs into single `build-and-deploy` job
  - Replaced GitHub Pages-specific actions with `JamesIves/github-pages-deploy-action` for more direct control
  - Updated permissions to only require `contents: write`
  - Added `clean-exclude: pr-preview/` to preserve PR preview directories during main branch deployments

## Implementation Details
- PR previews are built with public URL `/nexrad-workbench/pr-preview/pr-{number}/` to avoid conflicts with main site
- Both workflows use Rust caching and conditional steps to optimize build times
- Concurrency control prevents duplicate deployments for the same PR

https://claude.ai/code/session_01Xq5Qw5regm6KUo6CFRWNQQ