### PR TITLE
Fix archive download entering infinite loop

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -549,6 +549,9 @@ impl WorkbenchApp {
             None => return, // Just pumping queue, nothing to build
         };
 
+        // Clear re-fetch tracking for the new download attempt
+        self.acquisition.listing_refetch_attempts.clear();
+
         // Get the download range: either from selection or from current position.
         // For position download, we use a temporary wide window to determine which
         // date listings to fetch, then narrow to the exact scan below.
@@ -607,16 +610,23 @@ impl WorkbenchApp {
                                 boundary.end,
                             ));
                         }
-                    } else {
+                    } else if !self
+                        .acquisition
+                        .listing_refetch_attempts
+                        .contains(&current_date)
+                    {
                         // No scan covers this time in the cached listing.
                         // The listing may be stale (e.g. archives created after
-                        // it was cached), so invalidate and re-fetch.
+                        // it was cached), so invalidate and re-fetch once.
                         log::info!(
                             "No scan at {} in cached listing for {}/{}; re-fetching",
                             sel_start_i64,
                             site_id,
                             current_date
                         );
+                        self.acquisition
+                            .listing_refetch_attempts
+                            .insert(current_date);
                         self.acquisition
                             .archive_index
                             .remove(&site_id, &current_date);
@@ -636,6 +646,15 @@ impl WorkbenchApp {
                         self.state.status_message =
                             format!("Re-fetching archive listing for {}...", current_date);
                         return;
+                    } else {
+                        // Already re-fetched this listing and still no scan
+                        // at this position — skip rather than looping forever.
+                        log::info!(
+                            "No scan at {} in listing for {}/{} after re-fetch; skipping",
+                            sel_start_i64,
+                            site_id,
+                            current_date
+                        );
                     }
                 } else {
                     // Range selection: find all scans that intersect [sel_start, sel_end]

--- a/src/main.rs
+++ b/src/main.rs
@@ -542,15 +542,23 @@ impl WorkbenchApp {
             return;
         }
 
-        // No queue — check if a new download command was issued
+        // No queue — check if a new download command was issued or a pending
+        // download is being resumed after a listing arrived.
         let is_position_download = match download_type {
-            Some(true) => true,
-            Some(false) => false,
-            None => return, // Just pumping queue, nothing to build
+            Some(is_pos) => {
+                // Fresh user action (not a pending resume) — reset pending state
+                if self
+                    .acquisition
+                    .pending_download
+                    .as_ref()
+                    .is_none_or(|p| p.is_position != is_pos)
+                {
+                    self.acquisition.pending_download = None;
+                }
+                is_pos
+            }
+            None => return, // Just pumping queue, nothing to do
         };
-
-        // Clear re-fetch tracking for the new download attempt
-        self.acquisition.listing_refetch_attempts.clear();
 
         // Get the download range: either from selection or from current position.
         // For position download, we use a temporary wide window to determine which
@@ -610,45 +618,53 @@ impl WorkbenchApp {
                                 boundary.end,
                             ));
                         }
-                    } else if !self
-                        .acquisition
-                        .listing_refetch_attempts
-                        .contains(&current_date)
-                    {
-                        // No scan covers this time in the cached listing.
-                        // The listing may be stale (e.g. archives created after
-                        // it was cached), so invalidate and re-fetch once.
-                        log::info!(
-                            "No scan at {} in cached listing for {}/{}; re-fetching",
-                            sel_start_i64,
-                            site_id,
-                            current_date
-                        );
-                        self.acquisition
-                            .listing_refetch_attempts
-                            .insert(current_date);
-                        self.acquisition
-                            .archive_index
-                            .remove(&site_id, &current_date);
-                        if !self
-                            .acquisition
-                            .download_channel
-                            .is_listing_pending(&site_id, &current_date)
-                        {
-                            self.acquisition.download_channel.fetch_listing(
-                                ctx.clone(),
-                                site_id.clone(),
-                                current_date,
-                            );
-                        }
-                        self.state
-                            .push_command(state::AppCommand::DownloadAtPosition);
-                        self.state.status_message =
-                            format!("Re-fetching archive listing for {}...", current_date);
-                        return;
                     } else {
-                        // Already re-fetched this listing and still no scan
-                        // at this position — skip rather than looping forever.
+                        // No scan covers this time in the cached listing.
+                        // Check if we already re-fetched this date's listing.
+                        let already_refetched = self
+                            .acquisition
+                            .pending_download
+                            .as_ref()
+                            .is_some_and(|p| p.refetched_dates.contains(&current_date));
+
+                        if !already_refetched {
+                            // The listing may be stale (e.g. archives created
+                            // after it was cached), so invalidate and re-fetch
+                            // once. Store intent so we resume when it arrives.
+                            log::info!(
+                                "No scan at {} in cached listing for {}/{}; re-fetching",
+                                sel_start_i64,
+                                site_id,
+                                current_date
+                            );
+                            let pending =
+                                self.acquisition.pending_download.get_or_insert_with(|| {
+                                    nexrad::acquisition_coordinator::PendingDownload {
+                                        is_position: true,
+                                        refetched_dates: std::collections::HashSet::new(),
+                                    }
+                                });
+                            pending.refetched_dates.insert(current_date);
+                            self.acquisition
+                                .archive_index
+                                .remove(&site_id, &current_date);
+                            if !self
+                                .acquisition
+                                .download_channel
+                                .is_listing_pending(&site_id, &current_date)
+                            {
+                                self.acquisition.download_channel.fetch_listing(
+                                    ctx.clone(),
+                                    site_id.clone(),
+                                    current_date,
+                                );
+                            }
+                            self.state.status_message =
+                                format!("Re-fetching archive listing for {}...", current_date);
+                            return;
+                        }
+
+                        // Already re-fetched — no scan here, skip.
                         log::info!(
                             "No scan at {} in listing for {}/{} after re-fetch; skipping",
                             sel_start_i64,
@@ -674,7 +690,8 @@ impl WorkbenchApp {
                     }
                 }
             } else {
-                // Need to fetch the listing first
+                // Need to fetch the listing first. Store intent so we resume
+                // when the listing arrives (via handle_listing_outcome).
                 if !self
                     .acquisition
                     .download_channel
@@ -687,14 +704,12 @@ impl WorkbenchApp {
                         current_date,
                     );
                 }
-                // Re-trigger once listing arrives — preserve the download type
-                if is_position_download {
-                    self.state
-                        .push_command(state::AppCommand::DownloadAtPosition);
-                } else {
-                    self.state
-                        .push_command(state::AppCommand::DownloadSelection);
-                }
+                self.acquisition.pending_download.get_or_insert_with(|| {
+                    nexrad::acquisition_coordinator::PendingDownload {
+                        is_position: is_position_download,
+                        refetched_dates: std::collections::HashSet::new(),
+                    }
+                });
                 self.state.status_message =
                     format!("Fetching archive listing for {}...", current_date);
                 return;
@@ -702,6 +717,9 @@ impl WorkbenchApp {
 
             current_date += chrono::Duration::days(1);
         }
+
+        // Queue building complete — clear pending state
+        self.acquisition.pending_download = None;
 
         if files_to_download.is_empty() {
             self.state.status_message = "No new scans to download in selection".to_string();
@@ -2288,9 +2306,26 @@ impl WorkbenchApp {
                         .archive_index
                         .all_boundaries_for_site(&site_id);
                 }
+
+                // Resume pending download now that the listing is available
+                if let Some(pending) = &self.acquisition.pending_download {
+                    if pending.is_position {
+                        self.state
+                            .push_command(state::AppCommand::DownloadAtPosition);
+                    } else {
+                        self.state
+                            .push_command(state::AppCommand::DownloadSelection);
+                    }
+                }
             }
             nexrad::ListingResult::Error(msg) => {
                 log::error!("Listing request failed: {}", msg);
+                // Abandon pending download on listing failure
+                if self.acquisition.pending_download.is_some() {
+                    self.acquisition.pending_download = None;
+                    self.state.status_message =
+                        format!("Download cancelled: listing fetch failed ({})", msg);
+                }
             }
         }
     }

--- a/src/nexrad/acquisition_coordinator.rs
+++ b/src/nexrad/acquisition_coordinator.rs
@@ -26,6 +26,10 @@ pub struct AcquisitionCoordinator {
     pub(crate) current_scan: Option<CachedScan>,
     /// Record-based data facade.
     pub(crate) data_facade: DataFacade,
+    /// Dates whose listings have already been re-fetched during the current
+    /// download attempt. Prevents infinite re-fetch loops when a listing
+    /// genuinely doesn't contain the requested timestamp.
+    pub(crate) listing_refetch_attempts: std::collections::HashSet<chrono::NaiveDate>,
 }
 
 #[allow(dead_code)]
@@ -41,6 +45,7 @@ impl AcquisitionCoordinator {
             archive_index: ArchiveIndex::new(),
             current_scan: None,
             data_facade,
+            listing_refetch_attempts: std::collections::HashSet::new(),
         }
     }
 

--- a/src/nexrad/acquisition_coordinator.rs
+++ b/src/nexrad/acquisition_coordinator.rs
@@ -12,6 +12,16 @@ use crate::nexrad::types::{CachedScan, DownloadResult};
 use crate::nexrad::ListingResult;
 use crate::nexrad::ScanBoundary;
 
+/// A deferred download waiting for one or more archive listings to arrive.
+#[derive(Clone, Debug)]
+pub(crate) struct PendingDownload {
+    /// `true` = position download, `false` = selection download.
+    pub is_position: bool,
+    /// Dates whose listings have already been re-fetched (stale-listing retry).
+    /// Each date is allowed at most one re-fetch to avoid infinite loops.
+    pub refetched_dates: std::collections::HashSet<chrono::NaiveDate>,
+}
+
 /// Owns the download pipeline: channels, queue, archive index, and current scan.
 pub struct AcquisitionCoordinator {
     /// Channel for async NEXRAD download operations.
@@ -26,10 +36,10 @@ pub struct AcquisitionCoordinator {
     pub(crate) current_scan: Option<CachedScan>,
     /// Record-based data facade.
     pub(crate) data_facade: DataFacade,
-    /// Dates whose listings have already been re-fetched during the current
-    /// download attempt. Prevents infinite re-fetch loops when a listing
-    /// genuinely doesn't contain the requested timestamp.
-    pub(crate) listing_refetch_attempts: std::collections::HashSet<chrono::NaiveDate>,
+    /// A download waiting for archive listings before it can build its queue.
+    /// Set when a listing is missing or stale; cleared when queue building
+    /// completes or is abandoned.
+    pub(crate) pending_download: Option<PendingDownload>,
 }
 
 #[allow(dead_code)]
@@ -45,7 +55,7 @@ impl AcquisitionCoordinator {
             archive_index: ArchiveIndex::new(),
             current_scan: None,
             data_facade,
-            listing_refetch_attempts: std::collections::HashSet::new(),
+            pending_download: None,
         }
     }
 


### PR DESCRIPTION
When downloading archival data especially near "now", it enters an infinite loop.