### PR TITLE
Auto-zoom timeline to micro mode when entering live mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -821,6 +821,15 @@ impl WorkbenchApp {
         self.state.playback_state.set_playback_position(now);
         self.state.playback_state.time_model.enable_realtime_lock();
         self.state.playback_state.playing = true;
+
+        // Ensure the timeline is zoomed in far enough to show individual sweeps
+        // and chunks. Live mode enforces micro-mode as the widest allowed zoom.
+        const LIVE_DEFAULT_ZOOM: f64 = 2.0;
+        if self.state.playback_state.timeline_zoom < LIVE_DEFAULT_ZOOM {
+            self.state.playback_state.timeline_zoom = LIVE_DEFAULT_ZOOM;
+            self.state.playback_state.center_view_on(now);
+        }
+
         self.state.status_message = "Connecting to live stream...".to_string();
 
         self.streaming

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -32,7 +32,9 @@ pub use app_mode::AppMode;
 pub use layer::{GeoLayerVisibility, LayerState};
 pub use live_mode::{LiveExitReason, LiveModeState, LivePhase};
 pub use live_radar_model::LiveRadarModel;
-pub use playback::{LoopMode, PlaybackMode, PlaybackSpeed, PlaybackState, TimeModel};
+pub use playback::{
+    LoopMode, PlaybackMode, PlaybackSpeed, PlaybackState, TimeModel, MICRO_ZOOM_THRESHOLD,
+};
 pub use preferences::UserPreferences;
 pub use radar_data::RadarTimeline;
 pub use saved_events::{SavedEvent, SavedEvents};

--- a/src/state/playback.rs
+++ b/src/state/playback.rs
@@ -3,6 +3,10 @@
 //! Implements a dual-time model separating playback position from wall-clock time,
 //! with timeline bounds enforcement and zoom-based feature restrictions.
 
+/// Zoom boundary between macro (scan blocks) and micro (individual sweeps) modes,
+/// in pixels per second.
+pub const MICRO_ZOOM_THRESHOLD: f64 = 1.0;
+
 /// Playback mode derived from timeline zoom level.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum PlaybackMode {
@@ -445,7 +449,7 @@ impl PlaybackState {
 
     /// Derive the current playback mode from timeline zoom level.
     pub fn playback_mode(&self) -> PlaybackMode {
-        if self.timeline_zoom < 1.0 {
+        if self.timeline_zoom < MICRO_ZOOM_THRESHOLD {
             PlaybackMode::Macro
         } else {
             PlaybackMode::Micro

--- a/src/ui/timeline/interaction.rs
+++ b/src/ui/timeline/interaction.rs
@@ -1,6 +1,6 @@
 //! Timeline interaction: click, shift+click, drag-to-pan, scroll-to-zoom.
 
-use crate::state::{AppState, LiveExitReason};
+use crate::state::{AppState, LiveExitReason, MICRO_ZOOM_THRESHOLD};
 use eframe::egui::{self, Rect};
 
 /// Handle mouse interaction on the timeline: click, shift+click, drag-to-pan, scroll-to-zoom.
@@ -86,7 +86,14 @@ pub(super) fn handle_timeline_interaction(
         if scroll_delta.y != 0.0 {
             let zoom_factor = 1.0 + scroll_delta.y as f64 * 0.002;
             let old_zoom = state.playback_state.timeline_zoom;
-            let new_zoom = (old_zoom * zoom_factor).clamp(0.000001, 1000.0);
+            // In live mode, never let the user zoom out past micro-mode — they
+            // must be able to see individual sweeps and chunks.
+            let min_zoom = if state.live_mode_state.is_active() {
+                MICRO_ZOOM_THRESHOLD
+            } else {
+                0.000001
+            };
+            let new_zoom = (old_zoom * zoom_factor).clamp(min_zoom, 1000.0);
 
             if let Some(cursor_pos) = response.hover_pos() {
                 let cursor_ts = view_start + (cursor_pos.x - full_rect.left()) as f64 / old_zoom;


### PR DESCRIPTION
Entering real-time streaming now bumps timeline zoom to 2.0 px/sec (if
lower) so individual sweeps and chunks are visible, and scroll-zoom is
clamped to the macro/micro boundary while live so the user cannot zoom
out into scan-block territory.