### PR TITLE
Remove chunk count label from realtime progress overlay

### DIFF
--- a/src/ui/timeline/overlays.rs
+++ b/src/ui/timeline/overlays.rs
@@ -554,18 +554,6 @@ pub(super) fn render_realtime_progress(
                 block,
                 DashedBorder::rect(Stroke::new(1.0, border_color), 4.0, 8.0, 3.0, 6.0),
             );
-
-            // Chunk count label (e.g., "2/6")
-            if width > 30.0 {
-                let label = format!("{}/{}", chunks_received, exp_n);
-                painter.text(
-                    block.center(),
-                    egui::Align2::CENTER_CENTER,
-                    label,
-                    egui::FontId::monospace(8.0),
-                    Color32::from_rgba_unmultiplied(140, 200, 255, 180),
-                );
-            }
         } else if is_future {
             // Check if this is the first future sweep (next to receive data)
             // and we're waiting for a chunk with no downloading sweep active.


### PR DESCRIPTION
## Summary
Removed the chunk count label (e.g., "2/6") that was displayed in the center of realtime progress blocks in the timeline overlay.

## Changes
- Deleted the conditional rendering logic that displayed the chunk count label when the progress block width exceeded 30.0 pixels
- Removed the associated text rendering call that positioned the label at the block center using monospace font

## Details
The chunk count label was a visual indicator showing the number of chunks received versus the expected total. This change simplifies the realtime progress visualization by removing this text overlay, likely to reduce visual clutter or as part of a UI redesign for the timeline overlay.

https://claude.ai/code/session_01YQfvmrao4SujHYUeWEpGgY