### PR TITLE
Move release creation from automatic to manual workflow_dispatch trigger

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,11 +2,6 @@ name: Deploy to GitHub Pages
 
 on:
   workflow_call:
-    inputs:
-      version:
-        description: Version tag to embed in the build
-        required: false
-        type: string
   workflow_dispatch:
 
 permissions:
@@ -45,9 +40,15 @@ jobs:
         with:
           version: latest
 
+      - name: Determine version
+        id: version
+        run: |
+          LATEST=$(git tag --list 'v[0-9]*' --sort=-version:refname | head -n1)
+          echo "tag=${LATEST:-dev}" >> "$GITHUB_OUTPUT"
+
       - name: Build with Trunk
         env:
-          NEXRAD_VERSION: ${{ inputs.version || '' }}
+          NEXRAD_VERSION: ${{ steps.version.outputs.tag }}
         run: trunk build --release --public-url /nexrad-workbench/
 
       - name: Deploy to GitHub Pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,6 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    outputs:
-      tag: ${{ steps.version.outputs.tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,5 +42,3 @@ jobs:
   deploy:
     needs: release
     uses: ./.github/workflows/pages.yml
-    with:
-      version: ${{ needs.release.outputs.tag }}


### PR DESCRIPTION
Separates the release/tagging logic out of the GitHub Pages deploy workflow
into its own release.yml workflow triggered via workflow_dispatch. This
allows batching multiple merges into a single release rather than cutting
a release on every merge to main.

GitHub Pages deployment continues to happen automatically on every push
to main.

https://claude.ai/code/session_014MjAvdTr7dRbYrVV1oisnP