### PR TITLE
Add "Now" button to jump to current wall-clock time

### DIFF
--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -20,7 +20,7 @@ mod viz;
 pub use crate::geo::camera::CameraMode;
 pub use layer::{GeoLayerVisibility, LayerState};
 pub use live_mode::{LiveExitReason, LiveModeState, LivePhase};
-pub use playback::{LoopMode, PlaybackSpeed, PlaybackState};
+pub use playback::{LoopMode, PlaybackSpeed, PlaybackState, TimeModel};
 pub use preferences::UserPreferences;
 pub use radar_data::RadarTimeline;
 pub use saved_events::{SavedEvent, SavedEvents};

--- a/src/ui/playback_controls.rs
+++ b/src/ui/playback_controls.rs
@@ -2,7 +2,7 @@
 
 use super::colors::{live, timeline as tl_colors, ui as ui_colors};
 use super::timeline::format_timestamp_full;
-use crate::state::{AppState, LiveExitReason, LivePhase, LoopMode, PlaybackSpeed};
+use crate::state::{AppState, LiveExitReason, LivePhase, LoopMode, PlaybackSpeed, TimeModel};
 use eframe::egui::{self, Color32, RichText, Vec2};
 
 /// Render the datetime picker popup for jumping to a specific time.
@@ -277,6 +277,32 @@ pub(super) fn render_playback_controls(ui: &mut egui::Ui, state: &mut AppState) 
                         .timeline_seconds_per_real_second(),
             );
         state.playback_state.set_playback_position(new_pos);
+    }
+
+    // "Now" button — jump to current wall-clock time
+    if ui
+        .button(RichText::new(format!("{} Now", egui_phosphor::regular::CROSSHAIR)).size(12.0))
+        .on_hover_text("Jump to current time")
+        .clicked()
+    {
+        let now = TimeModel::wall_clock_time();
+
+        // Exit live mode if active
+        if state.live_mode_state.is_active() {
+            state.live_mode_state.stop(LiveExitReason::UserSeeked);
+            state.playback_state.time_model.disable_realtime_lock();
+        }
+
+        // Stop playback
+        state.playback_state.playing = false;
+
+        // Clear bounds so seek_to doesn't clamp
+        state.playback_state.time_model.clear_bounds();
+        state.playback_state.clear_selection();
+
+        // Jump playback position and center the view
+        state.playback_state.time_model.playback_position = now;
+        state.playback_state.center_view_on(now);
     }
 
     ui.separator();


### PR DESCRIPTION
## Summary
Added a new "Now" button to the playback controls that allows users to quickly jump to the current wall-clock time, with automatic handling of live mode and playback state.

## Key Changes
- Added a new "Now" button in the playback controls UI that jumps to the current time
- The button displays a crosshair icon with "Now" label
- When clicked, the button:
  - Retrieves the current wall-clock time using `TimeModel::wall_clock_time()`
  - Exits live mode if currently active (with `LiveExitReason::UserSeeked`)
  - Disables realtime lock on the time model
  - Stops playback
  - Clears time bounds to allow seeking to any position
  - Clears any active selection
  - Updates the playback position and centers the view on the current time
- Exported `TimeModel` from the state module to make it accessible in the UI layer

## Implementation Details
- The button includes a hover tooltip explaining its function
- The implementation properly handles the interaction between live mode, playback state, and time model to ensure consistent state after seeking
- Uses the existing `center_view_on()` method to keep the timeline view focused on the jumped-to time

https://claude.ai/code/session_019atejZN8k5GGEFEfiUHYwc