### PR TITLE
Add NWS alerts integration with modal UI and canvas overlay

### DIFF
--- a/src/alerts/api.rs
+++ b/src/alerts/api.rs
@@ -1,0 +1,108 @@
+//! NWS alerts API fetch logic.
+//!
+//! Uses the browser Fetch API via web-sys. The endpoint is CORS-enabled
+//! and requires no authentication. We send `If-None-Match` with the last
+//! seen ETag to let the server return 304 when nothing has changed.
+
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_futures::JsFuture;
+
+use super::channel::{AlertsChannel, AlertsEvent};
+use super::parse::parse_response;
+
+/// Endpoint for currently-active alerts across the US. The API returns
+/// GeoJSON; the `Accept` header requests the weather.gov content type.
+const ALERTS_URL: &str = "https://api.weather.gov/alerts/active";
+const ACCEPT: &str = "application/geo+json";
+/// Browsers will usually ignore or overwrite this, but the NWS API
+/// recommends an identifying value. We set it best-effort.
+const USER_AGENT: &str = "NEXRAD-Workbench (https://github.com/danielway/nexrad-workbench)";
+
+/// Spawn a background fetch. Results are pushed into `channel` when done.
+pub fn spawn_fetch(
+    ctx: eframe::egui::Context,
+    channel: AlertsChannel,
+    if_none_match: Option<String>,
+) {
+    wasm_bindgen_futures::spawn_local(async move {
+        let event = match fetch_inner(if_none_match).await {
+            Ok(FetchOutcome::Updated { body, etag }) => match parse_response(&body) {
+                Ok(parsed) => AlertsEvent::Updated {
+                    alerts: parsed.alerts,
+                    etag,
+                },
+                Err(e) => AlertsEvent::Error(format!("parse failed: {}", e)),
+            },
+            Ok(FetchOutcome::NotModified) => AlertsEvent::NotModified,
+            Err(e) => AlertsEvent::Error(e),
+        };
+        channel.push(event);
+        ctx.request_repaint();
+    });
+}
+
+enum FetchOutcome {
+    Updated { body: String, etag: Option<String> },
+    NotModified,
+}
+
+async fn fetch_inner(if_none_match: Option<String>) -> Result<FetchOutcome, String> {
+    let window = web_sys::window().ok_or_else(|| "no window".to_string())?;
+
+    // Build a Request with the custom headers we need.
+    let init = web_sys::RequestInit::new();
+    init.set_method("GET");
+    init.set_mode(web_sys::RequestMode::Cors);
+
+    let headers = web_sys::Headers::new().map_err(|_| "failed to allocate headers".to_string())?;
+    let _ = headers.set("Accept", ACCEPT);
+    let _ = headers.set("User-Agent", USER_AGENT);
+    if let Some(etag) = if_none_match.as_ref() {
+        let _ = headers.set("If-None-Match", etag);
+    }
+    init.set_headers(&JsValue::from(headers));
+
+    let request = web_sys::Request::new_with_str_and_init(ALERTS_URL, &init)
+        .map_err(|e| format!("request init failed: {:?}", e))?;
+
+    let resp_value = JsFuture::from(window.fetch_with_request(&request))
+        .await
+        .map_err(|e| format!("network error: {}", err_text(e)))?;
+
+    let resp: web_sys::Response = resp_value
+        .dyn_into()
+        .map_err(|_| "invalid response object".to_string())?;
+
+    let status = resp.status();
+    if status == 304 {
+        return Ok(FetchOutcome::NotModified);
+    }
+    if !resp.ok() {
+        return Err(format!("HTTP {}", status));
+    }
+
+    let etag = resp.headers().get("ETag").ok().flatten();
+
+    let text_promise = resp
+        .text()
+        .map_err(|e| format!("failed to read body: {}", err_text(e)))?;
+    let text_value = JsFuture::from(text_promise)
+        .await
+        .map_err(|e| format!("failed to read body: {}", err_text(e)))?;
+    let body = text_value
+        .as_string()
+        .ok_or_else(|| "body not a string".to_string())?;
+
+    Ok(FetchOutcome::Updated { body, etag })
+}
+
+fn err_text(v: JsValue) -> String {
+    v.as_string()
+        .or_else(|| {
+            js_sys::Reflect::get(&v, &JsValue::from_str("message"))
+                .ok()
+                .and_then(|m| m.as_string())
+        })
+        .unwrap_or_else(|| format!("{:?}", v))
+}

--- a/src/alerts/channel.rs
+++ b/src/alerts/channel.rs
@@ -1,0 +1,46 @@
+//! Channel plumbing for async NWS alert fetches.
+//!
+//! Follows the `Rc<RefCell<Vec<_>>>` pattern used elsewhere (e.g.
+//! `SiteModalState::location_results`) so results produced inside a
+//! `spawn_local` future can be drained synchronously each UI frame.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use super::types::Alert;
+
+/// An event delivered by the fetch future into the UI loop.
+pub enum AlertsEvent {
+    /// Fetch succeeded with the full parsed alert set and an ETag (if the
+    /// server returned one).
+    Updated {
+        alerts: Vec<Alert>,
+        etag: Option<String>,
+    },
+    /// Server returned 304 Not Modified — keep existing alerts.
+    NotModified,
+    /// Fetch failed with a human-readable reason.
+    Error(String),
+}
+
+/// Shared buffer for events produced by the async fetch.
+#[derive(Clone, Default)]
+pub struct AlertsChannel {
+    events: Rc<RefCell<Vec<AlertsEvent>>>,
+}
+
+impl AlertsChannel {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Push an event from inside an async task.
+    pub fn push(&self, event: AlertsEvent) {
+        self.events.borrow_mut().push(event);
+    }
+
+    /// Drain all pending events; called once per frame.
+    pub fn drain(&self) -> Vec<AlertsEvent> {
+        std::mem::take(&mut *self.events.borrow_mut())
+    }
+}

--- a/src/alerts/geometry.rs
+++ b/src/alerts/geometry.rs
@@ -1,0 +1,55 @@
+//! Lightweight geometric tests used for filtering and hit-testing alerts.
+
+use super::types::Alert;
+
+/// True if the alert's bounding box intersects the given view bounds.
+/// Bounds are `(min_lon, min_lat, max_lon, max_lat)`.
+pub fn bbox_intersects(alert: &Alert, bounds: (f64, f64, f64, f64)) -> bool {
+    let Some((amin_lon, amin_lat, amax_lon, amax_lat)) = alert.geometry.bbox else {
+        return false;
+    };
+    let (min_lon, min_lat, max_lon, max_lat) = bounds;
+    !(amax_lon < min_lon || amin_lon > max_lon || amax_lat < min_lat || amin_lat > max_lat)
+}
+
+/// True if `(lon, lat)` lies inside any polygon of `alert`, respecting holes.
+///
+/// Uses the even-odd ray-casting rule. Each outer ring is tested for
+/// containment; if inside, hole rings invalidate the hit.
+pub fn contains_point(alert: &Alert, lon: f64, lat: f64) -> bool {
+    for polygon in &alert.geometry.polygons {
+        let mut iter = polygon.iter();
+        let Some(outer) = iter.next() else { continue };
+        if point_in_ring(outer, lon, lat) {
+            let in_hole = iter.any(|hole| point_in_ring(hole, lon, lat));
+            if !in_hole {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn point_in_ring(ring: &[(f64, f64)], lon: f64, lat: f64) -> bool {
+    if ring.len() < 3 {
+        return false;
+    }
+    let mut inside = false;
+    let n = ring.len();
+    let mut j = n - 1;
+    for i in 0..n {
+        let (xi, yi) = ring[i];
+        let (xj, yj) = ring[j];
+        let crosses = (yi > lat) != (yj > lat);
+        if crosses {
+            let dy = yj - yi;
+            // crosses==true implies yi != yj, so dy is nonzero.
+            let x_at_lat = (xj - xi) * (lat - yi) / dy + xi;
+            if lon < x_at_lat {
+                inside = !inside;
+            }
+        }
+        j = i;
+    }
+    inside
+}

--- a/src/alerts/manager.rs
+++ b/src/alerts/manager.rs
@@ -1,0 +1,102 @@
+//! Owns the NWS alert fetch lifecycle and drains results into app state.
+//!
+//! Polls every `POLL_INTERVAL_MS`. The first tick after construction triggers
+//! an immediate fetch. Results flow through an `AlertsChannel` and are applied
+//! to `AlertsState` in-place.
+
+use eframe::egui;
+
+use super::api;
+use super::channel::{AlertsChannel, AlertsEvent};
+use crate::state::AppState;
+
+/// Poll interval in wall-clock milliseconds. NWS recommends <= 1 req/min;
+/// 2 minutes is comfortable and still plenty fresh for warnings.
+const POLL_INTERVAL_MS: f64 = 120_000.0;
+
+/// Retry interval after a failed fetch — shorter than the regular interval
+/// so transient errors recover quickly.
+const RETRY_INTERVAL_MS: f64 = 30_000.0;
+
+pub struct AlertsManager {
+    channel: AlertsChannel,
+    /// True while a fetch future is in flight and we're waiting on it.
+    fetch_in_flight: bool,
+}
+
+impl Default for AlertsManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AlertsManager {
+    pub fn new() -> Self {
+        Self {
+            channel: AlertsChannel::new(),
+            fetch_in_flight: false,
+        }
+    }
+
+    /// Called every frame. Drains any events, kicks off a new fetch when due.
+    pub fn tick(&mut self, ctx: &egui::Context, state: &mut AppState) {
+        // Drain events produced by any in-flight fetch.
+        let events = self.channel.drain();
+        if !events.is_empty() {
+            self.fetch_in_flight = false;
+        }
+        for event in events {
+            self.apply_event(state, event);
+        }
+
+        // Drop expired alerts proactively so the UI never shows stale items.
+        let now = js_sys::Date::now() / 1000.0;
+        if !state.alerts.alerts.is_empty() {
+            state.alerts.alerts.retain(|a| !a.is_expired(now));
+        }
+
+        // Was a manual refresh requested?
+        let manual_refresh = std::mem::take(&mut state.alerts.refresh_requested);
+
+        // Due to poll?
+        let now_ms = js_sys::Date::now();
+        let elapsed = now_ms - state.alerts.last_poll_ms;
+        let due = state.alerts.last_poll_ms <= 0.0
+            || (state.alerts.last_error.is_some() && elapsed >= RETRY_INTERVAL_MS)
+            || elapsed >= POLL_INTERVAL_MS;
+
+        if !self.fetch_in_flight && (manual_refresh || due) {
+            self.start_fetch(ctx, state);
+        }
+    }
+
+    fn start_fetch(&mut self, ctx: &egui::Context, state: &mut AppState) {
+        self.fetch_in_flight = true;
+        state.alerts.fetch_in_flight = true;
+        state.alerts.last_poll_ms = js_sys::Date::now();
+        let etag = state.alerts.last_etag.clone();
+        api::spawn_fetch(ctx.clone(), self.channel.clone(), etag);
+    }
+
+    fn apply_event(&mut self, state: &mut AppState, event: AlertsEvent) {
+        state.alerts.fetch_in_flight = false;
+        match event {
+            AlertsEvent::Updated { alerts, etag } => {
+                state.alerts.alerts = alerts;
+                state.alerts.last_etag = etag;
+                state.alerts.last_error = None;
+                state.alerts.last_success_ms = js_sys::Date::now();
+                log::info!("NWS alerts refreshed: {} active", state.alerts.alerts.len());
+            }
+            AlertsEvent::NotModified => {
+                state.alerts.last_error = None;
+                state.alerts.last_success_ms = js_sys::Date::now();
+                log::debug!("NWS alerts: 304 Not Modified");
+            }
+            AlertsEvent::Error(msg) => {
+                log::warn!("NWS alerts fetch failed: {}", msg);
+                state.alerts.last_error = Some(msg);
+            }
+        }
+    }
+}

--- a/src/alerts/mod.rs
+++ b/src/alerts/mod.rs
@@ -1,0 +1,19 @@
+//! NWS Alerts integration.
+//!
+//! Polls the public National Weather Service alerts API
+//! (`https://api.weather.gov/alerts/active`) and exposes currently active
+//! alerts to the UI layer. Alerts intersecting the current viewing area
+//! are surfaced in the top bar; a toggleable canvas overlay renders the
+//! polygon footprints on the 2D map; and a modal displays full alert
+//! details on click.
+
+mod api;
+mod channel;
+mod geometry;
+mod manager;
+mod parse;
+mod types;
+
+pub use geometry::{bbox_intersects, contains_point};
+pub use manager::AlertsManager;
+pub use types::{Alert, AlertSeverity};

--- a/src/alerts/parse.rs
+++ b/src/alerts/parse.rs
@@ -1,0 +1,175 @@
+//! GeoJSON → `Alert` parsing.
+//!
+//! The NWS alerts endpoint returns a GeoJSON FeatureCollection. We parse only
+//! the fields we display or use for filtering and skip features without
+//! renderable geometry (zone-only alerts).
+
+use super::types::{Alert, AlertGeometry, AlertSeverity, Ring};
+use serde_json::Value;
+
+/// Parsed response payload.
+pub struct ParsedAlerts {
+    pub alerts: Vec<Alert>,
+}
+
+/// Parse a complete alerts response body.
+pub fn parse_response(body: &str) -> Result<ParsedAlerts, String> {
+    let root: Value = serde_json::from_str(body).map_err(|e| format!("parse error: {}", e))?;
+
+    let features = root
+        .get("features")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| "response missing 'features' array".to_string())?;
+
+    let mut alerts = Vec::with_capacity(features.len());
+    for feature in features {
+        if let Some(alert) = parse_feature(feature) {
+            alerts.push(alert);
+        }
+    }
+
+    Ok(ParsedAlerts { alerts })
+}
+
+fn parse_feature(feature: &Value) -> Option<Alert> {
+    let props = feature.get("properties")?;
+
+    // Prefer the feature's top-level id; fall back to properties.id.
+    let id = feature
+        .get("id")
+        .and_then(|v| v.as_str())
+        .or_else(|| props.get("id").and_then(|v| v.as_str()))?
+        .to_string();
+
+    let event = props
+        .get("event")
+        .and_then(|v| v.as_str())
+        .unwrap_or("Alert")
+        .to_string();
+
+    let severity = props
+        .get("severity")
+        .and_then(|v| v.as_str())
+        .map(AlertSeverity::parse)
+        .unwrap_or(AlertSeverity::Unknown);
+
+    let headline = string_field(props, "headline");
+    let description = string_field(props, "description");
+    let instruction = string_field(props, "instruction");
+    let urgency = string_field(props, "urgency");
+    let certainty = string_field(props, "certainty");
+    let area_desc = string_field(props, "areaDesc");
+    let sender = string_field(props, "senderName");
+
+    let effective_secs = parse_iso_secs(props, "effective");
+    let onset_secs = parse_iso_secs(props, "onset");
+    let expires_secs = parse_iso_secs(props, "expires");
+    let ends_secs = parse_iso_secs(props, "ends");
+
+    let geometry = parse_geometry(feature.get("geometry"));
+    if geometry.is_empty() {
+        // Zone-only alerts — skip in v1.
+        return None;
+    }
+
+    Some(Alert {
+        id,
+        event,
+        headline,
+        description,
+        instruction,
+        severity,
+        urgency,
+        certainty,
+        area_desc,
+        sender,
+        effective_secs,
+        onset_secs,
+        expires_secs,
+        ends_secs,
+        geometry,
+    })
+}
+
+fn string_field(props: &Value, key: &str) -> String {
+    props
+        .get(key)
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string()
+}
+
+fn parse_iso_secs(props: &Value, key: &str) -> Option<f64> {
+    let s = props.get(key)?.as_str()?;
+    // NWS timestamps are ISO 8601 with timezone offset, e.g.
+    // "2024-07-15T21:45:00-05:00". `chrono` parses these.
+    chrono::DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|dt| dt.timestamp() as f64)
+}
+
+fn parse_geometry(geom: Option<&Value>) -> AlertGeometry {
+    let mut out = AlertGeometry::default();
+    let geom = match geom {
+        Some(g) if !g.is_null() => g,
+        _ => return out,
+    };
+
+    let ty = geom.get("type").and_then(|v| v.as_str()).unwrap_or("");
+    let coords = match geom.get("coordinates") {
+        Some(c) => c,
+        None => return out,
+    };
+
+    match ty {
+        "Polygon" => {
+            // coordinates: [ring, ring, ...]
+            if let Some(polygon) = parse_polygon(coords) {
+                out.polygons.push(polygon);
+            }
+        }
+        "MultiPolygon" => {
+            // coordinates: [polygon, polygon, ...]
+            if let Some(arr) = coords.as_array() {
+                for poly in arr {
+                    if let Some(polygon) = parse_polygon(poly) {
+                        out.polygons.push(polygon);
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+
+    out.recompute_bbox();
+    out
+}
+
+/// Parse a GeoJSON polygon (array of rings).
+fn parse_polygon(value: &Value) -> Option<Vec<Ring>> {
+    let rings = value.as_array()?;
+    let mut out = Vec::with_capacity(rings.len());
+    for ring_value in rings {
+        let ring = parse_ring(ring_value)?;
+        if ring.len() >= 3 {
+            out.push(ring);
+        }
+    }
+    if out.is_empty() {
+        None
+    } else {
+        Some(out)
+    }
+}
+
+fn parse_ring(value: &Value) -> Option<Ring> {
+    let pts = value.as_array()?;
+    let mut ring = Vec::with_capacity(pts.len());
+    for pt in pts {
+        let pair = pt.as_array()?;
+        let lon = pair.first()?.as_f64()?;
+        let lat = pair.get(1)?.as_f64()?;
+        ring.push((lon, lat));
+    }
+    Some(ring)
+}

--- a/src/alerts/types.rs
+++ b/src/alerts/types.rs
@@ -1,0 +1,156 @@
+//! NWS alert data types.
+//!
+//! These types are a simplified projection of the GeoJSON documents returned
+//! by `https://api.weather.gov/alerts/active`. We only extract the fields we
+//! display or use for filtering.
+
+/// Severity classification per the Common Alerting Protocol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AlertSeverity {
+    Extreme,
+    Severe,
+    Moderate,
+    Minor,
+    Unknown,
+}
+
+impl AlertSeverity {
+    pub fn parse(s: &str) -> Self {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "extreme" => Self::Extreme,
+            "severe" => Self::Severe,
+            "moderate" => Self::Moderate,
+            "minor" => Self::Minor,
+            _ => Self::Unknown,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Extreme => "Extreme",
+            Self::Severe => "Severe",
+            Self::Moderate => "Moderate",
+            Self::Minor => "Minor",
+            Self::Unknown => "Unknown",
+        }
+    }
+
+    /// Numeric rank so callers can sort highest-severity first.
+    pub fn rank(self) -> u8 {
+        match self {
+            Self::Extreme => 4,
+            Self::Severe => 3,
+            Self::Moderate => 2,
+            Self::Minor => 1,
+            Self::Unknown => 0,
+        }
+    }
+
+    /// RGB color for this severity (used in top bar, modal, and canvas overlay).
+    pub fn color(self) -> (u8, u8, u8) {
+        match self {
+            Self::Extreme => (220, 40, 40),
+            Self::Severe => (240, 130, 30),
+            Self::Moderate => (230, 200, 50),
+            Self::Minor | Self::Unknown => (120, 180, 230),
+        }
+    }
+}
+
+/// A polygon ring is a closed sequence of (lon, lat) vertices.
+pub type Ring = Vec<(f64, f64)>;
+
+/// An alert's spatial footprint. A MultiPolygon is a list of polygons; each
+/// polygon is an outer ring followed by zero or more holes.
+#[derive(Debug, Clone, Default)]
+pub struct AlertGeometry {
+    /// Polygons; each polygon is [outer_ring, hole_ring, hole_ring, ...].
+    pub polygons: Vec<Vec<Ring>>,
+    /// Precomputed bounding box (min_lon, min_lat, max_lon, max_lat).
+    pub bbox: Option<(f64, f64, f64, f64)>,
+}
+
+impl AlertGeometry {
+    /// True if this geometry is empty (e.g. zone-only alerts without
+    /// resolved geometry).
+    pub fn is_empty(&self) -> bool {
+        self.polygons.is_empty()
+    }
+
+    /// Recompute bbox from `polygons`. Call after mutating `polygons`.
+    pub fn recompute_bbox(&mut self) {
+        let mut min_lon = f64::INFINITY;
+        let mut min_lat = f64::INFINITY;
+        let mut max_lon = f64::NEG_INFINITY;
+        let mut max_lat = f64::NEG_INFINITY;
+        let mut any = false;
+        for polygon in &self.polygons {
+            for ring in polygon {
+                for &(lon, lat) in ring {
+                    if lon < min_lon {
+                        min_lon = lon;
+                    }
+                    if lon > max_lon {
+                        max_lon = lon;
+                    }
+                    if lat < min_lat {
+                        min_lat = lat;
+                    }
+                    if lat > max_lat {
+                        max_lat = lat;
+                    }
+                    any = true;
+                }
+            }
+        }
+        self.bbox = if any {
+            Some((min_lon, min_lat, max_lon, max_lat))
+        } else {
+            None
+        };
+    }
+}
+
+/// A single active NWS alert. Geometry may be empty for zone-only alerts;
+/// those are filtered out before reaching the UI.
+#[derive(Debug, Clone)]
+pub struct Alert {
+    /// Stable identifier (from GeoJSON feature `id`). Used as a selection key.
+    pub id: String,
+    /// Event name (e.g. "Tornado Warning", "Flood Advisory").
+    pub event: String,
+    /// One-line headline (properties.headline), may be empty.
+    pub headline: String,
+    /// Long-form description (properties.description), may be empty.
+    pub description: String,
+    /// Recommended action (properties.instruction), may be empty.
+    pub instruction: String,
+    /// Classification.
+    pub severity: AlertSeverity,
+    /// Urgency (Immediate, Expected, Future, Past, Unknown) — raw string.
+    pub urgency: String,
+    /// Certainty (Observed, Likely, Possible, Unlikely, Unknown) — raw string.
+    pub certainty: String,
+    /// Human-readable list of affected areas.
+    pub area_desc: String,
+    /// Issuing office / sender (e.g. "NWS Des Moines IA").
+    pub sender: String,
+    /// Effective timestamp (Unix seconds). None if unparseable.
+    pub effective_secs: Option<f64>,
+    /// Onset timestamp (Unix seconds). None if unparseable.
+    pub onset_secs: Option<f64>,
+    /// Expiration timestamp (Unix seconds). None if unparseable.
+    pub expires_secs: Option<f64>,
+    /// Ends timestamp (Unix seconds). None if unparseable.
+    pub ends_secs: Option<f64>,
+    /// Spatial footprint.
+    pub geometry: AlertGeometry,
+}
+
+impl Alert {
+    /// True when the alert has an end timestamp in the past.
+    pub fn is_expired(&self, now_secs: f64) -> bool {
+        let end = self.ends_secs.or(self.expires_secs);
+        matches!(end, Some(t) if t < now_secs)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@
 //! and `nexrad::worker_api`). The main thread is a thin UI shell that uploads
 //! worker results to the GPU and paints the interface.
 
+mod alerts;
 mod data;
 mod geo;
 mod nexrad;
@@ -155,6 +156,9 @@ pub struct WorkbenchApp {
 
     /// Sweep cache and previous-sweep resolution for sweep animation.
     playback_manager: PlaybackManager,
+
+    /// NWS alerts polling lifecycle.
+    alerts_manager: alerts::AlertsManager,
 }
 
 // Embed shapefile data at compile time
@@ -448,6 +452,7 @@ impl WorkbenchApp {
             event_modal_state: ui::EventModalState::default(),
             network_monitor: nexrad::NetworkMonitor::new(),
             playback_manager: PlaybackManager::new(),
+            alerts_manager: alerts::AlertsManager::new(),
         };
 
         // Check cross-origin isolation status on startup
@@ -1353,6 +1358,16 @@ impl WorkbenchApp {
                         self.state.worker_init_error = Some(msg);
                     }
                 },
+                state::AppCommand::RefreshAlerts => {
+                    self.state.alerts.refresh_requested = true;
+                }
+                state::AppCommand::OpenAlert(id) => {
+                    self.state.alerts.selected_alert_id = Some(id);
+                }
+                state::AppCommand::CloseAlert => {
+                    self.state.alerts.selected_alert_id = None;
+                    self.state.alerts.list_modal_open = false;
+                }
             }
         }
 
@@ -2822,6 +2837,9 @@ impl eframe::App for WorkbenchApp {
         self.update_network_stats();
         self.persist_url_state();
 
+        // Poll the NWS alerts feed if due; drain any completed fetches.
+        self.alerts_manager.tick(ctx, &mut self.state);
+
         // Compute the live radar model snapshot for this frame so all UI
         // consumers see consistent state from the same `now` timestamp.
         self.state.refresh_live_model();
@@ -2846,5 +2864,6 @@ impl eframe::App for WorkbenchApp {
         ui::render_stats_modal(ctx, &mut self.state);
         ui::render_network_log(ctx, &mut self.state);
         ui::render_event_modal(ctx, &mut self.state, &mut self.event_modal_state);
+        ui::render_alerts_modals(ctx, &mut self.state);
     }
 }

--- a/src/state/alerts.rs
+++ b/src/state/alerts.rs
@@ -36,7 +36,7 @@ impl AlertsState {
             .iter()
             .filter(|a| crate::alerts::bbox_intersects(a, bounds))
             .collect();
-        out.sort_by(|a, b| b.severity.rank().cmp(&a.severity.rank()));
+        out.sort_by_key(|a| std::cmp::Reverse(a.severity.rank()));
         out
     }
 

--- a/src/state/alerts.rs
+++ b/src/state/alerts.rs
@@ -1,0 +1,47 @@
+//! NWS alerts state.
+//!
+//! Mirrors the alert list owned by `AlertsManager` plus transient UI
+//! selections (which alert is open in the detail modal, is the list modal
+//! open, etc.).
+
+use crate::alerts::Alert;
+
+#[derive(Default)]
+pub struct AlertsState {
+    /// All currently-active alerts returned by the most recent successful fetch.
+    pub alerts: Vec<Alert>,
+    /// Wall-clock ms (JS Date.now) when the last fetch was started.
+    pub last_poll_ms: f64,
+    /// Wall-clock ms when the last fetch succeeded (including 304).
+    pub last_success_ms: f64,
+    /// ETag from the last successful response; sent as If-None-Match.
+    pub last_etag: Option<String>,
+    /// True while a fetch is in flight (for tooltip/status display).
+    pub fetch_in_flight: bool,
+    /// Last error message (cleared on success).
+    pub last_error: Option<String>,
+    /// When set, a manual refresh is requested on the next manager tick.
+    pub refresh_requested: bool,
+    /// Alert id currently shown in the detail modal.
+    pub selected_alert_id: Option<String>,
+    /// Whether the list modal is open.
+    pub list_modal_open: bool,
+}
+
+impl AlertsState {
+    /// Return alerts whose bbox intersects `bounds`, sorted by severity (high first).
+    pub fn visible_in(&self, bounds: (f64, f64, f64, f64)) -> Vec<&Alert> {
+        let mut out: Vec<&Alert> = self
+            .alerts
+            .iter()
+            .filter(|a| crate::alerts::bbox_intersects(a, bounds))
+            .collect();
+        out.sort_by(|a, b| b.severity.rank().cmp(&a.severity.rank()));
+        out
+    }
+
+    /// Look up an alert by id.
+    pub fn find(&self, id: &str) -> Option<&Alert> {
+        self.alerts.iter().find(|a| a.id == id)
+    }
+}

--- a/src/state/layer.rs
+++ b/src/state/layer.rs
@@ -24,6 +24,8 @@ pub struct GeoLayerVisibility {
     pub highways: bool,
     /// Show lakes and water bodies
     pub lakes: bool,
+    /// Show NWS active alert polygons
+    pub alerts: bool,
 }
 
 impl Default for GeoLayerVisibility {
@@ -36,6 +38,7 @@ impl Default for GeoLayerVisibility {
             cities: true,
             highways: false,
             lakes: false,
+            alerts: false,
         }
     }
 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -6,6 +6,7 @@
 
 #[allow(dead_code)]
 pub(crate) mod acquisition;
+mod alerts;
 mod layer;
 mod live_mode;
 mod live_radar_model;
@@ -27,6 +28,7 @@ pub use acquisition::{
     AcquisitionState, DrawerTab, NetworkGroupKey, OperationId, OperationKind, OperationStatus,
     QueueState,
 };
+pub use alerts::AlertsState;
 pub use layer::{GeoLayerVisibility, LayerState};
 pub use live_mode::{LiveExitReason, LiveModeState, LivePhase};
 pub use live_radar_model::LiveRadarModel;
@@ -86,6 +88,13 @@ pub enum AppCommand {
     ReorderOperation(OperationId, isize),
     /// Retry initializing the decode worker after a failure.
     RetryWorker,
+    /// Request an immediate refresh of the NWS alerts feed.
+    RefreshAlerts,
+    /// Open the alert detail modal for a specific alert id.
+    OpenAlert(String),
+    /// Close any open alert modal (detail or list).
+    #[allow(dead_code)] // Provided for symmetry; modals close via their own buttons.
+    CloseAlert,
 }
 
 /// Root application state containing all sub-states.
@@ -210,6 +219,9 @@ pub struct AppState {
     /// Persistent worker initialization error message.
     /// When set, a non-dismissable error banner is shown in the top bar.
     pub worker_init_error: Option<String>,
+
+    /// NWS active alerts + related modal state.
+    pub alerts: AlertsState,
 }
 
 /// State for the datetime jump picker popup.

--- a/src/state/preferences.rs
+++ b/src/state/preferences.rs
@@ -27,6 +27,8 @@ pub struct UserPreferences {
     #[serde(default = "default_true")]
     pub layer_cities: bool,
     #[serde(default)]
+    pub layer_alerts: bool,
+    #[serde(default)]
     pub use_local_time: bool,
     /// Preferred NEXRAD site from first-visit selection. When `Some`, the
     /// first-visit modal is skipped and this site is used as the default.
@@ -75,6 +77,7 @@ impl Default for UserPreferences {
             layer_labels: true,
             layer_nexrad_sites: false,
             layer_cities: true,
+            layer_alerts: false,
             use_local_time: false,
             preferred_site: None,
             interpolation: InterpolationMode::default(),
@@ -101,6 +104,7 @@ impl UserPreferences {
             layer_labels: state.layer_state.geo.labels,
             layer_nexrad_sites: state.layer_state.geo.nexrad_sites,
             layer_cities: state.layer_state.geo.cities,
+            layer_alerts: state.layer_state.geo.alerts,
             use_local_time: state.use_local_time,
             preferred_site: state.preferred_site.clone(),
             interpolation: state.render_processing.interpolation,
@@ -129,6 +133,7 @@ impl UserPreferences {
         state.layer_state.geo.labels = self.layer_labels;
         state.layer_state.geo.nexrad_sites = self.layer_nexrad_sites;
         state.layer_state.geo.cities = self.layer_cities;
+        state.layer_state.geo.alerts = self.layer_alerts;
         state.use_local_time = self.use_local_time;
         state.preferred_site = self.preferred_site.clone();
         state.render_processing.interpolation = self.interpolation;

--- a/src/state/viz.rs
+++ b/src/state/viz.rs
@@ -344,6 +344,13 @@ pub struct VizState {
 
     /// Elevation number of the currently displayed sweep.
     pub displayed_sweep_elevation_number: Option<u8>,
+
+    /// Last observed visible map bounds in 2D mode, as
+    /// `(min_lon, min_lat, max_lon, max_lat)`. Updated each frame by the
+    /// canvas renderer and consumed by top-bar / modal logic that needs
+    /// to know what area the user is looking at without access to the
+    /// canvas rect. `None` while in 3D globe mode.
+    pub last_visible_bounds: Option<(f64, f64, f64, f64)>,
 }
 
 impl Default for VizState {
@@ -381,6 +388,7 @@ impl Default for VizState {
             detected_storm_cells: Vec::new(),
             displayed_scan_timestamp: None,
             displayed_sweep_elevation_number: None,
+            last_visible_bounds: None,
         }
     }
 }

--- a/src/ui/alerts_modal.rs
+++ b/src/ui/alerts_modal.rs
@@ -1,0 +1,399 @@
+//! Modal UI for browsing and viewing NWS alert details.
+//!
+//! Two closely-related modals live here:
+//!
+//!  * **List modal** — opened from the top-bar alerts chip when multiple
+//!    alerts intersect the current viewing area. Shows a scrollable list
+//!    of affected alerts; clicking an item selects it for the detail modal.
+//!  * **Detail modal** — shows full alert information (headline, severity,
+//!    area, effective/expires times, description, instructions).
+//!
+//! Both follow the existing `modal_backdrop` + anchored `egui::Window` pattern
+//! used by `site_modal`, `event_modal`, etc.
+
+use super::modal_helper::modal_backdrop;
+use crate::alerts::{Alert, AlertSeverity};
+use crate::state::{AppCommand, AppState};
+use eframe::egui::{self, Color32, RichText, ScrollArea, Vec2};
+
+/// Render the list + detail modals. Call once per frame from the main update loop.
+pub fn render_alerts_modals(ctx: &egui::Context, state: &mut AppState) {
+    if state.alerts.list_modal_open {
+        render_list_modal(ctx, state);
+    }
+    if state.alerts.selected_alert_id.is_some() {
+        render_detail_modal(ctx, state);
+    }
+}
+
+fn render_list_modal(ctx: &egui::Context, state: &mut AppState) {
+    if modal_backdrop(ctx, "alerts_list_backdrop", 140) {
+        state.alerts.list_modal_open = false;
+        return;
+    }
+
+    // Collect the filtered list now, then release the borrow of state.alerts
+    // before we render (so we can push commands freely inside the closure).
+    let visible: Vec<(String, String, String, AlertSeverity, Option<f64>)> =
+        match state.viz_state.last_visible_bounds {
+            Some(bounds) => state
+                .alerts
+                .visible_in(bounds)
+                .into_iter()
+                .map(|a| {
+                    (
+                        a.id.clone(),
+                        a.event.clone(),
+                        a.area_desc.clone(),
+                        a.severity,
+                        a.expires_secs,
+                    )
+                })
+                .collect(),
+            None => Vec::new(),
+        };
+
+    let mut selected_id: Option<String> = None;
+    let mut close = false;
+
+    egui::Window::new("Active Alerts in View")
+        .collapsible(false)
+        .resizable(false)
+        .anchor(egui::Align2::CENTER_CENTER, Vec2::ZERO)
+        .fixed_size(Vec2::new(520.0, 560.0))
+        .order(egui::Order::Foreground)
+        .show(ctx, |ui| {
+            ui.add_space(4.0);
+            ui.horizontal(|ui| {
+                ui.label(
+                    RichText::new(format!(
+                        "{} alert(s) intersect the visible area",
+                        visible.len()
+                    ))
+                    .size(13.0)
+                    .color(Color32::from_rgb(180, 180, 180)),
+                );
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    if ui.small_button("Close").clicked() {
+                        close = true;
+                    }
+                    if ui
+                        .small_button(RichText::new(format!(
+                            "{} Refresh",
+                            egui_phosphor::regular::ARROWS_CLOCKWISE
+                        )))
+                        .on_hover_text("Re-fetch the NWS alerts feed")
+                        .clicked()
+                    {
+                        state.push_command(AppCommand::RefreshAlerts);
+                    }
+                });
+            });
+            ui.separator();
+
+            if visible.is_empty() {
+                ui.add_space(24.0);
+                ui.vertical_centered(|ui| {
+                    ui.label(
+                        RichText::new("No active alerts in the current view.").color(Color32::GRAY),
+                    );
+                });
+                ui.add_space(12.0);
+                return;
+            }
+
+            ScrollArea::vertical().max_height(480.0).show(ui, |ui| {
+                for (id, event, area_desc, severity, expires) in &visible {
+                    ui.add_space(2.0);
+                    let bg_stroke = severity_stroke(*severity);
+                    let frame = egui::Frame::default()
+                        .stroke(bg_stroke)
+                        .inner_margin(egui::Margin::symmetric(10, 8))
+                        .corner_radius(egui::CornerRadius::same(4));
+                    let response = frame
+                        .show(ui, |ui| {
+                            ui.horizontal(|ui| {
+                                severity_dot(ui, *severity);
+                                ui.vertical(|ui| {
+                                    ui.label(RichText::new(event).size(14.0).strong());
+                                    if !area_desc.is_empty() {
+                                        ui.label(
+                                            RichText::new(truncate(area_desc, 120))
+                                                .size(11.0)
+                                                .color(Color32::from_rgb(170, 170, 170)),
+                                        );
+                                    }
+                                    if let Some(exp) = expires {
+                                        ui.label(
+                                            RichText::new(format!(
+                                                "Expires {}",
+                                                format_relative(*exp)
+                                            ))
+                                            .size(10.0)
+                                            .color(Color32::from_rgb(140, 140, 140)),
+                                        );
+                                    }
+                                });
+                            });
+                        })
+                        .response
+                        .interact(egui::Sense::click());
+
+                    if response.hovered() {
+                        ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+                    }
+                    if response.clicked() {
+                        selected_id = Some(id.clone());
+                    }
+                    ui.add_space(2.0);
+                }
+            });
+        });
+
+    if close {
+        state.alerts.list_modal_open = false;
+    }
+    if let Some(id) = selected_id {
+        state.alerts.selected_alert_id = Some(id);
+    }
+}
+
+fn render_detail_modal(ctx: &egui::Context, state: &mut AppState) {
+    if modal_backdrop(ctx, "alerts_detail_backdrop", 160) {
+        state.alerts.selected_alert_id = None;
+        return;
+    }
+
+    // Clone the alert once so we don't hold a borrow through the UI closure.
+    let alert: Alert = match state
+        .alerts
+        .selected_alert_id
+        .as_ref()
+        .and_then(|id| state.alerts.find(id))
+    {
+        Some(a) => a.clone(),
+        None => {
+            // Stale selection (e.g. alert expired while modal was open).
+            state.alerts.selected_alert_id = None;
+            return;
+        }
+    };
+
+    let mut close = false;
+
+    egui::Window::new(format!("{} — {}", alert.severity.label(), alert.event))
+        .collapsible(false)
+        .resizable(false)
+        .anchor(egui::Align2::CENTER_CENTER, Vec2::ZERO)
+        .fixed_size(Vec2::new(560.0, 600.0))
+        .order(egui::Order::Foreground)
+        .show(ctx, |ui| {
+            ui.add_space(4.0);
+
+            // Severity / urgency / certainty badges.
+            ui.horizontal_wrapped(|ui| {
+                severity_badge(ui, alert.severity);
+                if !alert.urgency.is_empty() {
+                    chip_badge(
+                        ui,
+                        &format!("Urgency: {}", alert.urgency),
+                        Color32::from_rgb(90, 110, 140),
+                    );
+                }
+                if !alert.certainty.is_empty() {
+                    chip_badge(
+                        ui,
+                        &format!("Certainty: {}", alert.certainty),
+                        Color32::from_rgb(90, 110, 140),
+                    );
+                }
+            });
+
+            if !alert.headline.is_empty() {
+                ui.add_space(6.0);
+                ui.label(RichText::new(&alert.headline).size(14.0).strong());
+            }
+
+            ui.add_space(6.0);
+            ui.separator();
+
+            // Timing + area meta block.
+            ui.horizontal(|ui| {
+                ui.vertical(|ui| {
+                    if let Some(t) = alert.effective_secs {
+                        meta_row(ui, "Effective", &format_absolute(t));
+                    }
+                    if let Some(t) = alert.onset_secs {
+                        meta_row(ui, "Onset", &format_absolute(t));
+                    }
+                    if let Some(t) = alert.expires_secs {
+                        meta_row(ui, "Expires", &format_absolute(t));
+                    }
+                    if let Some(t) = alert.ends_secs {
+                        meta_row(ui, "Ends", &format_absolute(t));
+                    }
+                    if !alert.sender.is_empty() {
+                        meta_row(ui, "Sender", &alert.sender);
+                    }
+                });
+            });
+
+            ui.separator();
+            ui.add_space(4.0);
+            if !alert.area_desc.is_empty() {
+                ui.label(RichText::new("Area").strong().size(12.0));
+                ui.label(
+                    RichText::new(&alert.area_desc)
+                        .size(12.0)
+                        .color(Color32::from_rgb(200, 200, 200)),
+                );
+                ui.add_space(6.0);
+            }
+
+            ScrollArea::vertical()
+                .id_salt("alert_detail_scroll")
+                .max_height(360.0)
+                .show(ui, |ui| {
+                    if !alert.description.is_empty() {
+                        ui.label(RichText::new("Description").strong().size(12.0));
+                        ui.label(RichText::new(&alert.description).size(12.0));
+                        ui.add_space(8.0);
+                    }
+                    if !alert.instruction.is_empty() {
+                        ui.label(
+                            RichText::new("Instructions")
+                                .strong()
+                                .size(12.0)
+                                .color(Color32::from_rgb(250, 220, 120)),
+                        );
+                        ui.label(
+                            RichText::new(&alert.instruction)
+                                .size(12.0)
+                                .color(Color32::from_rgb(240, 220, 160)),
+                        );
+                    }
+                });
+
+            ui.add_space(8.0);
+            ui.separator();
+            ui.horizontal(|ui| {
+                if ui
+                    .button(RichText::new(format!(
+                        "{} Show on map",
+                        egui_phosphor::regular::MAP_PIN_LINE
+                    )))
+                    .on_hover_text("Center the 2D map on the alert and enable the alerts overlay")
+                    .clicked()
+                {
+                    focus_on_alert(state, &alert);
+                    close = true;
+                }
+
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    if ui.button("Close").clicked() {
+                        close = true;
+                    }
+                });
+            });
+        });
+
+    if close {
+        state.alerts.selected_alert_id = None;
+    }
+}
+
+fn focus_on_alert(state: &mut AppState, alert: &Alert) {
+    // Turn on the overlay layer.
+    state.layer_state.geo.alerts = true;
+
+    // Center the 2D view on the alert bbox centroid if we have one.
+    if let Some((min_lon, min_lat, max_lon, max_lat)) = alert.geometry.bbox {
+        let center_lat = (min_lat + max_lat) * 0.5;
+        let center_lon = (min_lon + max_lon) * 0.5;
+        state.viz_state.center_lat = center_lat;
+        state.viz_state.center_lon = center_lon;
+        state.viz_state.pan_offset = egui::Vec2::ZERO;
+        state.viz_state.camera.center_on(center_lat, center_lon);
+    }
+}
+
+fn severity_dot(ui: &mut egui::Ui, severity: AlertSeverity) {
+    let (r, g, b) = severity.color();
+    let color = Color32::from_rgb(r, g, b);
+    let (rect, _) = ui.allocate_exact_size(Vec2::new(10.0, 10.0), egui::Sense::hover());
+    ui.painter().circle_filled(rect.center(), 5.0, color);
+}
+
+fn severity_badge(ui: &mut egui::Ui, severity: AlertSeverity) {
+    let (r, g, b) = severity.color();
+    let color = Color32::from_rgb(r, g, b);
+    chip_badge(ui, severity.label(), color);
+}
+
+fn chip_badge(ui: &mut egui::Ui, label: &str, color: Color32) {
+    let text = RichText::new(label).size(11.0).strong().color(color);
+    egui::Frame::default()
+        .stroke(egui::Stroke::new(1.0, color))
+        .inner_margin(egui::Margin::symmetric(6, 2))
+        .corner_radius(egui::CornerRadius::same(3))
+        .show(ui, |ui| {
+            ui.label(text);
+        });
+}
+
+fn severity_stroke(severity: AlertSeverity) -> egui::Stroke {
+    let (r, g, b) = severity.color();
+    egui::Stroke::new(1.0, Color32::from_rgb(r, g, b))
+}
+
+fn meta_row(ui: &mut egui::Ui, label: &str, value: &str) {
+    ui.horizontal(|ui| {
+        ui.label(
+            RichText::new(format!("{}:", label))
+                .size(11.0)
+                .color(Color32::from_rgb(150, 150, 150)),
+        );
+        ui.label(RichText::new(value).size(11.0));
+    });
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
+        out.push('\u{2026}');
+        out
+    }
+}
+
+fn format_absolute(ts_secs: f64) -> String {
+    // Show as local date-time; the user can mentally convert if needed.
+    let d = js_sys::Date::new(&wasm_bindgen::JsValue::from_f64(ts_secs * 1000.0));
+    format!(
+        "{:04}-{:02}-{:02} {:02}:{:02} local",
+        d.get_full_year(),
+        d.get_month() + 1,
+        d.get_date(),
+        d.get_hours(),
+        d.get_minutes(),
+    )
+}
+
+fn format_relative(ts_secs: f64) -> String {
+    let now = js_sys::Date::now() / 1000.0;
+    let delta = ts_secs - now;
+    if delta < 0.0 {
+        return "in the past".to_string();
+    }
+    let delta = delta as i64;
+    if delta < 60 {
+        format!("in {}s", delta)
+    } else if delta < 3600 {
+        format!("in {}m", delta / 60)
+    } else if delta < 86400 {
+        format!("in {}h{}m", delta / 3600, (delta % 3600) / 60)
+    } else {
+        format!("in {}d", delta / 86400)
+    }
+}

--- a/src/ui/canvas.rs
+++ b/src/ui/canvas.rs
@@ -3,8 +3,8 @@
 use super::canvas_inspector::{render_distance_measurement, render_inspector, render_storm_cells};
 use super::canvas_interaction::{handle_canvas_interaction, handle_globe_interaction};
 use super::canvas_overlays::{
-    draw_color_scale, draw_compass, draw_globe, draw_overlay_info, render_nexrad_sites,
-    render_radar_sweep,
+    draw_color_scale, draw_compass, draw_globe, draw_overlay_info, render_alerts,
+    render_nexrad_sites, render_radar_sweep,
 };
 use super::colors::canvas as canvas_colors;
 use crate::geo::{GeoLayerSet, MapProjection};
@@ -40,6 +40,10 @@ pub fn render_canvas_with_geo(
 
         match state.viz_state.view_mode {
             ViewMode::Globe3D => {
+                // Globe view doesn't have meaningful 2D lat/lon bounds;
+                // downstream consumers should treat `None` as "unknown".
+                state.viz_state.last_visible_bounds = None;
+
                 // Update camera aspect ratio
                 state.viz_state.camera.set_aspect(rect);
 
@@ -69,6 +73,11 @@ pub fn render_canvas_with_geo(
                     MapProjection::new(state.viz_state.center_lat, state.viz_state.center_lon);
                 projection.update(state.viz_state.zoom, state.viz_state.pan_offset, rect);
 
+                // Cache current visible bounds so non-canvas UI (top bar chip,
+                // modals) can filter geographic data without reconstructing
+                // the projection.
+                state.viz_state.last_visible_bounds = Some(projection.visible_bounds());
+
                 if let Some(layers) = geo_layers {
                     let filtered = filter_geo_layers(layers, &state.layer_state.geo);
                     crate::geo::render_geo_layers(
@@ -86,6 +95,10 @@ pub fn render_canvas_with_geo(
                     &state.viz_state.site_id,
                     &state.layer_state.geo,
                 );
+
+                if state.layer_state.geo.alerts && !state.alerts.alerts.is_empty() {
+                    render_alerts(&painter, &projection, &state.alerts.alerts);
+                }
 
                 let sweep_info = compute_sweep_line_azimuth(state);
                 let (gpu_sweep, between_sweeps) = compute_gpu_sweep_state(state, sweep_info);

--- a/src/ui/canvas_interaction.rs
+++ b/src/ui/canvas_interaction.rs
@@ -99,6 +99,32 @@ pub(crate) fn handle_canvas_interaction(
                 state.viz_state.distance_end = Some((geo.y, geo.x));
             }
         }
+    } else if state.layer_state.geo.alerts
+        && response.clicked()
+        && !state.viz_state.distance_tool_active
+    {
+        // Alert hit-testing: when the alerts overlay is on, a simple click
+        // that lands inside an alert polygon opens that alert's detail
+        // modal. Highest-severity alert wins on overlap.
+        if let Some(click_pos) = response.interact_pointer_pos() {
+            let geo = projection.screen_to_geo(click_pos);
+            let bounds = projection.visible_bounds();
+            let mut best: Option<(u8, String)> = None;
+            for alert in &state.alerts.alerts {
+                if !crate::alerts::bbox_intersects(alert, bounds) {
+                    continue;
+                }
+                if crate::alerts::contains_point(alert, geo.x, geo.y) {
+                    let rank = alert.severity.rank();
+                    if best.as_ref().is_none_or(|(r, _)| rank > *r) {
+                        best = Some((rank, alert.id.clone()));
+                    }
+                }
+            }
+            if let Some((_, id)) = best {
+                state.push_command(crate::state::AppCommand::OpenAlert(id));
+            }
+        }
     }
 
     if response.dragged() {

--- a/src/ui/canvas_overlays/alerts.rs
+++ b/src/ui/canvas_overlays/alerts.rs
@@ -1,0 +1,68 @@
+//! NWS alerts canvas overlay.
+//!
+//! Draws the polygon footprints of every alert whose bounding box intersects
+//! the currently visible area. Each polygon is filled with a transparent
+//! severity color and outlined with a solid stroke.
+//!
+//! Only runs in 2D flat mode.
+
+use crate::alerts::{bbox_intersects, Alert};
+use crate::geo::MapProjection;
+use eframe::egui::{Color32, Painter, Pos2, Shape, Stroke};
+use geo_types::Coord;
+
+/// Render alert polygons on top of the radar view.
+pub(crate) fn render_alerts(painter: &Painter, projection: &MapProjection, alerts: &[Alert]) {
+    let bounds = projection.visible_bounds();
+
+    // Sort lowest → highest severity so highest draws on top. We iterate in
+    // that order without mutating the caller's slice.
+    let mut ordered: Vec<&Alert> = alerts
+        .iter()
+        .filter(|a| bbox_intersects(a, bounds))
+        .collect();
+    ordered.sort_by_key(|a| a.severity.rank());
+
+    for alert in ordered {
+        let (r, g, b) = alert.severity.color();
+        let fill = Color32::from_rgba_unmultiplied(r, g, b, 48);
+        let stroke_color = Color32::from_rgba_unmultiplied(r, g, b, 220);
+        let stroke = Stroke::new(1.5, stroke_color);
+
+        for polygon in &alert.geometry.polygons {
+            // Project all rings once.
+            let projected_rings: Vec<Vec<Pos2>> = polygon
+                .iter()
+                .map(|ring| {
+                    ring.iter()
+                        .map(|&(lon, lat)| projection.geo_to_screen(Coord { x: lon, y: lat }))
+                        .collect()
+                })
+                .collect();
+
+            let Some(outer) = projected_rings.first() else {
+                continue;
+            };
+            if outer.len() < 3 {
+                continue;
+            }
+
+            // Filled outline — use a closed path with a tinted fill. egui's
+            // convex_polygon handles non-convex rings reasonably well for
+            // visualization purposes; self-intersecting rings are very rare
+            // in NWS alert data and if they occur, the fill will still give
+            // a meaningful visual indication.
+            painter.add(Shape::convex_polygon(outer.clone(), fill, Stroke::NONE));
+            painter.add(Shape::closed_line(outer.clone(), stroke));
+
+            // Hole rings: draw outline only so the user can see the cutout
+            // even though we don't actually subtract it from the fill.
+            for hole in projected_rings.iter().skip(1) {
+                if hole.len() < 3 {
+                    continue;
+                }
+                painter.add(Shape::closed_line(hole.clone(), stroke));
+            }
+        }
+    }
+}

--- a/src/ui/canvas_overlays/mod.rs
+++ b/src/ui/canvas_overlays/mod.rs
@@ -4,6 +4,7 @@
 //! canvas `Rect` using the egui `Painter`. Overlays are drawn in painter
 //! order after the radar texture and geographic layers.
 
+mod alerts;
 mod color_scale;
 mod compass;
 mod globe;
@@ -11,6 +12,7 @@ mod info;
 mod sites;
 mod sweep;
 
+pub(crate) use alerts::render_alerts;
 pub(crate) use color_scale::draw_color_scale;
 pub(crate) use compass::draw_compass;
 pub(crate) use globe::draw_globe;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -8,6 +8,7 @@
 //! - Right panel: Product selection, layers, and rendering controls
 
 pub(crate) mod acquisition_drawer;
+mod alerts_modal;
 mod bottom_panel;
 mod canvas;
 mod canvas_inspector;
@@ -27,6 +28,7 @@ mod timeline;
 mod top_bar;
 mod wipe_modal;
 
+pub use alerts_modal::render_alerts_modals;
 pub use bottom_panel::render_bottom_panel;
 pub use canvas::render_canvas_with_geo;
 pub use event_modal::{render_event_modal, EventModalState};

--- a/src/ui/right_panel.rs
+++ b/src/ui/right_panel.rs
@@ -191,6 +191,10 @@ fn render_layers_section(ui: &mut egui::Ui, state: &mut AppState) {
             ui.checkbox(&mut state.layer_state.geo.counties, "County Lines");
             ui.checkbox(&mut state.layer_state.geo.cities, "Cities");
             ui.checkbox(&mut state.layer_state.geo.labels, "Labels");
+            ui.checkbox(&mut state.layer_state.geo.alerts, "Weather Alerts")
+                .on_hover_text(
+                    "Show active NWS alert polygons on the 2D map (click polygon for details)",
+                );
         });
 }
 

--- a/src/ui/site_modal.rs
+++ b/src/ui/site_modal.rs
@@ -77,6 +77,7 @@ fn apply_site_selection(state: &mut AppState, site_id: &str, lat: f64, lon: f64)
         auto_position: true,
     });
     state.push_command(crate::state::AppCommand::FetchLatest);
+    state.push_command(crate::state::AppCommand::RefreshAlerts);
     state.preferred_site = Some(site_id.to_string());
     state.site_modal_open = false;
 }

--- a/src/ui/top_bar.rs
+++ b/src/ui/top_bar.rs
@@ -1,7 +1,8 @@
 //! Top bar UI: app title, status, and site context.
 
 use super::colors::live;
-use crate::state::{AppState, CameraMode, LivePhase, ViewMode};
+use crate::alerts::AlertSeverity;
+use crate::state::{AppCommand, AppState, CameraMode, LivePhase, ViewMode};
 use eframe::egui::{self, Color32, RichText};
 
 pub fn render_top_bar(ctx: &egui::Context, state: &mut AppState) {
@@ -49,6 +50,10 @@ pub fn render_top_bar(ctx: &egui::Context, state: &mut AppState) {
                 }
 
                 ui.separator();
+
+                // NWS alerts chip — shown only in 2D when one or more alerts
+                // intersect the visible map bounds.
+                render_alerts_chip(ui, state);
 
                 // Persistent worker initialization error banner
                 if let Some(ref error_msg) = state.worker_init_error {
@@ -243,6 +248,116 @@ pub fn render_top_bar(ctx: &egui::Context, state: &mut AppState) {
                 });
             });
         });
+}
+
+/// Render a compact alerts indicator for the top bar. Shows nothing when
+/// no active NWS alerts intersect the current viewing area (or when the
+/// viewing area is undefined, e.g. in 3D globe mode).
+fn render_alerts_chip(ui: &mut egui::Ui, state: &mut AppState) {
+    // Show a subtle loading/error hint on the first fetch so the user knows
+    // the feed is being contacted. After the first success, stay quiet unless
+    // there are alerts to surface.
+    let has_ever_loaded = state.alerts.last_success_ms > 0.0;
+    let has_error = state.alerts.last_error.is_some();
+    if !has_ever_loaded && !has_error {
+        let icon = RichText::new(egui_phosphor::regular::BELL_SIMPLE)
+            .size(14.0)
+            .color(Color32::from_rgb(130, 130, 130));
+        ui.add(egui::Label::new(icon))
+            .on_hover_text("Loading NWS alerts\u{2026}");
+        ui.separator();
+        return;
+    }
+
+    let Some(bounds) = state.viz_state.last_visible_bounds else {
+        // 3D globe view or canvas hasn't rendered yet.
+        return;
+    };
+
+    let visible: Vec<(String, String, AlertSeverity)> = state
+        .alerts
+        .visible_in(bounds)
+        .into_iter()
+        .map(|a| (a.id.clone(), a.event.clone(), a.severity))
+        .collect();
+
+    if visible.is_empty() {
+        // Render a quiet dimmed icon so users know the feed is live when hovered.
+        let tooltip = if has_error {
+            format!(
+                "NWS alerts: {}",
+                state.alerts.last_error.as_deref().unwrap_or("error")
+            )
+        } else {
+            format!(
+                "No active alerts in view ({} active nationwide)",
+                state.alerts.alerts.len()
+            )
+        };
+        let color = if has_error {
+            Color32::from_rgb(200, 120, 60)
+        } else {
+            Color32::from_rgb(110, 110, 110)
+        };
+        let icon = RichText::new(egui_phosphor::regular::BELL_SIMPLE)
+            .size(14.0)
+            .color(color);
+        let response = ui.add(egui::Label::new(icon).sense(egui::Sense::click()));
+        response.clone().on_hover_text(tooltip);
+        if response.clicked() {
+            state.push_command(AppCommand::RefreshAlerts);
+        }
+        ui.separator();
+        return;
+    }
+
+    // Use the highest-severity alert for the chip color (list is already
+    // sorted by severity descending by `visible_in`).
+    let top_severity = visible[0].2;
+    let (r, g, b) = top_severity.color();
+    let chip_color = Color32::from_rgb(r, g, b);
+
+    let label = if visible.len() == 1 {
+        let event = &visible[0].1;
+        format!("{} {}", egui_phosphor::regular::WARNING, event)
+    } else {
+        format!(
+            "{} {} alerts",
+            egui_phosphor::regular::WARNING,
+            visible.len()
+        )
+    };
+
+    let response = ui.add(egui::Button::new(
+        RichText::new(label).size(13.0).strong().color(chip_color),
+    ));
+
+    if response.hovered() {
+        ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+    }
+
+    let hover = if visible.len() == 1 {
+        format!("{} — click for details", visible[0].1,)
+    } else {
+        let mut lines = String::from("Click to view alerts in this area:\n");
+        for (_, event, sev) in visible.iter().take(6) {
+            lines.push_str(&format!("\n  \u{2022} [{}] {}", sev.label(), event));
+        }
+        if visible.len() > 6 {
+            lines.push_str(&format!("\n  \u{2026} and {} more", visible.len() - 6));
+        }
+        lines
+    };
+
+    if response.on_hover_text(hover).clicked() {
+        if visible.len() == 1 {
+            state.push_command(AppCommand::OpenAlert(visible[0].0.clone()));
+        } else {
+            state.alerts.list_modal_open = true;
+        }
+    }
+
+    ui.separator();
 }
 
 /// Render live mode status in the top bar.


### PR DESCRIPTION
## Summary
Adds comprehensive National Weather Service (NWS) alerts support to the workbench, including real-time polling of active alerts, a toggleable canvas overlay showing alert polygons, and modal dialogs for browsing and viewing alert details.

## Key Changes

### New Alerts Module (`src/alerts/`)
- **`types.rs`**: Core data structures for alerts, including `Alert`, `AlertSeverity` (Extreme/Severe/Moderate/Minor), and `AlertGeometry` for polygon footprints with bounding box computation
- **`parse.rs`**: GeoJSON parser for the NWS alerts API response, extracting relevant fields (event, severity, timestamps, description, instructions, geometry)
- **`api.rs`**: Browser Fetch API integration with ETag-based caching and CORS support for `https://api.weather.gov/alerts/active`
- **`manager.rs`**: Lifecycle manager that polls the alerts feed every 2 minutes (with 30-second retry on error), drains async results, and proactively removes expired alerts
- **`channel.rs`**: Event channel for async fetch results using `Rc<RefCell<>>` pattern
- **`geometry.rs`**: Geometric utilities for bounding box intersection testing and point-in-polygon hit detection (even-odd ray casting)

### UI Components
- **`alerts_modal.rs`**: Two-modal system:
  - List modal: Shows all alerts intersecting the current view bounds, sorted by severity, with click-to-select
  - Detail modal: Displays full alert information (headline, severity badges, timing, area, description, instructions) with "Show on map" button to center and enable overlay
- **Top bar chip**: Compact alerts indicator showing highest-severity alert or count; displays loading/error state on first fetch; opens list modal on click
- **Canvas overlay** (`canvas_overlays/alerts.rs`): Renders alert polygon footprints with severity-based colors (transparent fill + solid stroke), sorted by severity for proper layering

### State Management
- **`AlertsState`** (`state/alerts.rs`): Tracks active alerts, fetch metadata (ETag, timestamps, errors), and UI selections (selected alert, list modal open state)
- **`VizState`**: Added `last_visible_bounds` to track current 2D map viewport for filtering
- **`LayerState`**: Added `alerts` boolean to toggle overlay visibility
- **`UserPreferences`**: Added `layer_alerts` persistence for overlay toggle state

### Integration Points
- Canvas interaction: Click-to-select alerts when overlay is enabled; highest-severity alert wins on overlap
- Site modal: Triggers alert refresh when selecting a new site
- Right panel: Checkbox to toggle alerts overlay layer

## Notable Implementation Details
- Alerts are filtered client-side by bounding box intersection; zone-only alerts (without geometry) are skipped during parsing
- ETag caching prevents unnecessary re-parsing when the server returns 304 Not Modified
- Expired alerts are proactively removed each frame based on `ends_secs` or `expires_secs`
- Severity colors are consistent across top bar, modals, and canvas (Extreme: red, Severe: orange, Moderate: yellow, Minor/Unknown: blue)
- Modal backdrop pattern follows existing conventions (`site_modal`, `event_modal`)
- All timestamps are converted to Unix seconds for consistent handling

https://claude.ai/code/session_01DA1qQMhwNqrjrnZAydt32J