### PR TITLE
Fix modal backdrop z-order by changing from Foreground to Middle

### DIFF
--- a/src/ui/event_modal.rs
+++ b/src/ui/event_modal.rs
@@ -236,7 +236,7 @@ pub fn render_event_modal(
     // Semi-transparent backdrop
     egui::Area::new(egui::Id::new("event_modal_backdrop"))
         .fixed_pos(egui::Pos2::ZERO)
-        .order(egui::Order::Foreground)
+        .order(egui::Order::Middle)
         .show(ctx, |ui| {
             let screen_rect = ctx.input(|i| i.viewport_rect());
             let (response, painter) = ui.allocate_painter(screen_rect.size(), egui::Sense::click());

--- a/src/ui/network_panel.rs
+++ b/src/ui/network_panel.rs
@@ -22,7 +22,7 @@ pub fn render_network_log(ctx: &egui::Context, state: &mut AppState) {
     // Semi-transparent backdrop
     egui::Area::new(egui::Id::new("network_log_backdrop"))
         .fixed_pos(egui::Pos2::ZERO)
-        .order(egui::Order::Foreground)
+        .order(egui::Order::Middle)
         .show(ctx, |ui| {
             let screen_rect = ctx.input(|i| i.viewport_rect());
             let (response, painter) = ui.allocate_painter(screen_rect.size(), egui::Sense::click());

--- a/src/ui/site_modal.rs
+++ b/src/ui/site_modal.rs
@@ -290,7 +290,7 @@ pub fn render_site_modal(
     // Semi-transparent backdrop
     egui::Area::new(egui::Id::new("site_modal_backdrop"))
         .fixed_pos(egui::Pos2::ZERO)
-        .order(egui::Order::Foreground)
+        .order(egui::Order::Middle)
         .show(ctx, |ui| {
             let screen_rect = ctx.input(|i| i.viewport_rect());
             let (response, painter) = ui.allocate_painter(screen_rect.size(), egui::Sense::click());

--- a/src/ui/stats_modal.rs
+++ b/src/ui/stats_modal.rs
@@ -21,7 +21,7 @@ pub fn render_stats_modal(ctx: &egui::Context, state: &mut AppState) {
     // Semi-transparent backdrop
     egui::Area::new(egui::Id::new("stats_modal_backdrop"))
         .fixed_pos(egui::Pos2::ZERO)
-        .order(egui::Order::Foreground)
+        .order(egui::Order::Middle)
         .show(ctx, |ui| {
             let screen_rect = ctx.input(|i| i.viewport_rect());
             let (response, painter) = ui.allocate_painter(screen_rect.size(), egui::Sense::click());

--- a/src/ui/wipe_modal.rs
+++ b/src/ui/wipe_modal.rs
@@ -19,7 +19,7 @@ pub fn render_wipe_modal(ctx: &egui::Context, state: &mut AppState) {
     // Semi-transparent backdrop
     egui::Area::new(egui::Id::new("wipe_modal_backdrop"))
         .fixed_pos(egui::Pos2::ZERO)
-        .order(egui::Order::Foreground)
+        .order(egui::Order::Middle)
         .show(ctx, |ui| {
             let screen_rect = ctx.input(|i| i.viewport_rect());
             let (response, painter) = ui.allocate_painter(screen_rect.size(), egui::Sense::click());


### PR DESCRIPTION
## Summary
This PR fixes the z-order layering of modal backdrops across the UI by changing their rendering order from `egui::Order::Foreground` to `egui::Order::Middle`. This ensures that modal backdrops render at the correct depth level relative to other UI elements.

## Changes
- **event_modal.rs**: Changed backdrop order from `Foreground` to `Middle`
- **network_panel.rs**: Changed backdrop order from `Foreground` to `Middle`
- **site_modal.rs**: Changed backdrop order from `Foreground` to `Middle`
- **stats_modal.rs**: Changed backdrop order from `Foreground` to `Middle`
- **wipe_modal.rs**: Changed backdrop order from `Foreground` to `Middle`

## Details
All modal backdrop areas were using `egui::Order::Foreground`, which was likely causing z-order conflicts with modal content or other UI elements. By changing to `egui::Order::Middle`, the backdrops now render at an appropriate intermediate layer, allowing proper visual hierarchy and interaction handling across all modal dialogs in the application.

https://claude.ai/code/session_01Dqzv7Yt3ykAspkE5tLtQLD