### PR TITLE
Change default ViewMode from Globe3D to Flat2D

### DIFF
--- a/src/state/viz.rs
+++ b/src/state/viz.rs
@@ -186,9 +186,9 @@ impl Default for RenderProcessing {
 #[derive(Default, Clone, Copy, PartialEq, Eq)]
 pub enum ViewMode {
     /// Classic flat equirectangular map.
+    #[default]
     Flat2D,
     /// 3D globe.
-    #[default]
     Globe3D,
 }
 


### PR DESCRIPTION
## Summary
Updated the default variant of the `ViewMode` enum from `Globe3D` to `Flat2D` by moving the `#[default]` attribute accordingly.

## Changes
- Moved `#[default]` attribute from `Globe3D` to `Flat2D` variant in the `ViewMode` enum
- This makes the classic flat equirectangular map the default visualization mode instead of the 3D globe

## Details
The `ViewMode` enum in `src/state/viz.rs` now defaults to `Flat2D` when a new instance is created without explicit specification. This is a simple but intentional change to the default user experience for map visualization.

https://claude.ai/code/session_01Da4dKSTEpNYMkuvqz7M9Cj