### PR TITLE
Parallelize the data pipeline for archive downloads

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -384,11 +384,14 @@ impl WorkbenchApp {
         let initial_prefs = state::UserPreferences::from_app_state(&state);
         let has_preferred_site = state.preferred_site.is_some();
 
-        // Create decode worker (offloads nexrad::load() to a Web Worker)
-        let decode_worker = match nexrad::DecodeWorker::new(cc.egui_ctx.clone()) {
-            Ok(w) => Some(w),
+        // Create decode worker pool (offloads heavy NEXRAD work to parallel
+        // Web Workers so the download → decompress → store pipeline can fan
+        // out across cores instead of serializing through a single worker).
+        let pool_size = nexrad::default_pool_size();
+        let decode_worker = match nexrad::WorkerPool::new(cc.egui_ctx.clone(), pool_size) {
+            Ok(pool) => Some(pool),
             Err(e) => {
-                log::warn!("Failed to create decode worker: {}", e);
+                log::warn!("Failed to create decode worker pool: {}", e);
                 state.worker_init_error =
                     Some(format!("Decode worker failed to initialize: {}", e));
                 None
@@ -484,76 +487,102 @@ impl WorkbenchApp {
     fn process_selection_download(&mut self, ctx: &egui::Context, download_type: Option<bool>) {
         let site_id = self.state.viz_state.site_id.clone();
 
-        // If we have items in the queue, try to advance the state machine
+        // If we have items in the queue, try to advance the state machine.
+        // The queue allows up to `max_parallel` concurrent downloads; we both
+        // reap completed slots and fill empty slots on every poll.
         if self.acquisition.download_queue.has_work() {
-            // If there is an Active item, check whether its download has finished
-            if let Some(active) = self.acquisition.download_queue.active_item() {
-                let still_pending = self
-                    .acquisition
-                    .download_channel
-                    .is_download_pending(&site_id, active.scan_start);
-
-                if still_pending {
-                    // Still downloading, wait
-                    return;
-                }
-
-                // Download finished — transition Active → Done
-                let active_start = active.scan_start;
-                self.acquisition
-                    .download_queue
-                    .mark_active_done(active_start);
+            // 1. Sweep all Active items and mark any whose download has finished.
+            let finished_starts: Vec<i64> = self
+                .acquisition
+                .download_queue
+                .active_items()
+                .filter_map(|item| {
+                    if !self
+                        .acquisition
+                        .download_channel
+                        .is_download_pending(&site_id, item.scan_start)
+                    {
+                        Some(item.scan_start)
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            for start in finished_starts {
+                self.acquisition.download_queue.mark_active_done(start);
             }
 
-            // Advance the queue (handles pause check internally)
+            // 2. Refresh the timeline-ghost list from the queue state.
+            self.state.download_progress.active_scans = self
+                .acquisition
+                .download_queue
+                .active_items()
+                .map(|item| (item.scan_start, item.scan_end))
+                .collect();
+
+            // 3. Fill as many concurrency slots as possible.
             let is_paused = self.state.acquisition.is_paused();
-            match self.acquisition.download_queue.advance(is_paused) {
-                QueueAction::StartDownload {
-                    idx: _,
-                    date,
-                    file_name,
-                    scan_start,
-                    scan_end,
-                    remaining,
-                } => {
-                    self.state.status_message =
-                        format!("Downloading {} ({} remaining)", file_name, remaining);
-                    self.state.download_progress.active_scan = Some((scan_start, scan_end));
-                    self.state.download_progress.phase = crate::state::DownloadPhase::Downloading;
-                    self.state.download_progress.batch_completed += 1;
-
-                    // Mark next acquisition operation as active
-                    if let Some(op_id) = self.state.acquisition.next_queued_id() {
-                        self.state.acquisition.mark_active(op_id);
-                        self.acquisition
-                            .download_queue
-                            .set_active_operation_id(Some(op_id));
-                    }
-
-                    self.acquisition.download_channel.download_file(
-                        ctx.clone(),
-                        site_id.clone(),
+            let mut completed_this_pump = false;
+            loop {
+                match self.acquisition.download_queue.advance(is_paused) {
+                    QueueAction::StartDownload {
+                        idx: _,
                         date,
                         file_name,
                         scan_start,
-                        self.acquisition.facade().clone(),
-                    );
-                }
-                QueueAction::Complete => {
-                    self.state.download_selection_in_progress = false;
-                    self.state.download_progress.pending_scans.clear();
-                    self.state.download_progress.active_scan = None;
-                    self.state.download_progress.phase = crate::state::DownloadPhase::Done;
-                    // Full clear only if no in-flight scans remain.
-                    if self.state.download_progress.in_flight_scans.is_empty() {
-                        self.state.download_progress.clear();
+                        scan_end,
+                        remaining,
+                    } => {
+                        self.state.status_message =
+                            format!("Downloading {} ({} remaining)", file_name, remaining);
+                        self.state.download_progress.phase =
+                            crate::state::DownloadPhase::Downloading;
+                        self.state.download_progress.batch_completed += 1;
+                        self.state
+                            .download_progress
+                            .active_scans
+                            .push((scan_start, scan_end));
+
+                        // Mark next acquisition operation as active and pin it
+                        // to this download's scan_start so correlation survives
+                        // concurrent completions.
+                        if let Some(op_id) = self.state.acquisition.next_queued_id() {
+                            self.state.acquisition.mark_active(op_id);
+                            self.acquisition
+                                .download_queue
+                                .set_operation_id(scan_start, op_id);
+                        }
+
+                        self.acquisition.download_channel.download_file(
+                            ctx.clone(),
+                            site_id.clone(),
+                            date,
+                            file_name,
+                            scan_start,
+                            self.acquisition.facade().clone(),
+                        );
                     }
-                    self.state.status_message = "Selection download complete".to_string();
-                    log::debug!("Selection download complete");
+                    QueueAction::Complete => {
+                        completed_this_pump = true;
+                        break;
+                    }
+                    QueueAction::Saturated | QueueAction::Paused => {
+                        break;
+                    }
                 }
-                QueueAction::Paused | QueueAction::StillDownloading => {
-                    return;
+            }
+
+            if completed_this_pump {
+                self.state.download_selection_in_progress = false;
+                self.state.download_progress.pending_scans.clear();
+                self.state.download_progress.active_scans.clear();
+                self.state.download_progress.phase = crate::state::DownloadPhase::Done;
+                // Full clear only if no in-flight scans remain.
+                if self.state.download_progress.in_flight_scans.is_empty() {
+                    self.state.download_progress.clear();
                 }
+                self.state.status_message = "Selection download complete".to_string();
+                log::debug!("Selection download complete");
             }
             return;
         }
@@ -783,33 +812,37 @@ impl WorkbenchApp {
             progress.batch_total = self.acquisition.download_queue.len() as u32;
             progress.batch_completed = 0;
             progress.phase = crate::state::DownloadPhase::Downloading;
-            let first = &self.acquisition.download_queue.items()[0];
-            progress.active_scan = Some((first.scan_start, first.scan_end));
+            progress.active_scans.clear();
         }
 
-        // Kick off first download
-        if let Some(QueueAction::StartDownload {
+        // Kick off as many downloads as the concurrency limit allows.
+        let is_paused = self.state.acquisition.is_paused();
+        while let QueueAction::StartDownload {
             idx: _,
             date,
             file_name,
             scan_start,
-            scan_end: _,
+            scan_end,
             remaining,
-        }) = self.acquisition.download_queue.start_first()
+        } = self.acquisition.download_queue.advance(is_paused)
         {
-            self.state.status_message = format!("Downloading {} ({} total)", file_name, remaining);
+            self.state.status_message =
+                format!("Downloading {} ({} remaining)", file_name, remaining);
+            self.state
+                .download_progress
+                .active_scans
+                .push((scan_start, scan_end));
 
-            // Mark the first acquisition operation as active
             if let Some(op_id) = self.state.acquisition.next_queued_id() {
                 self.state.acquisition.mark_active(op_id);
                 self.acquisition
                     .download_queue
-                    .set_active_operation_id(Some(op_id));
+                    .set_operation_id(scan_start, op_id);
             }
 
             self.acquisition.download_channel.download_file(
                 ctx.clone(),
-                site_id,
+                site_id.clone(),
                 date,
                 file_name,
                 scan_start,
@@ -2277,21 +2310,40 @@ impl WorkbenchApp {
 
         // Mark acquisition operation completed on success
         if let Some(scan) = scan_opt {
-            if let Some(op_id) = self.acquisition.download_queue.take_active_operation_id() {
+            let scan_ts = scan.key.scan_start.as_secs();
+            if let Some(op_id) = self.acquisition.download_queue.take_operation_id(scan_ts) {
                 self.state
                     .acquisition
                     .mark_completed(op_id, scan.data.len() as u64);
             }
         }
 
-        if let nexrad::DownloadResult::Error(msg) = &result {
-            self.state.status_message = format!("Download failed: {}", msg);
-            log::error!("Download failed: {}", msg);
+        if let nexrad::DownloadResult::Error {
+            message,
+            scan_start,
+        } = &result
+        {
+            self.state.status_message = format!("Download failed: {}", message);
+            log::error!("Download failed: {}", message);
 
-            // Mark acquisition operation as failed and error-pause
-            if let Some(op_id) = self.acquisition.download_queue.take_active_operation_id() {
-                self.state.acquisition.mark_failed(op_id, msg.clone());
+            // Mark this scan's acquisition operation as failed
+            if let Some(op_id) = self
+                .acquisition
+                .download_queue
+                .take_operation_id(*scan_start)
+            {
+                self.state.acquisition.mark_failed(op_id, message.clone());
             }
+
+            // Transition the failed queue item out of Active so the concurrency
+            // slot frees up for the next pump.
+            self.acquisition
+                .download_queue
+                .mark_active_done(*scan_start);
+            self.state
+                .download_progress
+                .active_scans
+                .retain(|&(s, _)| s != *scan_start);
 
             // Clear download progress on error if no more work remains
             if !self.acquisition.download_queue.has_work() {

--- a/src/nexrad/decode_worker/mod.rs
+++ b/src/nexrad/decode_worker/mod.rs
@@ -4,10 +4,12 @@
 //! thread into a dedicated Web Worker. Communication uses `postMessage` with
 //! Transferable ArrayBuffers for zero-copy data transfer.
 
+mod pool;
 mod receive;
 mod send;
 mod types;
 
+pub use pool::{default_pool_size, WorkerPool};
 pub use types::{
     ChunkIngestContext, ChunkIngestResult, DecodeResult, IngestContext, IngestResult,
     RenderContext, VolumeData, VolumeRenderContext, VolumeSweepMeta, WorkerOutcome,

--- a/src/nexrad/decode_worker/pool.rs
+++ b/src/nexrad/decode_worker/pool.rs
@@ -1,0 +1,153 @@
+//! Pool of decode workers for parallel ingest and render.
+//!
+//! Dispatch strategy:
+//! - `ingest` (archive) — round-robin across all workers so concurrent downloads
+//!   don't serialize on a single bzip2/decode pipeline.
+//! - `render`, `render_volume` — round-robin; render requests just read from
+//!   IDB and every worker has its own connection.
+//! - `ingest_chunk` and `render_live` — pinned to worker 0 because the live
+//!   accumulator (`CHUNK_ACCUM`) is a per-worker thread-local.
+//!
+//! Each worker in the pool owns its own JS `Worker` handle and its own
+//! `pending_*` maps, so message correlation remains per-worker. `try_recv`
+//! drains outcomes from every worker into a single vector.
+
+use super::DecodeWorker;
+use super::WorkerOutcome;
+use eframe::egui;
+
+/// Index of the worker that exclusively handles live chunk ingest and
+/// partial-sweep render_live requests (these rely on a thread-local
+/// accumulator, so they must stay pinned to one worker).
+const LIVE_WORKER_INDEX: usize = 0;
+
+/// Pool of [`DecodeWorker`]s that parallelizes archive ingest and render.
+pub struct WorkerPool {
+    workers: Vec<DecodeWorker>,
+    next_ingest: usize,
+    next_render: usize,
+}
+
+impl WorkerPool {
+    /// Create a pool of `count` workers. `count` is clamped to at least 1.
+    ///
+    /// Returns an error if **any** worker fails to spawn — the caller then
+    /// treats the pool as unavailable and surfaces a retry affordance, just
+    /// as it did for a single worker.
+    pub fn new(ctx: egui::Context, count: usize) -> Result<Self, String> {
+        let count = count.max(1);
+        let mut workers = Vec::with_capacity(count);
+        for _ in 0..count {
+            workers.push(DecodeWorker::new(ctx.clone())?);
+        }
+        log::debug!("WorkerPool spawned with {} worker(s)", workers.len());
+        Ok(Self {
+            workers,
+            next_ingest: 0,
+            next_render: 0,
+        })
+    }
+
+    /// Number of workers in the pool.
+    #[allow(dead_code)]
+    pub fn size(&self) -> usize {
+        self.workers.len()
+    }
+
+    fn next_ingest_index(&mut self) -> usize {
+        let idx = self.next_ingest % self.workers.len();
+        self.next_ingest = self.next_ingest.wrapping_add(1);
+        idx
+    }
+
+    fn next_render_index(&mut self) -> usize {
+        let idx = self.next_render % self.workers.len();
+        self.next_render = self.next_render.wrapping_add(1);
+        idx
+    }
+
+    /// Submit an archive ingest (full file) — round-robined across workers.
+    pub fn ingest(
+        &mut self,
+        data: Vec<u8>,
+        site_id: String,
+        timestamp_secs: i64,
+        file_name: String,
+        fetch_latency_ms: f64,
+    ) {
+        let idx = self.next_ingest_index();
+        self.workers[idx].ingest(data, site_id, timestamp_secs, file_name, fetch_latency_ms);
+    }
+
+    /// Submit a per-chunk ingest — pinned to the live-worker slot so the
+    /// accumulator thread-local stays consistent across chunks of the same
+    /// volume.
+    #[allow(clippy::too_many_arguments)]
+    pub fn ingest_chunk(
+        &mut self,
+        data: Vec<u8>,
+        site_id: String,
+        timestamp_secs: i64,
+        chunk_index: u32,
+        is_start: bool,
+        is_end: bool,
+        file_name: String,
+        skip_overlap_delete: bool,
+        is_last_in_sweep: bool,
+    ) {
+        self.workers[LIVE_WORKER_INDEX].ingest_chunk(
+            data,
+            site_id,
+            timestamp_secs,
+            chunk_index,
+            is_start,
+            is_end,
+            file_name,
+            skip_overlap_delete,
+            is_last_in_sweep,
+        );
+    }
+
+    /// Submit an archive render — round-robined across workers.
+    pub fn render(&mut self, scan_key: String, elevation_number: u8, product: String) {
+        let idx = self.next_render_index();
+        self.workers[idx].render(scan_key, elevation_number, product);
+    }
+
+    /// Submit a live (partial) render — pinned to the live worker because it
+    /// reads the in-memory accumulator populated by `ingest_chunk`.
+    pub fn render_live(&mut self, elevation_number: u8, product: String) {
+        self.workers[LIVE_WORKER_INDEX].render_live(elevation_number, product);
+    }
+
+    /// Submit a volume render — round-robined across workers.
+    pub fn render_volume(&mut self, scan_key: String, product: String, elevation_numbers: Vec<u8>) {
+        let idx = self.next_render_index();
+        self.workers[idx].render_volume(scan_key, product, elevation_numbers);
+    }
+
+    /// Drain pending outcomes from every worker.
+    pub fn try_recv(&mut self) -> Vec<WorkerOutcome> {
+        let mut out = Vec::new();
+        for worker in &mut self.workers {
+            out.extend(worker.try_recv());
+        }
+        out
+    }
+}
+
+/// Determine a sensible worker pool size from `navigator.hardwareConcurrency`.
+///
+/// We reserve one core for the UI thread and cap the pool at 4 workers to
+/// avoid the diminishing returns of over-subscription on laptops. Fallback is
+/// 2 workers when the browser doesn't expose hardware concurrency.
+pub fn default_pool_size() -> usize {
+    let hw = web_sys::window()
+        .map(|w| w.navigator().hardware_concurrency() as usize)
+        .unwrap_or(0);
+
+    if hw == 0 {
+        return 2;
+    }
+    hw.saturating_sub(1).clamp(1, 4)
+}

--- a/src/nexrad/download.rs
+++ b/src/nexrad/download.rs
@@ -357,11 +357,17 @@ async fn download_specific_file(
         }
         Ok(Err(e)) => {
             stats.request_completed(0);
-            return DownloadResult::Error(format!("Failed to list files: {}", e));
+            return DownloadResult::Error {
+                message: format!("Failed to list files: {}", e),
+                scan_start: timestamp,
+            };
         }
         Err(timeout_msg) => {
             stats.request_completed(0);
-            return DownloadResult::Error(timeout_msg);
+            return DownloadResult::Error {
+                message: timeout_msg,
+                scan_start: timestamp,
+            };
         }
     };
 
@@ -369,7 +375,10 @@ async fn download_specific_file(
     let file_meta = match files.iter().find(|f| f.name() == file_name) {
         Some(f) => f.clone(),
         None => {
-            return DownloadResult::Error(format!("File not found: {}", file_name));
+            return DownloadResult::Error {
+                message: format!("File not found: {}", file_name),
+                scan_start: timestamp,
+            };
         }
     };
 
@@ -386,11 +395,17 @@ async fn download_specific_file(
         Ok(Ok(file)) => file,
         Ok(Err(e)) => {
             stats.request_completed(0);
-            return DownloadResult::Error(format!("Download failed: {}", e));
+            return DownloadResult::Error {
+                message: format!("Download failed: {}", e),
+                scan_start: timestamp,
+            };
         }
         Err(timeout_msg) => {
             stats.request_completed(0);
-            return DownloadResult::Error(timeout_msg);
+            return DownloadResult::Error {
+                message: timeout_msg,
+                scan_start: timestamp,
+            };
         }
     };
     let fetch_ms = fetch_start.elapsed().as_secs_f64() * 1000.0;

--- a/src/nexrad/download_queue.rs
+++ b/src/nexrad/download_queue.rs
@@ -1,9 +1,13 @@
-//! Download queue manager for serial archive downloads.
+//! Download queue manager for archive downloads.
 //!
 //! Encapsulates the queue of files to download and the state machine for
 //! advancing through them. The manager does NOT perform downloads or access
 //! network channels — it returns [`QueueAction`] values telling the caller
 //! what to do next.
+//!
+//! Downloads may run in parallel up to a configurable concurrency limit
+//! (see [`DEFAULT_MAX_PARALLEL`]); callers advance the queue until either
+//! all pending work is drained or the concurrency ceiling is reached.
 
 /// State of a single item in the download queue.
 #[derive(Clone, Debug)]
@@ -55,27 +59,40 @@ pub(crate) enum QueueAction {
     },
     /// All items are done/failed — queue is drained.
     Complete,
-    /// The active download is still in progress — do nothing.
-    StillDownloading,
+    /// The concurrency ceiling is reached — caller should poll again once
+    /// one or more active downloads complete.
+    Saturated,
     /// Queue is paused — do nothing.
     Paused,
 }
 
+/// Default maximum number of concurrent downloads.
+///
+/// Keeping a small cap here avoids overwhelming the browser's per-origin
+/// connection limit (commonly 6) while still pipelining enough requests to
+/// saturate a residential uplink.
+pub(crate) const DEFAULT_MAX_PARALLEL: usize = 4;
+
 /// Manages the download queue state machine.
 ///
-/// This struct owns the queue of [`QueueItem`]s and the active operation ID.
-/// It does **not** hold references to download channels or data facades —
-/// the caller acts on the returned [`QueueAction`].
+/// This struct owns the queue of [`QueueItem`]s and the per-item operation
+/// IDs. It does **not** hold references to download channels or data facades
+/// — the caller acts on the returned [`QueueAction`] values.
 pub(crate) struct DownloadQueueManager {
     queue: Vec<QueueItem>,
-    active_operation_id: Option<crate::state::OperationId>,
+    /// Maps an Active item's `scan_start` to the acquisition operation ID
+    /// that represents it. Keeps correlation correct when multiple downloads
+    /// are in flight simultaneously.
+    active_operation_ids: std::collections::HashMap<i64, crate::state::OperationId>,
+    max_parallel: usize,
 }
 
 impl DownloadQueueManager {
     pub fn new() -> Self {
         Self {
             queue: Vec::new(),
-            active_operation_id: None,
+            active_operation_ids: std::collections::HashMap::new(),
+            max_parallel: DEFAULT_MAX_PARALLEL,
         }
     }
 
@@ -86,9 +103,10 @@ impl DownloadQueueManager {
             .any(|item| matches!(item.state, QueueItemState::Pending | QueueItemState::Active))
     }
 
-    /// Mark the currently active item as done (download completed).
+    /// Mark an active item as done (its download completed successfully).
     ///
-    /// Finds the active item whose `scan_start` matches and transitions it to `Done`.
+    /// Idempotent: if the item is already Done or no longer Active, this is
+    /// a no-op.
     pub fn mark_active_done(&mut self, scan_start: i64) {
         if let Some(item) = self.queue.iter_mut().find(|item| {
             matches!(item.state, QueueItemState::Active) && item.scan_start == scan_start
@@ -97,20 +115,30 @@ impl DownloadQueueManager {
         }
     }
 
-    /// Find the currently active item (if any).
-    pub fn active_item(&self) -> Option<&QueueItem> {
+    /// Number of items currently in the Active state.
+    pub fn active_count(&self) -> usize {
         self.queue
             .iter()
-            .find(|item| matches!(item.state, QueueItemState::Active))
+            .filter(|item| matches!(item.state, QueueItemState::Active))
+            .count()
     }
 
-    /// Advance the queue: find next pending item and return an action.
-    ///
-    /// Call this after `mark_active_done` to start the next download.
-    /// `is_paused` should reflect whether the acquisition system is paused.
+    /// All currently active items (for concurrency polling).
+    pub fn active_items(&self) -> impl Iterator<Item = &QueueItem> {
+        self.queue
+            .iter()
+            .filter(|item| matches!(item.state, QueueItemState::Active))
+    }
+
+    /// Advance the queue: start the next pending item if a concurrency slot
+    /// is available and the queue is not paused.
     pub fn advance(&mut self, is_paused: bool) -> QueueAction {
         if is_paused {
             return QueueAction::Paused;
+        }
+
+        if self.active_count() >= self.max_parallel {
+            return QueueAction::Saturated;
         }
 
         let next_pending = self
@@ -135,46 +163,30 @@ impl DownloadQueueManager {
             };
             self.queue[idx].state = QueueItemState::Active;
             action
-        } else {
-            // All items are Done/Failed — queue drained
+        } else if self.active_count() == 0 {
+            // All items are Done/Failed and nothing is in flight — queue drained.
             self.queue.clear();
             QueueAction::Complete
+        } else {
+            // Nothing pending, but downloads still in flight. Caller should
+            // poll again after they complete.
+            QueueAction::Saturated
         }
     }
 
     /// Replace the queue with a new set of items.
     ///
-    /// Clears the active operation ID and sets the new queue.
-    /// The first item is **not** automatically started — call `advance()` or
-    /// `start_first()` after this.
+    /// Clears all active operation IDs and sets the new queue.
+    /// Items are **not** automatically started — call `advance()` in a loop
+    /// to saturate the concurrency limit.
     pub fn set_queue(&mut self, items: Vec<QueueItem>) {
-        self.active_operation_id = None;
+        self.active_operation_ids.clear();
         self.queue = items;
     }
 
-    /// Start the first item in the queue, returning the action.
-    ///
-    /// This is a convenience for the initial download kick-off after `set_queue`.
-    pub fn start_first(&mut self) -> Option<QueueAction> {
-        if self.queue.is_empty() {
-            return None;
-        }
-        let item = &self.queue[0];
-        let action = QueueAction::StartDownload {
-            idx: 0,
-            date: item.date,
-            file_name: item.file_name.clone(),
-            scan_start: item.scan_start,
-            scan_end: item.scan_end,
-            remaining: self.queue.len(),
-        };
-        self.queue[0].state = QueueItemState::Active;
-        Some(action)
-    }
-
-    /// Get progress info: `(completed_count, total_count, pending_scans, active_scan)`.
+    /// Get progress info: `(completed_count, total_count, pending_scans, active_scans)`.
     #[allow(clippy::type_complexity, dead_code)]
-    pub fn progress(&self) -> (u32, u32, Vec<(i64, i64)>, Option<(i64, i64)>) {
+    pub fn progress(&self) -> (u32, u32, Vec<(i64, i64)>, Vec<(i64, i64)>) {
         let total = self.queue.len() as u32;
         let completed = self
             .queue
@@ -186,10 +198,11 @@ impl DownloadQueueManager {
             .iter()
             .map(|item| (item.scan_start, item.scan_end))
             .collect();
-        let active_scan = self
-            .active_item()
-            .map(|item| (item.scan_start, item.scan_end));
-        (completed, total, pending_scans, active_scan)
+        let active_scans: Vec<(i64, i64)> = self
+            .active_items()
+            .map(|item| (item.scan_start, item.scan_end))
+            .collect();
+        (completed, total, pending_scans, active_scans)
     }
 
     /// Get current queue length.
@@ -202,26 +215,26 @@ impl DownloadQueueManager {
         &self.queue
     }
 
-    /// Clear the queue and reset the active operation ID.
+    /// Clear the queue and all tracked operation IDs.
     pub fn clear(&mut self) {
         self.queue.clear();
-        self.active_operation_id = None;
+        self.active_operation_ids.clear();
     }
 
-    /// Get the active download operation ID.
+    /// Get the operation ID for the active download with the given scan_start.
     #[allow(dead_code)]
-    pub fn active_operation_id(&self) -> Option<crate::state::OperationId> {
-        self.active_operation_id
+    pub fn operation_id(&self, scan_start: i64) -> Option<crate::state::OperationId> {
+        self.active_operation_ids.get(&scan_start).copied()
     }
 
-    /// Set the active download operation ID.
-    pub fn set_active_operation_id(&mut self, id: Option<crate::state::OperationId>) {
-        self.active_operation_id = id;
+    /// Associate an acquisition operation ID with an active download.
+    pub fn set_operation_id(&mut self, scan_start: i64, id: crate::state::OperationId) {
+        self.active_operation_ids.insert(scan_start, id);
     }
 
-    /// Take the active operation ID, leaving `None` in its place.
-    pub fn take_active_operation_id(&mut self) -> Option<crate::state::OperationId> {
-        self.active_operation_id.take()
+    /// Take (remove) the operation ID for the given scan_start.
+    pub fn take_operation_id(&mut self, scan_start: i64) -> Option<crate::state::OperationId> {
+        self.active_operation_ids.remove(&scan_start)
     }
 
     /// Find an item by scan_start timestamp.

--- a/src/nexrad/mod.rs
+++ b/src/nexrad/mod.rs
@@ -37,8 +37,8 @@ pub use acquisition_coordinator::AcquisitionCoordinator;
 pub use archive_index::ScanBoundary;
 pub use cache_channel::CacheLoadResult;
 pub use decode_worker::{
-    ChunkIngestResult, DecodeResult, DecodeWorker, IngestResult, VolumeData, VolumeSweepMeta,
-    WorkerOutcome,
+    default_pool_size, ChunkIngestResult, DecodeResult, IngestResult, VolumeData, VolumeSweepMeta,
+    WorkerOutcome, WorkerPool,
 };
 pub use download::{ListingResult, NetworkStats};
 pub use globe_radar_renderer::GlobeRadarRenderer;

--- a/src/nexrad/render_coordinator.rs
+++ b/src/nexrad/render_coordinator.rs
@@ -1,16 +1,20 @@
-//! Render coordinator: owns the decode worker and render request deduplication.
+//! Render coordinator: owns the decode worker pool and render request deduplication.
 //!
 //! Consolidates the five tightly-coupled fields that were scattered between
 //! WorkbenchApp and Renderers into a single owner.
 
-use super::decode_worker::{DecodeWorker, WorkerOutcome};
+use super::decode_worker::{default_pool_size, WorkerOutcome, WorkerPool};
 use super::render_request::{RenderRequest, VolumeRenderRequest};
 
-/// Coordinates render requests to the decode worker, deduplicating
+/// Coordinates render requests to a pool of decode workers, deduplicating
 /// identical requests and owning the current scan/elevation state.
+///
+/// The pool is chosen to saturate the ingest pipeline with parallel
+/// decompress/decode work while keeping the UI thread responsive — see
+/// [`default_pool_size`] for the sizing heuristic.
 pub struct RenderCoordinator {
-    /// Web Worker for offloading expensive NEXRAD operations.
-    worker: Option<DecodeWorker>,
+    /// Pool of Web Workers for offloading expensive NEXRAD operations.
+    worker: Option<WorkerPool>,
     /// Scan key of the currently displayed scan ("SITE|TIMESTAMP_MS").
     current_scan_key: Option<String>,
     /// Available elevation numbers for the current scan (from ingest).
@@ -22,7 +26,7 @@ pub struct RenderCoordinator {
 }
 
 impl RenderCoordinator {
-    pub fn new(worker: Option<DecodeWorker>) -> Self {
+    pub fn new(worker: Option<WorkerPool>) -> Self {
         Self {
             worker,
             current_scan_key: None,
@@ -247,15 +251,15 @@ impl RenderCoordinator {
         }
     }
 
-    /// Try to create a new decode worker (retry after failure).
+    /// Try to create a new decode worker pool (retry after failure).
     pub fn create_worker(&mut self, ctx: eframe::egui::Context) -> Result<(), String> {
-        match DecodeWorker::new(ctx) {
-            Ok(w) => {
-                self.worker = Some(w);
+        match WorkerPool::new(ctx, default_pool_size()) {
+            Ok(pool) => {
+                self.worker = Some(pool);
                 Ok(())
             }
             Err(e) => {
-                log::warn!("Failed to create decode worker: {}", e);
+                log::warn!("Failed to create decode worker pool: {}", e);
                 Err(format!("Decode worker failed to initialize: {}", e))
             }
         }

--- a/src/nexrad/types.rs
+++ b/src/nexrad/types.rs
@@ -85,8 +85,12 @@ pub enum DownloadResult {
         fetch_latency_ms: f64,
         decode_latency_ms: f64,
     },
-    /// Download failed with an error message
-    Error(String),
+    /// Download failed.
+    ///
+    /// `scan_start` is the timestamp (Unix seconds) of the scan the failed
+    /// download was attempting. With parallel downloads this is essential to
+    /// correlate the failure with the right queue entry.
+    Error { message: String, scan_start: i64 },
     /// Found in cache, no download needed
     CacheHit(CachedScan),
 }

--- a/src/state/stats.rs
+++ b/src/state/stats.rs
@@ -242,9 +242,10 @@ pub struct DownloadProgress {
     /// Scan boundaries (start, end) of files queued but not yet loaded.
     /// The timeline renders ghost markers spanning these intervals.
     pub pending_scans: Vec<(i64, i64)>,
-    /// Boundary of the file currently being downloaded/processed.
-    /// Its ghost marker pulses to distinguish it from queued items.
-    pub active_scan: Option<(i64, i64)>,
+    /// Boundaries of files currently being downloaded.
+    /// Their ghost markers pulse to distinguish them from queued items.
+    /// Multiple entries when parallel downloads are in flight.
+    pub active_scans: Vec<(i64, i64)>,
     /// Phase of the currently active file.
     pub phase: DownloadPhase,
     /// Batch total file count.

--- a/src/ui/timeline/overlays.rs
+++ b/src/ui/timeline/overlays.rs
@@ -172,8 +172,8 @@ pub(super) fn render_download_ghosts(
         draw_ghost(s, e, false, false);
     }
 
-    // Draw active scan
-    if let Some((s, e)) = progress.active_scan {
+    // Draw active scans
+    for &(s, e) in &progress.active_scans {
         draw_ghost(s, e, true, false);
     }
 


### PR DESCRIPTION
Batch downloads used to serialize twice: the queue permitted only one
active download at a time, and a single decode worker processed every
ingest end-to-end. Now downloads fan out up to DEFAULT_MAX_PARALLEL
concurrent slots and ingests round-robin across a pool of workers, so
download, decompress, and store stages overlap between scans instead of
running in lock-step.

- DownloadQueueManager tracks per-scan operation IDs and saturates the
  concurrency ceiling each frame instead of gating on a single active
  item.
- WorkerPool wraps multiple DecodeWorker instances. Archive ingest,
  render, and render_volume requests round-robin; ingest_chunk and
  render_live stay pinned to one worker so the live accumulator stays
  consistent. Pool size defaults to hardwareConcurrency-1 clamped to
  [1, 4].
- DownloadResult::Error now carries scan_start so a failed download in
  a parallel fleet can clean up the right queue entry and free its
  concurrency slot for the next pump.
- DownloadProgress.active_scan became active_scans so the timeline can
  render a pulsing ghost per in-flight download.

https://claude.ai/code/session_015JDcEp76Ju5e5wT4XJQguM