### PR TITLE
Update real-time rendering to close azimuth gaps

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1948,38 +1948,6 @@ impl WorkbenchApp {
             result.total_ms,
         );
 
-        // Pad partial sweep to a full 360° azimuth grid before GPU upload.
-        // The shader's find_bracket_az estimates the initial search index as
-        // azimuth_deg / (360/az_count). With N radials clustered in a small arc,
-        // the estimated spacing is wrong and the search misses. Padding to 720
-        // evenly-spaced slots makes the estimate correct; empty slots use
-        // sentinel gate values (0 = below threshold = transparent).
-        let gate_count = result.gate_count as usize;
-        let full_az_count: u32 = 720;
-        let step = 360.0f32 / full_az_count as f32;
-
-        let mut padded_az = Vec::with_capacity(full_az_count as usize);
-        let mut padded_gates = vec![0.0f32; full_az_count as usize * gate_count];
-        let mut padded_times = vec![0.0f64; full_az_count as usize];
-
-        for i in 0..full_az_count as usize {
-            padded_az.push(i as f32 * step);
-        }
-
-        for (src_row, &az) in result.azimuths.iter().enumerate() {
-            let dst_row = ((az / step).round() as usize) % full_az_count as usize;
-            padded_az[dst_row] = az;
-            let src_start = src_row * gate_count;
-            let dst_start = dst_row * gate_count;
-            if src_start + gate_count <= result.gate_values.len() {
-                padded_gates[dst_start..dst_start + gate_count]
-                    .copy_from_slice(&result.gate_values[src_start..src_start + gate_count]);
-            }
-            if src_row < result.radial_times.len() {
-                padded_times[dst_row] = result.radial_times[src_row];
-            }
-        }
-
         if let (Some(ref renderer), Some(ref gl)) = (&self.gpu.gpu, &self.gpu.gl) {
             if let Ok(mut r) = renderer.lock() {
                 // Build a live sweep ID so we can detect elevation transitions
@@ -2015,18 +1983,24 @@ impl WorkbenchApp {
                     r.promote_current_to_previous(gl);
                 }
 
+                // Pass sorted radials directly to the GPU — same as the archive
+                // path. The shader's azimuth search reads actual angles from the
+                // azimuth texture rather than assuming uniform spacing, so no
+                // padding is needed. The previous padding to 720 slots caused
+                // collisions where two radials mapped to the same slot, leaving
+                // thin radial gaps in the render.
                 r.update_data(
                     gl,
-                    &padded_az,
-                    &padded_gates,
-                    full_az_count,
+                    &result.azimuths,
+                    &result.gate_values,
+                    result.azimuth_count,
                     result.gate_count,
                     result.first_gate_range_km,
                     result.gate_interval_km,
                     result.max_range_km,
                     result.offset,
                     result.scale,
-                    &padded_times,
+                    &result.radial_times,
                 );
                 r.set_current_sweep_id(Some(live_sweep_id));
                 r.update_color_table(gl, &result.product);
@@ -2093,7 +2067,7 @@ impl WorkbenchApp {
                 first_az,
                 last_az,
                 result.azimuths.len(),
-                full_az_count,
+                result.azimuth_count,
             );
             self.state.live_mode_state.live_data_azimuth_range = Some((first_az, last_az));
         }


### PR DESCRIPTION
There's a bug with real-time chunk rendering, where gaps are left for some azimuths. This should fix that.