### PR TITLE
Rename data age indicator to data age desaturation, remove despeckle

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1191,7 +1191,7 @@ impl WorkbenchApp {
         }
 
         // Ensure continuous repainting for time-dependent UI elements (the "now"
-        // marker on the timeline and the data-age indicators) even when the user
+        // marker on the timeline and the data age desaturation) even when the user
         // is idle and playback is stopped.  Repaint once per second which is
         // sufficient for these indicators while being easy on the CPU.
         ctx.request_repaint_after(std::time::Duration::from_secs(1));

--- a/src/nexrad/globe_radar_renderer.rs
+++ b/src/nexrad/globe_radar_renderer.rs
@@ -120,29 +120,6 @@ void main() {{
         discard;
     }}
 
-    // Despeckle
-    if (u_despeckle_enabled == 1) {{
-        float dummy_az2;
-        float center_az = find_nearest_az_p(azimuth_deg, u_azimuth_count, u_azimuth_spacing_deg, u_azimuth_tex, dummy_az2);
-        float center_g = floor(gate_idx);
-        if (center_az >= 0.0) {{
-            int valid_count = 0;
-            for (int dg = -1; dg <= 1; dg++) {{
-                for (int da = -1; da <= 1; da++) {{
-                    if (dg == 0 && da == 0) continue;
-                    float ng = center_g + float(dg);
-                    float na = mod(center_az + float(da), u_azimuth_count);
-                    if (is_valid(sample_data_p(u_data_tex, u_gate_count, u_azimuth_count, ng, na))) {{
-                        valid_count++;
-                    }}
-                }}
-            }}
-            if (valid_count < u_despeckle_threshold) {{
-                discard;
-            }}
-        }}
-    }}
-
 {RAW_TO_PHYSICAL}
 {COLOR_LOOKUP}
 {PREMULTIPLIED_ALPHA_OUTPUT}
@@ -169,8 +146,6 @@ pub struct GlobeRadarRenderer {
     u_value_min: glow::UniformLocation,
     u_value_range: glow::UniformLocation,
     u_interpolation: glow::UniformLocation,
-    u_despeckle_enabled: glow::UniformLocation,
-    u_despeckle_threshold: glow::UniformLocation,
     u_opacity: glow::UniformLocation,
     u_offset: glow::UniformLocation,
     u_scale: glow::UniformLocation,
@@ -207,12 +182,6 @@ impl GlobeRadarRenderer {
         let u_value_min = gl.get_uniform_location(program, "u_value_min").unwrap();
         let u_value_range = gl.get_uniform_location(program, "u_value_range").unwrap();
         let u_interpolation = gl.get_uniform_location(program, "u_interpolation").unwrap();
-        let u_despeckle_enabled = gl
-            .get_uniform_location(program, "u_despeckle_enabled")
-            .unwrap();
-        let u_despeckle_threshold = gl
-            .get_uniform_location(program, "u_despeckle_threshold")
-            .unwrap();
         let u_opacity = gl.get_uniform_location(program, "u_opacity").unwrap();
         let u_offset = gl.get_uniform_location(program, "u_offset").unwrap();
         let u_scale = gl.get_uniform_location(program, "u_scale").unwrap();
@@ -269,8 +238,6 @@ impl GlobeRadarRenderer {
             u_value_min,
             u_value_range,
             u_interpolation,
-            u_despeckle_enabled,
-            u_despeckle_threshold,
             u_opacity,
             u_offset,
             u_scale,
@@ -391,14 +358,6 @@ impl GlobeRadarRenderer {
                 crate::state::InterpolationMode::Bilinear => 1,
             };
             gl.uniform_1_i32(Some(&self.u_interpolation), interp_mode);
-            gl.uniform_1_i32(
-                Some(&self.u_despeckle_enabled),
-                processing.despeckle_enabled as i32,
-            );
-            gl.uniform_1_i32(
-                Some(&self.u_despeckle_threshold),
-                processing.despeckle_threshold as i32,
-            );
             gl.uniform_1_f32(Some(&self.u_opacity), processing.opacity);
 
             // Raw-to-physical conversion

--- a/src/nexrad/gpu_renderer/mod.rs
+++ b/src/nexrad/gpu_renderer/mod.rs
@@ -66,10 +66,8 @@ struct UniformLocations {
     value_range: glow::UniformLocation,
     viewport_size: glow::UniformLocation,
     interpolation: glow::UniformLocation,
-    despeckle_enabled: glow::UniformLocation,
-    despeckle_threshold: glow::UniformLocation,
     opacity: glow::UniformLocation,
-    data_age_indicator: glow::UniformLocation,
+    data_age_desaturation: glow::UniformLocation,
     offset: glow::UniformLocation,
     scale: glow::UniformLocation,
     sweep_enabled: glow::UniformLocation,
@@ -225,10 +223,8 @@ impl RadarGpuRenderer {
                 value_range: uniform("u_value_range")?,
                 viewport_size: uniform("u_viewport_size")?,
                 interpolation: uniform("u_interpolation")?,
-                despeckle_enabled: uniform("u_despeckle_enabled")?,
-                despeckle_threshold: uniform("u_despeckle_threshold")?,
                 opacity: uniform("u_opacity")?,
-                data_age_indicator: uniform("u_data_age_indicator")?,
+                data_age_desaturation: uniform("u_data_age_desaturation")?,
                 offset: uniform("u_offset")?,
                 scale: uniform("u_scale")?,
                 sweep_enabled: uniform("u_sweep_enabled")?,
@@ -406,18 +402,10 @@ impl RadarGpuRenderer {
                 crate::state::InterpolationMode::Bilinear => 1,
             };
             gl.uniform_1_i32(Some(&self.uniforms.interpolation), interp_mode);
-            gl.uniform_1_i32(
-                Some(&self.uniforms.despeckle_enabled),
-                processing.despeckle_enabled as i32,
-            );
-            gl.uniform_1_i32(
-                Some(&self.uniforms.despeckle_threshold),
-                processing.despeckle_threshold as i32,
-            );
             gl.uniform_1_f32(Some(&self.uniforms.opacity), processing.opacity);
             gl.uniform_1_i32(
-                Some(&self.uniforms.data_age_indicator),
-                processing.data_age_indicator as i32,
+                Some(&self.uniforms.data_age_desaturation),
+                processing.data_age_desaturation as i32,
             );
 
             // Raw-to-physical conversion

--- a/src/nexrad/gpu_renderer/shaders.rs
+++ b/src/nexrad/gpu_renderer/shaders.rs
@@ -25,8 +25,6 @@ uniform sampler2D u_lut_tex;
 uniform sampler2D u_azimuth_tex;
 
 uniform int u_interpolation;
-uniform int u_despeckle_enabled;
-uniform int u_despeckle_threshold;
 uniform float u_opacity;
 
 uniform float u_offset;
@@ -224,7 +222,7 @@ uniform vec2 u_radar_center;       // radar center in screen pixels
 uniform float u_radar_radius;      // max coverage radius in screen pixels
 {FRAGMENT_PREAMBLE}
 // Processing uniforms
-uniform int u_data_age_indicator; // 0 or 1: desaturate oldest data behind sweep line
+uniform int u_data_age_desaturation; // 0 or 1: desaturate oldest data behind sweep line
 
 // Sweep animation (dual-texture compositing)
 uniform sampler2D u_prev_data_tex;    // previous scan gate values (R32F, texture unit 3)
@@ -274,7 +272,7 @@ void main() {{
     // The fade zone is 90° ahead of the now line in rotation direction —
     // the oldest data from the previous rotation, about to be overwritten.
     float desat_factor = 0.0;
-    if (u_sweep_enabled == 1 && u_data_age_indicator == 1 && u_sweep_chunk_boundary >= 0.0) {{
+    if (u_sweep_enabled == 1 && u_data_age_desaturation == 1 && u_sweep_chunk_boundary >= 0.0) {{
         // Distance behind the now line (opposite rotation direction).
         // 0 = at now line, increases going back through received data.
         float behind_now = mod(u_sweep_chunk_boundary - azimuth_deg + 360.0, 360.0);
@@ -293,7 +291,7 @@ void main() {{
         }}
     }}
     // Fallback when no estimated antenna position is available
-    if (u_sweep_enabled == 1 && u_data_age_indicator == 1 && u_sweep_chunk_boundary < 0.0) {{
+    if (u_sweep_enabled == 1 && u_data_age_desaturation == 1 && u_sweep_chunk_boundary < 0.0) {{
         float age = mod(u_sweep_azimuth - azimuth_deg + 360.0, 360.0) / 360.0;
         desat_factor = clamp((age - 0.75) / 0.25, 0.0, 1.0) * 0.9;
     }}
@@ -398,37 +396,6 @@ void main() {{
     if (!is_valid(value)) {{
         fragColor = vec4(0.0);
         return;
-    }}
-
-    // Despeckle filter
-    if (u_despeckle_enabled == 1) {{
-        float dummy_az2;
-        float center_az;
-        if (use_prev) {{
-            center_az = find_nearest_az_p(azimuth_deg, s_azimuth_count, s_azimuth_spacing, u_prev_azimuth_tex, dummy_az2);
-        }} else {{
-            center_az = find_nearest_az_p(azimuth_deg, s_azimuth_count, s_azimuth_spacing, u_azimuth_tex, dummy_az2);
-        }}
-        float center_g = floor(gate_idx);
-        if (center_az >= 0.0) {{
-            int valid_count = 0;
-            for (int dg = -1; dg <= 1; dg++) {{
-                for (int da = -1; da <= 1; da++) {{
-                    if (dg == 0 && da == 0) continue;
-                    float ng = center_g + float(dg);
-                    float na = mod(center_az + float(da), s_azimuth_count);
-                    if (use_prev) {{
-                        if (is_valid(sample_data_p(u_prev_data_tex, s_gate_count, s_azimuth_count, ng, na))) valid_count++;
-                    }} else {{
-                        if (is_valid(sample_data_p(u_data_tex, s_gate_count, s_azimuth_count, ng, na))) valid_count++;
-                    }}
-                }}
-            }}
-            if (valid_count < u_despeckle_threshold) {{
-                fragColor = vec4(0.0);
-                return;
-            }}
-        }}
     }}
 
 {RAW_TO_PHYSICAL}

--- a/src/state/preferences.rs
+++ b/src/state/preferences.rs
@@ -36,16 +36,12 @@ pub struct UserPreferences {
     // Rendering options
     #[serde(default)]
     pub interpolation: InterpolationMode,
-    #[serde(default)]
-    pub despeckle_enabled: bool,
-    #[serde(default = "default_despeckle_threshold")]
-    pub despeckle_threshold: u32,
     #[serde(default = "default_opacity")]
     pub opacity: f32,
     #[serde(default)]
     pub sweep_animation: bool,
     #[serde(default = "default_true")]
-    pub data_age_indicator: bool,
+    pub data_age_desaturation: bool,
 }
 
 fn default_true() -> bool {
@@ -54,10 +50,6 @@ fn default_true() -> bool {
 
 fn default_elevation_angle() -> f32 {
     0.5
-}
-
-fn default_despeckle_threshold() -> u32 {
-    3
 }
 
 fn default_opacity() -> f32 {
@@ -78,11 +70,9 @@ impl Default for UserPreferences {
             use_local_time: false,
             preferred_site: None,
             interpolation: InterpolationMode::default(),
-            despeckle_enabled: false,
-            despeckle_threshold: 3,
             opacity: 1.0,
             sweep_animation: false,
-            data_age_indicator: true,
+            data_age_desaturation: true,
         }
     }
 }
@@ -104,11 +94,9 @@ impl UserPreferences {
             use_local_time: state.use_local_time,
             preferred_site: state.preferred_site.clone(),
             interpolation: state.render_processing.interpolation,
-            despeckle_enabled: state.render_processing.despeckle_enabled,
-            despeckle_threshold: state.render_processing.despeckle_threshold,
             opacity: state.render_processing.opacity,
             sweep_animation: state.render_processing.sweep_animation,
-            data_age_indicator: state.render_processing.data_age_indicator,
+            data_age_desaturation: state.render_processing.data_age_desaturation,
         }
     }
 
@@ -132,11 +120,9 @@ impl UserPreferences {
         state.use_local_time = self.use_local_time;
         state.preferred_site = self.preferred_site.clone();
         state.render_processing.interpolation = self.interpolation;
-        state.render_processing.despeckle_enabled = self.despeckle_enabled;
-        state.render_processing.despeckle_threshold = self.despeckle_threshold;
         state.render_processing.opacity = self.opacity;
         state.render_processing.sweep_animation = self.sweep_animation;
-        state.render_processing.data_age_indicator = self.data_age_indicator;
+        state.render_processing.data_age_desaturation = self.data_age_desaturation;
     }
 
     /// Load preferences from localStorage.

--- a/src/state/viz.rs
+++ b/src/state/viz.rs
@@ -196,27 +196,21 @@ impl InterpolationMode {
 pub struct RenderProcessing {
     /// Interpolation mode (nearest vs bilinear).
     pub interpolation: InterpolationMode,
-    /// Whether despeckle filtering is enabled.
-    pub despeckle_enabled: bool,
-    /// Minimum valid neighbors to keep a pixel (1..8).
-    pub despeckle_threshold: u32,
     /// Global opacity for radar data (0.0..1.0).
     pub opacity: f32,
     /// Whether sweep animation is enabled (progressive radial reveal during playback).
     pub sweep_animation: bool,
-    /// Whether data age indicator is shown (desaturates oldest data behind sweep line).
-    pub data_age_indicator: bool,
+    /// Whether data age desaturation is shown (desaturates oldest data behind sweep line).
+    pub data_age_desaturation: bool,
 }
 
 impl Default for RenderProcessing {
     fn default() -> Self {
         Self {
             interpolation: InterpolationMode::Nearest,
-            despeckle_enabled: false,
-            despeckle_threshold: 3,
             opacity: 1.0,
             sweep_animation: false,
-            data_age_indicator: true,
+            data_age_desaturation: true,
         }
     }
 }

--- a/src/ui/right_panel.rs
+++ b/src/ui/right_panel.rs
@@ -232,22 +232,6 @@ fn render_rendering_section(ui: &mut egui::Ui, state: &mut AppState) {
 
             ui.add_space(8.0);
 
-            // Despeckle
-            ui.checkbox(&mut proc.despeckle_enabled, "Despeckle");
-            if proc.despeckle_enabled {
-                ui.indent("despeckle_indent", |ui| {
-                    let mut threshold = proc.despeckle_threshold as i32;
-                    if ui
-                        .add(egui::Slider::new(&mut threshold, 1..=16).text("Threshold"))
-                        .changed()
-                    {
-                        proc.despeckle_threshold = threshold as u32;
-                    }
-                });
-            }
-
-            ui.add_space(4.0);
-
             // Sweep animation (disabled in macro mode — not meaningful when
             // playback jumps between complete frames)
             ui.add_enabled_ui(!in_macro, |ui| {
@@ -259,10 +243,10 @@ fn render_rendering_section(ui: &mut egui::Ui, state: &mut AppState) {
                     });
             });
 
-            // Data age indicator (only meaningful when sweep animation is on)
+            // Data age desaturation (only meaningful when sweep animation is on)
             ui.add_enabled_ui(proc.sweep_animation && !in_macro, |ui| {
-                ui.indent("data_age_indent", |ui| {
-                    ui.checkbox(&mut proc.data_age_indicator, "Data Age Indicator")
+                ui.indent("data_age_desaturation_indent", |ui| {
+                    ui.checkbox(&mut proc.data_age_desaturation, "Data Age Desaturation")
                         .on_hover_text(
                             "Desaturate the oldest data behind the sweep line to indicate staleness",
                         );


### PR DESCRIPTION
Renames the existing render setting (state field, preference field,
shader uniform, and UI label) to match what it actually does: desaturate
older data behind the sweep line.

Drops the despeckle filter entirely — toggle, threshold slider,
preference fields, shader branches in both the flat and globe
fragment shaders, and the associated GPU uniforms.