### PR TITLE
Add PWA support for iOS home-screen installation

### DIFF
--- a/assets/manifest.webmanifest
+++ b/assets/manifest.webmanifest
@@ -2,14 +2,14 @@
   "name": "NEXRAD Workbench",
   "short_name": "NEXRAD",
   "description": "Browser-based NEXRAD weather radar visualization.",
-  "start_url": "./",
-  "scope": "./",
+  "start_url": "../",
+  "scope": "../",
   "display": "standalone",
   "background_color": "#1a1a2e",
   "theme_color": "#ff9b2e",
   "icons": [
-    { "src": "assets/favicon.svg",      "sizes": "any",     "type": "image/svg+xml", "purpose": "any" },
-    { "src": "assets/icon-192.png",     "sizes": "192x192", "type": "image/png",     "purpose": "any" },
-    { "src": "assets/icon-512.png",     "sizes": "512x512", "type": "image/png",     "purpose": "any" }
+    { "src": "favicon.svg",      "sizes": "any",     "type": "image/svg+xml", "purpose": "any" },
+    { "src": "icon-192.png",     "sizes": "192x192", "type": "image/png",     "purpose": "any" },
+    { "src": "icon-512.png",     "sizes": "512x512", "type": "image/png",     "purpose": "any" }
   ]
 }

--- a/index.html
+++ b/index.html
@@ -3,7 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <!-- viewport-fit=cover lets the canvas extend into the iPhone safe areas
+         (notch, home indicator) when installed as a home-screen PWA. -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover">
     <title>NEXRAD Workbench</title>
 
     <!-- Browser favicon. SVG is live-recolored by `setFaviconColor` (see below) to
@@ -13,6 +15,16 @@
     <link rel="apple-touch-icon" sizes="180x180" href="assets/apple-touch-icon.png">
     <link rel="manifest" href="assets/manifest.webmanifest">
     <meta name="theme-color" content="#ff9b2e">
+
+    <!-- iOS "Add to Home Screen" PWA metadata. The manifest's display:standalone
+         covers modern browsers, but iOS Safari still reads these legacy tags to
+         decide whether to launch without Safari chrome and how to style the
+         status bar. `black-translucent` lets the app paint under the status bar
+         together with viewport-fit=cover above. -->
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="apple-mobile-web-app-title" content="NEXRAD">
 
     <link data-trunk rel="rust" data-wasm-opt="2" />
     <link data-trunk rel="copy-file" href="worker.js" />

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,19 +1,72 @@
-// Service Worker — provides cross-origin isolation headers (COOP/COEP) to enable
-// SharedArrayBuffer and intercepts all fetch requests to report network metrics
-// back to the main thread for UI display.
+// Service Worker — three responsibilities:
+//   1. Inject COOP/COEP response headers to enable cross-origin isolation
+//      (required for SharedArrayBuffer in the worker / WASM).
+//   2. Cache the app shell so an installed PWA (Add to Home Screen on iOS)
+//      can launch without a network connection.
+//   3. Report per-request network metrics back to the UI.
 //
 // Protocol:
 //   SW → Client:  { type: 'network-metric', url, status, bytes, duration, ok, error? }
+//
+// Bump CACHE_VERSION whenever the shape of cached content changes in a way
+// that requires old entries to be evicted. Byte-level changes to this file
+// already cause the browser to install a fresh SW, so the activate handler's
+// cleanup of stale caches is what actually runs the eviction.
+const CACHE_VERSION = 'v1';
+const CACHE_NAME = `nexrad-workbench-${CACHE_VERSION}`;
 
-// Take over immediately on install (don't wait for old SW to retire).
-self.addEventListener('install', () => self.skipWaiting());
+// App shell — static, non-hashed files we can name ahead of time.
+// Trunk-emitted hashed assets (index-{hash}.js, *_bg.wasm, snippets/*) are
+// runtime-cached on first fetch below rather than listed here.
+const PRECACHE_URLS = [
+  './',
+  './index.html',
+  './worker.js',
+  './assets/manifest.webmanifest',
+  './assets/favicon.svg',
+  './assets/apple-touch-icon.png',
+  './assets/icon-192.png',
+  './assets/icon-512.png',
+];
 
-// Claim all clients on activation so the SW controls the page without a second reload.
-self.addEventListener('activate', (event) => {
-  event.waitUntil(self.clients.claim());
+self.addEventListener('install', (event) => {
+  event.waitUntil((async () => {
+    const cache = await caches.open(CACHE_NAME);
+    // Add entries individually so one missing asset doesn't abort the whole
+    // install — the fetch handler will still work without the cache.
+    await Promise.all(
+      PRECACHE_URLS.map((url) => cache.add(url).catch(() => {}))
+    );
+    await self.skipWaiting();
+  })());
 });
 
-// Report a completed network request metric to all controlled clients.
+self.addEventListener('activate', (event) => {
+  event.waitUntil((async () => {
+    const keys = await caches.keys();
+    await Promise.all(
+      keys
+        .filter((k) => k.startsWith('nexrad-workbench-') && k !== CACHE_NAME)
+        .map((k) => caches.delete(k))
+    );
+    await self.clients.claim();
+  })());
+});
+
+// Clone a response with COOP/COEP headers injected. 'credentialless' is used
+// for COEP instead of 'require-corp' so cross-origin resources (AWS S3, NOAA)
+// don't need to send Cross-Origin-Resource-Policy headers of their own.
+function withIsolationHeaders(response) {
+  const headers = new Headers(response.headers);
+  headers.set('Cross-Origin-Opener-Policy', 'same-origin');
+  headers.set('Cross-Origin-Embedder-Policy', 'credentialless');
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
 async function reportMetric(metric) {
   const clients = await self.clients.matchAll();
   for (const client of clients) {
@@ -29,44 +82,73 @@ async function reportMetric(metric) {
   }
 }
 
-// Intercept all fetch requests to:
-// 1. Add COOP/COEP headers for cross-origin isolation (enables SharedArrayBuffer)
-// 2. Measure and report request duration, status, and bytes transferred
-self.addEventListener('fetch', (event) => {
-  event.respondWith((async () => {
-    const url = event.request.url;
-    const startTime = performance.now();
+async function fetchAndReport(request) {
+  const url = request.url;
+  const startTime = performance.now();
+  try {
+    const response = await fetch(request);
+    const duration = performance.now() - startTime;
+    const contentLength = response.headers.get('Content-Length');
+    const bytes = contentLength ? parseInt(contentLength, 10) || 0 : 0;
+    reportMetric({ url, status: response.status, bytes, duration, ok: response.ok });
+    return response;
+  } catch (err) {
+    const duration = performance.now() - startTime;
+    reportMetric({ url, status: 0, bytes: 0, duration, ok: false, error: err.message });
+    throw err;
+  }
+}
 
+function isSameOrigin(request) {
+  try {
+    return new URL(request.url).origin === self.location.origin;
+  } catch {
+    return false;
+  }
+}
+
+async function handleFetch(request) {
+  // Navigation (HTML document) requests: network-first so users see new
+  // deploys immediately, falling back to the cached shell when offline.
+  if (request.mode === 'navigate') {
     try {
-      const response = await fetch(event.request);
-
-      // Measure response size: prefer Content-Length to avoid buffering
-      let bytes = 0;
-      const contentLength = response.headers.get('Content-Length');
-      if (contentLength) {
-        bytes = parseInt(contentLength, 10) || 0;
+      const response = await fetchAndReport(request);
+      if (response.ok && isSameOrigin(request)) {
+        const cache = await caches.open(CACHE_NAME);
+        cache.put(request, response.clone()).catch(() => {});
       }
-
-      // Build a new response with cross-origin isolation headers injected.
-      // Using 'credentialless' for COEP instead of 'require-corp' because it
-      // allows cross-origin resources (e.g. AWS S3) without requiring them to
-      // send Cross-Origin-Resource-Policy headers.
-      const headers = new Headers(response.headers);
-      headers.set('Cross-Origin-Opener-Policy', 'same-origin');
-      headers.set('Cross-Origin-Embedder-Policy', 'credentialless');
-
-      const duration = performance.now() - startTime;
-      reportMetric({ url, status: response.status, bytes, duration, ok: response.ok });
-
-      return new Response(response.body, {
-        status: response.status,
-        statusText: response.statusText,
-        headers,
-      });
+      return withIsolationHeaders(response);
     } catch (err) {
-      const duration = performance.now() - startTime;
-      reportMetric({ url, status: 0, bytes: 0, duration, ok: false, error: err.message });
+      const cached =
+        (await caches.match(request)) ||
+        (await caches.match('./index.html')) ||
+        (await caches.match('./'));
+      if (cached) return withIsolationHeaders(cached);
       throw err;
     }
-  })());
+  }
+
+  // Same-origin assets (WASM, JS, worker.js, icons, manifest): cache-first,
+  // runtime-cache on miss. Hashed filenames from Trunk make this safe — a
+  // new build produces new filenames, so the cache never serves stale code.
+  if (isSameOrigin(request) && request.method === 'GET') {
+    const cached = await caches.match(request);
+    if (cached) return withIsolationHeaders(cached);
+    const response = await fetchAndReport(request);
+    if (response.ok) {
+      const cache = await caches.open(CACHE_NAME);
+      cache.put(request, response.clone()).catch(() => {});
+    }
+    return withIsolationHeaders(response);
+  }
+
+  // Cross-origin (AWS S3 radar archives, NOAA): never cache — these are
+  // large and already stored in IndexedDB. Just pass through with headers
+  // and metrics.
+  const response = await fetchAndReport(request);
+  return withIsolationHeaders(response);
+}
+
+self.addEventListener('fetch', (event) => {
+  event.respondWith(handleFetch(event.request));
 });

--- a/src/ui/mobile/top_bar.rs
+++ b/src/ui/mobile/top_bar.rs
@@ -1,12 +1,12 @@
 //! Compact mobile top bar.
 //!
-//! Replaces the desktop top bar on mobile: drops the sidebar toggles, version
-//! stamp, help button, and view-mode switcher (all irrelevant on mobile), and
-//! trims to the essentials: mode accent, app mode badge, site chip, alerts,
-//! and worker error banner.
+//! Replaces the desktop top bar on mobile: drops the sidebar toggles, help
+//! button, and view-mode switcher (all irrelevant on mobile), and trims to
+//! the essentials: mode accent, app mode badge, site chip, alerts, worker
+//! error banner, and a small version stamp in the top-right.
 
 use crate::state::{AppMode, AppState};
-use eframe::egui::{self, Color32, Frame, RichText};
+use eframe::egui::{self, Align, Color32, Frame, Layout, RichText};
 
 pub(crate) fn render_mobile_top_bar(ctx: &egui::Context, state: &mut AppState) {
     // Same mode accent bar as desktop — the colored stripe doubles as the
@@ -67,6 +67,31 @@ pub(crate) fn render_mobile_top_bar(ctx: &egui::Context, state: &mut AppState) {
                         state.push_command(crate::state::AppCommand::RetryWorker);
                     }
                 }
+
+                // Version stamp — right-aligned. Useful for cross-referencing
+                // a deployed build against git history when reporting bugs.
+                ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                    const MAX_LEN: usize = 18;
+                    let version = env!("NEXRAD_VERSION");
+                    let display = if version.len() > MAX_LEN {
+                        let mut truncated = String::with_capacity(MAX_LEN + 3);
+                        for (i, ch) in version.char_indices() {
+                            if i >= MAX_LEN {
+                                break;
+                            }
+                            truncated.push(ch);
+                        }
+                        truncated.push('\u{2026}');
+                        truncated
+                    } else {
+                        version.to_string()
+                    };
+                    ui.label(
+                        RichText::new(display)
+                            .size(10.0)
+                            .color(Color32::from_rgb(120, 120, 120)),
+                    );
+                });
             });
         });
 }


### PR DESCRIPTION
Cache the app shell in the service worker so an installed PWA launches offline, and add the iOS-specific meta tags (apple-mobile-web-app-capable, status-bar-style, viewport-fit=cover) needed for Add to Home Screen to launch standalone without Safari chrome.