### PR TITLE
Add periodic repainting for time-dependent UI elements

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1339,6 +1339,12 @@ impl eframe::App for WorkbenchApp {
             }
         }
 
+        // Ensure continuous repainting for time-dependent UI elements (the "now"
+        // marker on the timeline and the data-age indicators) even when the user
+        // is idle and playback is stopped.  Repaint once per second which is
+        // sufficient for these indicators while being easy on the CPU.
+        ctx.request_repaint_after(std::time::Duration::from_secs(1));
+
         // Run storm cell detection on demand when toggled on with existing data
         if self.state.storm_cells_visible && self.state.detected_storm_cells.is_empty() {
             if let Some(ref renderer) = self.renderers.gpu {


### PR DESCRIPTION
## Summary
Added automatic periodic repainting to ensure time-dependent UI elements remain visually current even when the user is idle and playback is stopped.

## Key Changes
- Added `ctx.request_repaint_after(std::time::Duration::from_secs(1))` to request repainting once per second
- This ensures the "now" marker on the timeline and data-age indicators update continuously
- Balances visual responsiveness with CPU efficiency by using a 1-second repaint interval

## Implementation Details
The repaint request is placed in the main update loop of the `WorkbenchApp`, ensuring it applies globally to all time-dependent UI elements. A 1-second interval was chosen as it provides sufficient visual feedback for timeline and age indicators while minimizing unnecessary CPU usage during idle periods.

https://claude.ai/code/session_018wX7V9NXHnuN6BEvo4fr9d