### PR TITLE
Add VCP forecast diagnostics modal for sweep prediction analysis

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1037,6 +1037,7 @@ impl WorkbenchApp {
                 fetch_latency_ms,
                 projected_volume_end_secs,
                 chunk_projections,
+                arrival_stat,
             } => {
                 self.state
                     .session_stats
@@ -1057,6 +1058,10 @@ impl WorkbenchApp {
                     projected_volume_end_secs,
                     chunk_projections,
                 );
+
+                if let Some(stat) = arrival_stat {
+                    self.state.live_mode_state.record_chunk_arrival(stat);
+                }
 
                 // Record chunk latency for the acquisition drawer
                 self.state.acquisition.record_chunk_latency(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1626,6 +1626,11 @@ impl WorkbenchApp {
             // header (the first radial of the volume scan).
             if let Some(header_time) = result.volume_header_time_secs {
                 self.state.live_mode_state.current_volume_start = Some(header_time);
+                // Retry the forecast snapshot in case the VCP pattern was
+                // already recorded before the volume-start timestamp arrived.
+                // `record_vcp` below also calls this, so the usual flow picks
+                // up regardless of which side arrives first.
+                self.state.live_mode_state.try_capture_forecast();
             }
             if !result.elevations_completed.is_empty() {
                 let vol_start_ts = self
@@ -2990,6 +2995,7 @@ impl eframe::App for WorkbenchApp {
         ui::render_shortcuts_help(ctx, &mut self.state);
         ui::render_wipe_modal(ctx, &mut self.state);
         ui::render_stats_modal(ctx, &mut self.state);
+        ui::render_vcp_forecast_modal(ctx, &mut self.state);
         ui::render_network_log(ctx, &mut self.state);
         ui::render_event_modal(ctx, &mut self.state, &mut self.event_modal_state);
         ui::render_alerts_modals(ctx, &mut self.state);

--- a/src/nexrad/realtime.rs
+++ b/src/nexrad/realtime.rs
@@ -504,6 +504,7 @@ async fn streaming_loop(
     let mut none_retries: u32 = 0;
     let mut cur_predicted_at: Option<f64> = None; // absolute Unix seconds
     let mut cur_scheduled_at: Option<f64> = None; // first poll time
+    let mut cur_first_empty_at: Option<f64> = None;
     let mut cur_last_empty_at: Option<f64> = None;
     loop {
         // Check stop signal
@@ -567,12 +568,33 @@ async fn streaming_loop(
                     .identifier
                     .upload_date_time()
                     .map(|dt| dt.timestamp_millis() as f64 / 1000.0);
+
+                // Look up this chunk's entry in the library's projection list
+                // so we can attach elevation_number and chunk-within-sweep
+                // position to the arrival stat.
+                let chunk_projections = build_chunk_projections(&iter);
+                let (elevation_number, chunk_index_in_sweep, chunks_in_sweep) =
+                    match chunk_projections.as_ref().and_then(|projs| {
+                        projs.iter().find(|p| p.sequence as u32 == chunks_in_volume)
+                    }) {
+                        Some(p) => (
+                            p.elevation_number.map(|e| e as u8),
+                            Some(p.chunk_index_in_sweep as u32),
+                            Some(p.chunks_in_sweep as u32),
+                        ),
+                        None => (None, None, None),
+                    };
+
                 let arrival_stat = crate::state::ChunkArrivalStat {
                     sequence: chunks_in_volume,
                     chunk_type: type_label,
+                    elevation_number,
+                    chunk_index_in_sweep,
+                    chunks_in_sweep,
                     predicted_available_at: cur_predicted_at,
                     scheduled_at: cur_scheduled_at.unwrap_or(success_at),
                     empty_polls: none_retries,
+                    first_empty_poll_at: cur_first_empty_at,
                     last_empty_poll_at: cur_last_empty_at,
                     s3_last_modified_at,
                     success_at,
@@ -583,6 +605,7 @@ async fn streaming_loop(
                 none_retries = 0;
                 cur_predicted_at = None;
                 cur_scheduled_at = None;
+                cur_first_empty_at = None;
                 cur_last_empty_at = None;
 
                 let time_until_next = iter.time_until_next().and_then(|td| td.to_std().ok());
@@ -605,7 +628,7 @@ async fn streaming_loop(
                         is_volume_end: is_end,
                         fetch_latency_ms: chunk_fetch_ms,
                         projected_volume_end_secs: get_projected_volume_end_secs(&iter),
-                        chunk_projections: build_chunk_projections(&iter),
+                        chunk_projections,
                         arrival_stat: Some(arrival_stat),
                     });
                 }
@@ -615,7 +638,11 @@ async fn streaming_loop(
             Ok(None) => {
                 // Chunk not ready yet, brief retry
                 none_retries += 1;
-                cur_last_empty_at = Some(current_timestamp_f64());
+                let now = current_timestamp_f64();
+                if cur_first_empty_at.is_none() {
+                    cur_first_empty_at = Some(now);
+                }
+                cur_last_empty_at = Some(now);
                 if none_retries >= CHUNK_POLL_MAX_RETRIES {
                     let elapsed_secs =
                         (none_retries * CHUNK_POLL_INTERVAL_MS + CHUNK_POLL_GRACE_MS) / 1000;
@@ -637,6 +664,7 @@ async fn streaming_loop(
                             none_retries = 0;
                             cur_predicted_at = None;
                             cur_scheduled_at = None;
+                            cur_first_empty_at = None;
                             cur_last_empty_at = None;
                             continue;
                         }

--- a/src/nexrad/realtime.rs
+++ b/src/nexrad/realtime.rs
@@ -61,6 +61,9 @@ pub enum RealtimeResult {
         /// Per-chunk projection info for the entire volume.
         /// Structural metadata is present for all chunks; projected times only for future chunks.
         chunk_projections: Option<Vec<ChunkProjectionInfo>>,
+        /// Arrival diagnostics (empty-poll counts, predicted vs. actual time).
+        /// `None` on synthetic emissions such as the resume-from-cache path.
+        arrival_stat: Option<crate::state::ChunkArrivalStat>,
     },
     /// Raw chunk data for incremental ingest
     ChunkData {
@@ -454,6 +457,7 @@ async fn streaming_loop(
                 fetch_latency_ms: 0.0,
                 projected_volume_end_secs: get_projected_volume_end_secs(&iter),
                 chunk_projections: build_chunk_projections(&iter),
+                arrival_stat: None,
             });
         }
         ctx.request_repaint();
@@ -488,13 +492,19 @@ async fn streaming_loop(
                 fetch_latency_ms: 0.0,
                 projected_volume_end_secs: get_projected_volume_end_secs(&iter),
                 chunk_projections: build_chunk_projections(&iter),
+                arrival_stat: None,
             });
         }
         ctx.request_repaint();
     }
 
     // --- Main streaming loop: emit ChunkData per chunk ---
+    // Per-chunk arrival tracking: captured on the first iteration for each
+    // chunk and reset on success (or on final-retry recovery).
     let mut none_retries: u32 = 0;
+    let mut cur_predicted_at: Option<f64> = None; // absolute Unix seconds
+    let mut cur_scheduled_at: Option<f64> = None; // first poll time
+    let mut cur_last_empty_at: Option<f64> = None;
     loop {
         // Check stop signal
         if state.borrow().stop_requested {
@@ -502,8 +512,17 @@ async fn streaming_loop(
             break;
         }
 
-        // Wait for expected chunk time
-        if let Some(wait_duration) = iter.time_until_next().and_then(|d| d.to_std().ok()) {
+        // Wait for expected chunk time. Only capture the prediction on the
+        // first iteration for a given chunk — subsequent retry iterations
+        // re-enter here with a near-zero wait, which would overwrite the
+        // original estimate.
+        let time_until_next_opt = iter.time_until_next().and_then(|d| d.to_std().ok());
+        if cur_predicted_at.is_none() {
+            if let Some(d) = time_until_next_opt {
+                cur_predicted_at = Some(current_timestamp_f64() + d.as_secs_f64());
+            }
+        }
+        if let Some(wait_duration) = time_until_next_opt {
             let wait_ms = wait_duration.as_millis() as u32;
             if wait_ms > 0 && !interruptible_sleep(&state, &ctx, wait_ms).await {
                 log::debug!("Realtime streaming stopped");
@@ -511,12 +530,16 @@ async fn streaming_loop(
             }
         }
 
+        if cur_scheduled_at.is_none() {
+            cur_scheduled_at = Some(current_timestamp_f64());
+        }
+
         // Fetch next chunk (with timing)
         let chunk_fetch_start = web_time::Instant::now();
         match iter.try_next().await {
             Ok(Some(chunk)) => {
-                none_retries = 0;
                 let chunk_fetch_ms = chunk_fetch_start.elapsed().as_secs_f64() * 1000.0;
+                let success_at = current_timestamp_f64();
                 stats_tracker.update(&stats, &iter);
 
                 let chunk_data = chunk.chunk.data().to_vec();
@@ -532,6 +555,30 @@ async fn streaming_loop(
                 }
 
                 chunks_in_volume += 1;
+
+                let type_label: &'static str = if is_start {
+                    "Start"
+                } else if is_end {
+                    "End"
+                } else {
+                    "Intermediate"
+                };
+                let arrival_stat = crate::state::ChunkArrivalStat {
+                    sequence: chunks_in_volume,
+                    chunk_type: type_label,
+                    predicted_available_at: cur_predicted_at,
+                    scheduled_at: cur_scheduled_at.unwrap_or(success_at),
+                    empty_polls: none_retries,
+                    last_empty_poll_at: cur_last_empty_at,
+                    success_at,
+                    fetch_latency_ms: chunk_fetch_ms,
+                };
+
+                // Reset tracking state for the next chunk
+                none_retries = 0;
+                cur_predicted_at = None;
+                cur_scheduled_at = None;
+                cur_last_empty_at = None;
 
                 let time_until_next = iter.time_until_next().and_then(|td| td.to_std().ok());
 
@@ -554,6 +601,7 @@ async fn streaming_loop(
                         fetch_latency_ms: chunk_fetch_ms,
                         projected_volume_end_secs: get_projected_volume_end_secs(&iter),
                         chunk_projections: build_chunk_projections(&iter),
+                        arrival_stat: Some(arrival_stat),
                     });
                 }
 
@@ -562,6 +610,7 @@ async fn streaming_loop(
             Ok(None) => {
                 // Chunk not ready yet, brief retry
                 none_retries += 1;
+                cur_last_empty_at = Some(current_timestamp_f64());
                 if none_retries >= CHUNK_POLL_MAX_RETRIES {
                     let elapsed_secs =
                         (none_retries * CHUNK_POLL_INTERVAL_MS + CHUNK_POLL_GRACE_MS) / 1000;
@@ -576,8 +625,14 @@ async fn streaming_loop(
                     }
                     match iter.try_next().await {
                         Ok(Some(_chunk)) => {
-                            // Recovered — let the next loop iteration handle it normally
+                            // Recovered — let the next loop iteration handle it normally.
+                            // Reset the per-chunk tracking so the next successful fetch
+                            // emits a fresh ChunkArrivalStat (the discarded chunk here
+                            // is an existing quirk of the recovery path).
                             none_retries = 0;
+                            cur_predicted_at = None;
+                            cur_scheduled_at = None;
+                            cur_last_empty_at = None;
                             continue;
                         }
                         Ok(None) => {
@@ -682,6 +737,11 @@ impl StatsTracker {
 
 fn current_timestamp() -> i64 {
     (js_sys::Date::now() / 1000.0) as i64
+}
+
+/// Unix seconds with millisecond precision — for diagnostics timestamps.
+fn current_timestamp_f64() -> f64 {
+    js_sys::Date::now() / 1000.0
 }
 
 async fn sleep_ms(ms: u32) {

--- a/src/nexrad/realtime.rs
+++ b/src/nexrad/realtime.rs
@@ -563,6 +563,10 @@ async fn streaming_loop(
                 } else {
                     "Intermediate"
                 };
+                let s3_last_modified_at = chunk
+                    .identifier
+                    .upload_date_time()
+                    .map(|dt| dt.timestamp_millis() as f64 / 1000.0);
                 let arrival_stat = crate::state::ChunkArrivalStat {
                     sequence: chunks_in_volume,
                     chunk_type: type_label,
@@ -570,6 +574,7 @@ async fn streaming_loop(
                     scheduled_at: cur_scheduled_at.unwrap_or(success_at),
                     empty_polls: none_retries,
                     last_empty_poll_at: cur_last_empty_at,
+                    s3_last_modified_at,
                     success_at,
                     fetch_latency_ms: chunk_fetch_ms,
                 };

--- a/src/state/live_mode.rs
+++ b/src/state/live_mode.rs
@@ -181,6 +181,23 @@ pub struct LiveModeState {
     /// Structural metadata covers all chunks; projected times only for future chunks.
     /// Updated each time a new chunk arrives.
     pub chunk_projections: Option<Vec<crate::nexrad::ChunkProjectionInfo>>,
+
+    /// Diagnostic snapshot of the current live volume's forecast vs. actuals.
+    /// Populated at volume start (when both VCP pattern and volume_start are
+    /// known) by `try_capture_forecast`. Used by the VCP forecast diagnostics
+    /// modal to let the user compare predicted and observed values.
+    pub current_volume_forecast: Option<crate::state::VolumeForecastSnapshot>,
+
+    /// Most recently completed `current_volume_forecast`, moved here by
+    /// `handle_volume_complete`. Kept so the diagnostics modal still has
+    /// something to display immediately after a volume ends and before the
+    /// next one's snapshot is captured.
+    pub last_volume_forecast: Option<crate::state::VolumeForecastSnapshot>,
+
+    /// Observed end timestamp of the previous volume (Unix seconds). Survives
+    /// the reset in `handle_volume_complete` so the next volume's snapshot
+    /// can compute its inter-volume gap.
+    pub previous_volume_end_secs: Option<f64>,
 }
 
 impl Default for LiveModeState {
@@ -214,6 +231,9 @@ impl Default for LiveModeState {
             last_radial_time_secs: None,
             projected_volume_end_secs: None,
             chunk_projections: None,
+            current_volume_forecast: None,
+            last_volume_forecast: None,
+            previous_volume_end_secs: None,
         }
     }
 }
@@ -283,6 +303,9 @@ impl LiveModeState {
         self.last_radial_time_secs = None;
         self.projected_volume_end_secs = None;
         self.chunk_projections = None;
+        self.current_volume_forecast = None;
+        self.last_volume_forecast = None;
+        self.previous_volume_end_secs = None;
     }
 
     /// Set error state with message.
@@ -426,6 +449,16 @@ impl LiveModeState {
                 self.last_volume_duration_secs = Some(dur);
             }
         }
+
+        // Seal the forecast snapshot and preserve it for the diagnostics modal.
+        // Move it into `last_volume_forecast` so the modal has something to show
+        // while the next volume is spinning up.
+        if let Some(mut snap) = self.current_volume_forecast.take() {
+            snap.actual_volume_end = Some(now);
+            self.last_volume_forecast = Some(snap);
+        }
+        self.previous_volume_end_secs = Some(now);
+
         self.phase = LivePhase::Streaming;
         self.phase_started_at = Some(now);
         self.elevations_received.clear();
@@ -468,12 +501,14 @@ impl LiveModeState {
     /// sweeps for the current volume.
     pub fn update_sweep_metas(&mut self, metas: Vec<crate::data::SweepMeta>) {
         self.completed_sweep_metas = metas;
+        self.fill_forecast_actuals();
     }
 
     /// Record which elevation is currently being accumulated (partial sweep).
     /// Resets `sweep_start_azimuth` when the elevation changes.
     pub fn record_in_progress_elevation(&mut self, elevation: Option<u8>, radials: Option<u32>) {
-        if elevation != self.current_in_progress_elevation {
+        let elevation_changed = elevation != self.current_in_progress_elevation;
+        if elevation_changed {
             self.current_elev_chunks.clear();
             self.sweep_start_azimuth = None;
             // Keep live_data_azimuth_range until the LiveDecoded result arrives
@@ -482,6 +517,12 @@ impl LiveModeState {
         }
         self.current_in_progress_elevation = elevation;
         self.current_in_progress_radials = radials;
+
+        if elevation_changed {
+            if let Some(new_elev) = elevation {
+                self.capture_mid_prediction(new_elev);
+            }
+        }
     }
 
     /// Record VCP info from an ingest result. When a full `ExtractedVcp` with
@@ -507,6 +548,7 @@ impl LiveModeState {
                 self.estimated_sweep_durations = vcp.sweep_durations(vol_dur);
             }
         }
+        self.try_capture_forecast();
     }
 
     /// Record last radial azimuth and timestamp from a chunk.
@@ -516,6 +558,236 @@ impl LiveModeState {
         }
         if let Some(t) = time_secs {
             self.last_radial_time_secs = Some(t);
+        }
+    }
+
+    /// Capture a cold-start forecast snapshot for the current volume, if the
+    /// prerequisites are met and we don't already have one.
+    ///
+    /// Called at the end of `record_vcp` and also from the main update loop
+    /// right after `current_volume_start` is first set — either one may run
+    /// first depending on the order chunks arrive.
+    pub fn try_capture_forecast(&mut self) {
+        if self.current_volume_forecast.is_some() {
+            return;
+        }
+        let Some(vol_start) = self.current_volume_start else {
+            return;
+        };
+        let Some(vcp) = self.current_vcp_pattern.as_ref() else {
+            return;
+        };
+        if vcp.elevations.is_empty() {
+            return;
+        }
+
+        let vcp_number = vcp.number;
+        let vcp_name = crate::state::get_vcp_definition(vcp_number).map(|d| d.name);
+        let is_clear_air = crate::data::vcp::is_clear_air_vcp(vcp_number);
+
+        let total_vol_dur = vcp.estimated_volume_duration().unwrap_or(300.0);
+        let predicted_volume_end = self
+            .projected_volume_end_secs
+            .unwrap_or(vol_start + total_vol_dur);
+        let sweep_durations = vcp.sweep_durations(total_vol_dur);
+
+        // Group chunk_projections by elevation for per-sweep predictions.
+        let chunk_projections_available = self.chunk_projections.is_some();
+        let projected_per_elev: Option<
+            std::collections::BTreeMap<u8, (f64, f64, u32, f64)>, // (min_time, max_time, chunk_count, rate)
+        > = self.chunk_projections.as_ref().map(|projs| {
+            let mut map: std::collections::BTreeMap<u8, (f64, f64, u32, f64)> =
+                std::collections::BTreeMap::new();
+            for chunk in projs {
+                if let Some(e) = chunk.elevation_number {
+                    let entry = map.entry(e as u8).or_insert((
+                        f64::MAX,
+                        f64::MIN,
+                        0u32,
+                        chunk.azimuth_rate_dps,
+                    ));
+                    entry.2 += 1;
+                    if let Some(t) = chunk.projected_time_secs {
+                        entry.0 = entry.0.min(t);
+                        entry.1 = entry.1.max(t);
+                    }
+                    if entry.3 <= 0.0 {
+                        entry.3 = chunk.azimuth_rate_dps;
+                    }
+                }
+            }
+            map
+        });
+
+        let mut sweeps: Vec<crate::state::SweepForecast> = Vec::with_capacity(vcp.elevations.len());
+        let mut cum_offset = 0.0f64;
+
+        for (idx, elev) in vcp.elevations.iter().enumerate() {
+            let elev_number = (idx + 1) as u8;
+            let weighted_dur = sweep_durations
+                .get(idx)
+                .copied()
+                .unwrap_or(total_vol_dur / vcp.elevations.len() as f64);
+
+            let fallback_rate = crate::data::vcp::fallback_azimuth_rate(
+                is_clear_air,
+                &elev.waveform,
+                elev.prf_number,
+            );
+
+            // Rate selection priority: library projection > VCP msg > Method B fallback.
+            let proj = projected_per_elev
+                .as_ref()
+                .and_then(|m| m.get(&elev_number))
+                .copied();
+            let (rate_used, rate_source) = match (proj, elev.azimuth_rate) {
+                (Some((_, _, _, r)), _) if r > 0.0 => {
+                    (r, crate::state::RateSource::ProjectionLibrary)
+                }
+                (_, Some(r)) if r > 0.0 => (r as f64, crate::state::RateSource::VcpMessage),
+                _ => (fallback_rate, crate::state::RateSource::MethodBFallback),
+            };
+
+            // Prefer library projection bounds when usable; otherwise use the
+            // VCP-weighted cumulative offset (same cascade as VcpPositionModel).
+            let (predicted_start, predicted_end) = match proj {
+                Some((min_t, max_t, _, rate)) if min_t < f64::MAX => {
+                    let end = if max_t > f64::MIN {
+                        max_t
+                    } else if rate > 0.0 {
+                        min_t + (360.0 / rate - 0.67).max(0.0)
+                    } else {
+                        min_t + weighted_dur
+                    };
+                    (min_t, end)
+                }
+                _ => (
+                    vol_start + cum_offset,
+                    vol_start + cum_offset + weighted_dur,
+                ),
+            };
+
+            let predicted_duration = (predicted_end - predicted_start).max(0.0);
+            let predicted_chunks = proj.map(|(_, _, count, _)| count);
+
+            sweeps.push(crate::state::SweepForecast {
+                elev_number,
+                elev_angle: elev.angle,
+                waveform: elev.waveform.clone(),
+                prf_number: elev.prf_number,
+                is_sails: elev.is_sails,
+                is_mrle: elev.is_mrle,
+                is_base_tilt: elev.is_base_tilt,
+                vcp_azimuth_rate: elev.azimuth_rate,
+                fallback_azimuth_rate: fallback_rate,
+                azimuth_rate_used: rate_used,
+                rate_source,
+                predicted_start,
+                predicted_end,
+                predicted_duration,
+                predicted_chunks,
+                mid_predicted_start: None,
+                mid_predicted_end: None,
+                actual_start: None,
+                actual_end: None,
+                actual_chunks: None,
+                observed_rate_dps: None,
+                timing_source: None,
+                status: crate::state::SweepStatus::Future,
+            });
+
+            cum_offset += weighted_dur;
+        }
+
+        let inter_volume_gap_secs = self
+            .previous_volume_end_secs
+            .map(|prev_end| vol_start - prev_end);
+
+        let snap = crate::state::VolumeForecastSnapshot {
+            vcp_number,
+            vcp_name,
+            is_clear_air,
+            volume_start: vol_start,
+            predicted_volume_end,
+            actual_volume_end: None,
+            expected_elevation_count: vcp.elevations.len() as u8,
+            sweeps,
+            captured_at: vol_start,
+            chunk_projections_available_at_start: chunk_projections_available,
+            previous_volume_end: self.previous_volume_end_secs,
+            inter_volume_gap_secs,
+            predicted_inter_volume_gap_secs: None,
+        };
+        self.current_volume_forecast = Some(snap);
+
+        // Pre-fill actuals and mid-predictions in case some data arrived before
+        // the snapshot could be taken (e.g., VCP message came in after the
+        // first sweep of the volume had already been ingested).
+        self.fill_forecast_actuals();
+        if let Some(cur_elev) = self.current_in_progress_elevation {
+            self.capture_mid_prediction(cur_elev);
+        }
+    }
+
+    /// Walk `completed_sweep_metas` + `chunk_elev_spans` and fill actuals on
+    /// the current volume's forecast snapshot, if any.
+    fn fill_forecast_actuals(&mut self) {
+        let Some(snap) = self.current_volume_forecast.as_mut() else {
+            return;
+        };
+        for meta in &self.completed_sweep_metas {
+            let Some(forecast) = snap
+                .sweeps
+                .iter_mut()
+                .find(|s| s.elev_number == meta.elevation_number)
+            else {
+                continue;
+            };
+            forecast.actual_start = Some(meta.start);
+            forecast.actual_end = Some(meta.end);
+            let dur = meta.end - meta.start;
+            forecast.observed_rate_dps = if dur > 0.0 { Some(360.0 / dur) } else { None };
+            forecast.actual_chunks = Some(
+                self.chunk_elev_spans
+                    .iter()
+                    .filter(|&&(e, _, _, _)| e == meta.elevation_number)
+                    .count() as u32,
+            );
+            forecast.timing_source = Some(crate::state::SweepTiming::Observed);
+            forecast.status = crate::state::SweepStatus::Complete;
+        }
+    }
+
+    /// Record the "mid" prediction — what the projection library predicts for
+    /// the given elevation's bounds *now*, when it has just become in-progress.
+    fn capture_mid_prediction(&mut self, elev: u8) {
+        let Some(snap) = self.current_volume_forecast.as_mut() else {
+            return;
+        };
+        let Some(forecast) = snap.sweeps.iter_mut().find(|s| s.elev_number == elev) else {
+            return;
+        };
+        if forecast.mid_predicted_start.is_some() {
+            return;
+        }
+
+        if let Some(ref projs) = self.chunk_projections {
+            let mut min_t = f64::MAX;
+            let mut max_t = f64::MIN;
+            for chunk in projs {
+                if chunk.elevation_number == Some(elev as usize) {
+                    if let Some(t) = chunk.projected_time_secs {
+                        min_t = min_t.min(t);
+                        max_t = max_t.max(t);
+                    }
+                }
+            }
+            if min_t < f64::MAX {
+                forecast.mid_predicted_start = Some(min_t);
+                if max_t > f64::MIN {
+                    forecast.mid_predicted_end = Some(max_t);
+                }
+            }
         }
     }
 }

--- a/src/state/live_mode.rs
+++ b/src/state/live_mode.rs
@@ -198,6 +198,15 @@ pub struct LiveModeState {
     /// the reset in `handle_volume_complete` so the next volume's snapshot
     /// can compute its inter-volume gap.
     pub previous_volume_end_secs: Option<f64>,
+
+    /// Per-chunk arrival diagnostics for the current volume. One entry per
+    /// successful fetch, in arrival order. Reset on `handle_volume_complete`
+    /// (a trimmed copy is attached to `last_volume_forecast` via the modal).
+    pub chunk_arrivals: Vec<crate::state::ChunkArrivalStat>,
+
+    /// Most recent volume's `chunk_arrivals`, preserved for the diagnostics
+    /// modal alongside `last_volume_forecast`.
+    pub last_chunk_arrivals: Vec<crate::state::ChunkArrivalStat>,
 }
 
 impl Default for LiveModeState {
@@ -234,6 +243,8 @@ impl Default for LiveModeState {
             current_volume_forecast: None,
             last_volume_forecast: None,
             previous_volume_end_secs: None,
+            chunk_arrivals: Vec::new(),
+            last_chunk_arrivals: Vec::new(),
         }
     }
 }
@@ -306,6 +317,8 @@ impl LiveModeState {
         self.current_volume_forecast = None;
         self.last_volume_forecast = None;
         self.previous_volume_end_secs = None;
+        self.chunk_arrivals.clear();
+        self.last_chunk_arrivals.clear();
     }
 
     /// Set error state with message.
@@ -459,6 +472,10 @@ impl LiveModeState {
         }
         self.previous_volume_end_secs = Some(now);
 
+        // Preserve the just-completed volume's per-chunk arrival stats for the
+        // diagnostics modal, then reset for the next volume.
+        self.last_chunk_arrivals = std::mem::take(&mut self.chunk_arrivals);
+
         self.phase = LivePhase::Streaming;
         self.phase_started_at = Some(now);
         self.elevations_received.clear();
@@ -549,6 +566,15 @@ impl LiveModeState {
             }
         }
         self.try_capture_forecast();
+    }
+
+    /// Append a chunk arrival diagnostic sample for the current volume.
+    pub fn record_chunk_arrival(&mut self, stat: crate::state::ChunkArrivalStat) {
+        // Bound memory — clamp to 1024 per volume; anything beyond that is
+        // pathological and unhelpful to the diagnostics modal.
+        if self.chunk_arrivals.len() < 1024 {
+            self.chunk_arrivals.push(stat);
+        }
     }
 
     /// Record last radial azimuth and timestamp from a chunk.

--- a/src/state/live_mode.rs
+++ b/src/state/live_mode.rs
@@ -729,6 +729,21 @@ impl LiveModeState {
             .previous_volume_end_secs
             .map(|prev_end| vol_start - prev_end);
 
+        // Predicted gap: the iterator's predicted_available_at for the Start
+        // chunk of this volume, minus the previous volume's observed end.
+        // That's the forecaster's "when will the next volume begin arriving"
+        // estimate, which drives whether we start polling for it too early
+        // (wasted 404s) or too late (wasted wait).
+        let predicted_inter_volume_gap_secs = match self.previous_volume_end_secs {
+            Some(prev_end) => self
+                .chunk_arrivals
+                .first()
+                .filter(|a| a.chunk_type == "Start")
+                .and_then(|a| a.predicted_available_at)
+                .map(|pred| pred - prev_end),
+            None => None,
+        };
+
         let snap = crate::state::VolumeForecastSnapshot {
             vcp_number,
             vcp_name,
@@ -742,7 +757,7 @@ impl LiveModeState {
             chunk_projections_available_at_start: chunk_projections_available,
             previous_volume_end: self.previous_volume_end_secs,
             inter_volume_gap_secs,
-            predicted_inter_volume_gap_secs: None,
+            predicted_inter_volume_gap_secs,
         };
         self.current_volume_forecast = Some(snap);
 

--- a/src/state/live_mode.rs
+++ b/src/state/live_mode.rs
@@ -753,7 +753,6 @@ impl LiveModeState {
             actual_volume_end: None,
             expected_elevation_count: vcp.elevations.len() as u8,
             sweeps,
-            captured_at: vol_start,
             chunk_projections_available_at_start: chunk_projections_available,
             previous_volume_end: self.previous_volume_end_secs,
             inter_volume_gap_secs,

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -49,7 +49,7 @@ pub use stats::{
 // AppCommand is defined directly in this module above.
 pub use theme::ThemeMode;
 pub use vcp::get_vcp_definition;
-pub use vcp_forecast::{RateSource, SweepForecast, VolumeForecastSnapshot};
+pub use vcp_forecast::{ChunkArrivalStat, RateSource, SweepForecast, VolumeForecastSnapshot};
 pub use vcp_position::{SweepPosition, SweepStatus, SweepTiming, VcpPositionModel};
 pub use viz::{
     ElevationListEntry, ElevationSelection, InterpolationMode, RadarProduct, RenderProcessing,

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -21,6 +21,7 @@ mod stats;
 pub(crate) mod theme;
 pub(crate) mod url_state;
 pub(crate) mod vcp;
+pub(crate) mod vcp_forecast;
 mod vcp_position;
 mod viz;
 
@@ -48,6 +49,7 @@ pub use stats::{
 // AppCommand is defined directly in this module above.
 pub use theme::ThemeMode;
 pub use vcp::get_vcp_definition;
+pub use vcp_forecast::{RateSource, SweepForecast, VolumeForecastSnapshot};
 pub use vcp_position::{SweepPosition, SweepStatus, SweepTiming, VcpPositionModel};
 pub use viz::{
     ElevationListEntry, ElevationSelection, InterpolationMode, RadarProduct, RenderProcessing,
@@ -190,6 +192,9 @@ pub struct AppState {
 
     /// Whether the stats detail popup is open.
     pub stats_detail_open: bool,
+
+    /// Whether the VCP forecast diagnostics modal is open.
+    pub vcp_forecast_open: bool,
 
     /// User-saved weather event bookmarks.
     pub saved_events: SavedEvents,

--- a/src/state/vcp_forecast.rs
+++ b/src/state/vcp_forecast.rs
@@ -109,3 +109,55 @@ pub struct VolumeForecastSnapshot {
     /// Reserved for when the forecaster predicts the gap; always `None` today.
     pub predicted_inter_volume_gap_secs: Option<f64>,
 }
+
+/// Per-chunk arrival diagnostic sample. Captured by the real-time streaming
+/// loop on every successful chunk fetch and retained for the current volume.
+///
+/// The purpose is to answer:
+/// * How many empty polls did each chunk take? (wasted S3 requests)
+/// * How accurate was `time_until_next()` compared to actual arrival?
+/// * For chunks with empty polls, when could the fetch have succeeded
+///   earliest? (we know it wasn't there at `last_empty_poll_at` and it was
+///   there at `success_at`, so the earliest usable download time lies
+///   somewhere in between)
+#[derive(Clone, Debug)]
+pub struct ChunkArrivalStat {
+    /// 1-based sequence number within the volume at the time of success.
+    pub sequence: u32,
+    /// "Start" / "Intermediate" / "End".
+    pub chunk_type: &'static str,
+    /// What the iterator's `time_until_next()` said the chunk would be
+    /// available at (Unix seconds). `None` if the iterator had no prediction.
+    pub predicted_available_at: Option<f64>,
+    /// Time the first poll for this chunk was issued (end of the predicted
+    /// sleep), Unix seconds.
+    #[allow(dead_code)] // captured for future analysis; not currently rendered
+    pub scheduled_at: f64,
+    /// Number of empty `Ok(None)` polls before the successful fetch.
+    pub empty_polls: u32,
+    /// Time of the most recent empty poll (Unix seconds). `None` when
+    /// `empty_polls == 0`. Lower bound on when the chunk actually became
+    /// available on S3.
+    pub last_empty_poll_at: Option<f64>,
+    /// Time the successful poll received its response (Unix seconds).
+    pub success_at: f64,
+    /// HTTP round-trip time for the successful fetch, milliseconds.
+    pub fetch_latency_ms: f64,
+}
+
+impl ChunkArrivalStat {
+    /// Positive values mean the forecaster was too optimistic (we polled
+    /// before the chunk was actually available). Negative values mean we
+    /// waited longer than necessary.
+    pub fn prediction_error_secs(&self) -> Option<f64> {
+        self.predicted_available_at.map(|p| self.success_at - p)
+    }
+
+    /// Time between the last empty poll and the successful download.
+    /// Represents wait that could potentially have been avoided if the
+    /// poll schedule were better aligned to S3 publishing time.
+    pub fn wait_after_last_empty_ms(&self) -> Option<f64> {
+        self.last_empty_poll_at
+            .map(|t| (self.success_at - t) * 1000.0)
+    }
+}

--- a/src/state/vcp_forecast.rs
+++ b/src/state/vcp_forecast.rs
@@ -185,13 +185,12 @@ impl ChunkArrivalStat {
     }
 
     /// Time between S3's `Last-Modified` and our successful download.
-    /// Unlike `wait_after_last_empty_ms`, this is authoritative: the
-    /// object was provably available at `s3_last_modified_at`, so any
-    /// lag beyond that is pure client-side waste (wasted sleep + wasted
-    /// retries if we polled before it was published).
-    ///
-    /// Caveat: `Last-Modified` has 1-second resolution, so values are
-    /// ±1 s noisy. Negative values indicate client/server clock skew.
+    /// Unlike `wait_after_last_empty_ms`, this tries to be authoritative
+    /// (the object was provably available at `s3_last_modified_at`), but
+    /// `Last-Modified` has 1-second resolution so individual values carry
+    /// ±1 s of quantization noise — including sign flips. Magnitudes
+    /// smaller than 1000 ms are indistinguishable from zero; treat only
+    /// `|wait| > 1000 ms` as real client-side wait (or real clock skew).
     pub fn wait_after_s3_publish_ms(&self) -> Option<f64> {
         self.s3_last_modified_at
             .map(|t| (self.success_at - t) * 1000.0)

--- a/src/state/vcp_forecast.rs
+++ b/src/state/vcp_forecast.rs
@@ -136,9 +136,13 @@ pub struct ChunkArrivalStat {
     /// Number of empty `Ok(None)` polls before the successful fetch.
     pub empty_polls: u32,
     /// Time of the most recent empty poll (Unix seconds). `None` when
-    /// `empty_polls == 0`. Lower bound on when the chunk actually became
-    /// available on S3.
+    /// `empty_polls == 0`. Crude lower bound on when the chunk actually
+    /// became available on S3 — we only learn it via polling.
     pub last_empty_poll_at: Option<f64>,
+    /// S3's `Last-Modified` header for the object (Unix seconds). When
+    /// present this is the authoritative earliest-possible-download time
+    /// and strictly tighter than `last_empty_poll_at`.
+    pub s3_last_modified_at: Option<f64>,
     /// Time the successful poll received its response (Unix seconds).
     pub success_at: f64,
     /// HTTP round-trip time for the successful fetch, milliseconds.
@@ -158,6 +162,16 @@ impl ChunkArrivalStat {
     /// poll schedule were better aligned to S3 publishing time.
     pub fn wait_after_last_empty_ms(&self) -> Option<f64> {
         self.last_empty_poll_at
+            .map(|t| (self.success_at - t) * 1000.0)
+    }
+
+    /// Time between S3's `Last-Modified` and our successful download.
+    /// Unlike `wait_after_last_empty_ms`, this is authoritative: the
+    /// object was provably available at `s3_last_modified_at`, so any
+    /// lag beyond that is pure client-side waste (wasted sleep + wasted
+    /// retries if we polled before it was published).
+    pub fn wait_after_s3_publish_ms(&self) -> Option<f64> {
+        self.s3_last_modified_at
             .map(|t| (self.success_at - t) * 1000.0)
     }
 }

--- a/src/state/vcp_forecast.rs
+++ b/src/state/vcp_forecast.rs
@@ -1,0 +1,111 @@
+//! Diagnostic snapshot of VCP-based sweep forecasts vs. observed reality.
+//!
+//! A `VolumeForecastSnapshot` is captured at the start of a live volume — the
+//! moment both the VCP pattern (Message Type 5) and the volume-start timestamp
+//! are known — and then mutated as sweeps complete. The stored shape is a
+//! predicted/actual side-by-side for every elevation, designed to be
+//! serialized to plain text and pasted into a chat message so the forecasting
+//! algorithms can be iterated on from real session data.
+
+use super::{SweepStatus, SweepTiming};
+
+/// Where the azimuth-rate value driving the prediction came from.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RateSource {
+    /// Rate came straight from the VCP message (`ExtractedVcpElevation.azimuth_rate`).
+    VcpMessage,
+    /// VCP message had no rate — used `fallback_azimuth_rate(...)`.
+    MethodBFallback,
+    /// Used `ChunkProjectionInfo.azimuth_rate_dps` from the nexrad-data projection library.
+    ProjectionLibrary,
+}
+
+impl RateSource {
+    pub fn short(&self) -> &'static str {
+        match self {
+            RateSource::VcpMessage => "VCP",
+            RateSource::MethodBFallback => "FB",
+            RateSource::ProjectionLibrary => "LIB",
+        }
+    }
+}
+
+/// Per-elevation predicted values captured at volume start, with slots for
+/// actuals filled in as the sweep completes.
+#[derive(Clone, Debug)]
+pub struct SweepForecast {
+    pub elev_number: u8,
+    pub elev_angle: f32,
+    pub waveform: String,
+    pub prf_number: u8,
+    pub is_sails: bool,
+    pub is_mrle: bool,
+    pub is_base_tilt: bool,
+
+    /// Raw rate from the VCP message, if present.
+    pub vcp_azimuth_rate: Option<f32>,
+    /// Fallback rate computed from (waveform, prf, clear_air).
+    pub fallback_azimuth_rate: f64,
+    /// Rate actually used for the prediction (from VCP, fallback, or library).
+    pub azimuth_rate_used: f64,
+    pub rate_source: RateSource,
+
+    pub predicted_start: f64,
+    #[allow(dead_code)] // stored for future use; rendered via predicted_duration today
+    pub predicted_end: f64,
+    pub predicted_duration: f64,
+    /// `None` when no `ChunkProjectionInfo` was available at snapshot time
+    /// (we didn't guess a chunk count then).
+    pub predicted_chunks: Option<u32>,
+
+    /// Re-projected start when this elevation first becomes in-progress —
+    /// what the forecaster would predict once a chunk for it has arrived.
+    pub mid_predicted_start: Option<f64>,
+    pub mid_predicted_end: Option<f64>,
+
+    pub actual_start: Option<f64>,
+    pub actual_end: Option<f64>,
+    pub actual_chunks: Option<u32>,
+    /// `360 / actual_duration` for completed sweeps — comparable to `azimuth_rate_used`.
+    pub observed_rate_dps: Option<f64>,
+
+    pub timing_source: Option<SweepTiming>,
+    pub status: SweepStatus,
+}
+
+impl SweepForecast {
+    pub fn actual_duration(&self) -> Option<f64> {
+        match (self.actual_start, self.actual_end) {
+            (Some(s), Some(e)) if e > s => Some(e - s),
+            _ => None,
+        }
+    }
+}
+
+/// Volume-level snapshot. Serialized into the clipboard text.
+#[derive(Clone, Debug)]
+pub struct VolumeForecastSnapshot {
+    pub vcp_number: u16,
+    /// Name from the static `get_vcp_definition` table; `None` for unknown VCPs.
+    pub vcp_name: Option<&'static str>,
+    pub is_clear_air: bool,
+    pub volume_start: f64,
+    /// Predicted volume-end — the library projection if available, otherwise
+    /// `volume_start + ExtractedVcp::estimated_volume_duration()`.
+    pub predicted_volume_end: f64,
+    pub actual_volume_end: Option<f64>,
+    pub expected_elevation_count: u8,
+    pub sweeps: Vec<SweepForecast>,
+    /// When the snapshot was taken (Unix seconds).
+    pub captured_at: f64,
+    /// Whether `chunk_projections` were present at snapshot time — useful
+    /// context when reading the `predicted_chunks` column.
+    pub chunk_projections_available_at_start: bool,
+
+    /// Prior volume's observed end timestamp (Unix seconds), if we saw one.
+    pub previous_volume_end: Option<f64>,
+    /// `volume_start - previous_volume_end` when both are known.
+    pub inter_volume_gap_secs: Option<f64>,
+    /// Reserved for when the forecaster predicts the gap; always `None` today.
+    pub predicted_inter_volume_gap_secs: Option<f64>,
+}

--- a/src/state/vcp_forecast.rs
+++ b/src/state/vcp_forecast.rs
@@ -96,8 +96,6 @@ pub struct VolumeForecastSnapshot {
     pub actual_volume_end: Option<f64>,
     pub expected_elevation_count: u8,
     pub sweeps: Vec<SweepForecast>,
-    /// When the snapshot was taken (Unix seconds).
-    pub captured_at: f64,
     /// Whether `chunk_projections` were present at snapshot time — useful
     /// context when reading the `predicted_chunks` column.
     pub chunk_projections_available_at_start: bool,
@@ -126,22 +124,36 @@ pub struct ChunkArrivalStat {
     pub sequence: u32,
     /// "Start" / "Intermediate" / "End".
     pub chunk_type: &'static str,
+    /// 1-based elevation number the chunk contributes to. `None` for the
+    /// volume-start chunk (which carries VCP metadata, not a specific sweep).
+    pub elevation_number: Option<u8>,
+    /// 0-based index of this chunk within its sweep (e.g. 0, 1, 2 for a
+    /// standard sweep; 0–5 for super-res).
+    pub chunk_index_in_sweep: Option<u32>,
+    /// Total chunks expected in this sweep (3 for standard, 6 for super-res).
+    pub chunks_in_sweep: Option<u32>,
     /// What the iterator's `time_until_next()` said the chunk would be
     /// available at (Unix seconds). `None` if the iterator had no prediction.
     pub predicted_available_at: Option<f64>,
     /// Time the first poll for this chunk was issued (end of the predicted
-    /// sleep), Unix seconds.
-    #[allow(dead_code)] // captured for future analysis; not currently rendered
+    /// sleep), Unix seconds. The gap `scheduled_at - predicted_available_at`
+    /// is the scheduler slop (how precisely we woke on the predicted time).
     pub scheduled_at: f64,
     /// Number of empty `Ok(None)` polls before the successful fetch.
     pub empty_polls: u32,
+    /// Time of the first empty poll for this chunk (Unix seconds). `None`
+    /// when `empty_polls == 0`. Together with `last_empty_poll_at` bounds
+    /// the retry cluster.
+    pub first_empty_poll_at: Option<f64>,
     /// Time of the most recent empty poll (Unix seconds). `None` when
     /// `empty_polls == 0`. Crude lower bound on when the chunk actually
     /// became available on S3 — we only learn it via polling.
     pub last_empty_poll_at: Option<f64>,
     /// S3's `Last-Modified` header for the object (Unix seconds). When
     /// present this is the authoritative earliest-possible-download time
-    /// and strictly tighter than `last_empty_poll_at`.
+    /// and strictly tighter than `last_empty_poll_at`. Note: header has
+    /// 1-second resolution, so derived `wait_after_s3_publish_ms` values
+    /// are ±1s noisy.
     pub s3_last_modified_at: Option<f64>,
     /// Time the successful poll received its response (Unix seconds).
     pub success_at: f64,
@@ -157,6 +169,13 @@ impl ChunkArrivalStat {
         self.predicted_available_at.map(|p| self.success_at - p)
     }
 
+    /// Milliseconds between when we intended to wake and when we actually
+    /// polled — the scheduler's precision relative to the prediction.
+    pub fn scheduler_slop_ms(&self) -> Option<f64> {
+        self.predicted_available_at
+            .map(|p| (self.scheduled_at - p) * 1000.0)
+    }
+
     /// Time between the last empty poll and the successful download.
     /// Represents wait that could potentially have been avoided if the
     /// poll schedule were better aligned to S3 publishing time.
@@ -170,6 +189,9 @@ impl ChunkArrivalStat {
     /// object was provably available at `s3_last_modified_at`, so any
     /// lag beyond that is pure client-side waste (wasted sleep + wasted
     /// retries if we polled before it was published).
+    ///
+    /// Caveat: `Last-Modified` has 1-second resolution, so values are
+    /// ±1 s noisy. Negative values indicate client/server clock skew.
     pub fn wait_after_s3_publish_ms(&self) -> Option<f64> {
         self.s3_last_modified_at
             .map(|t| (self.success_at - t) * 1000.0)

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -27,6 +27,7 @@ mod site_modal;
 mod stats_modal;
 mod timeline;
 mod top_bar;
+mod vcp_forecast_modal;
 mod wipe_modal;
 
 pub use alerts_modal::render_alerts_modals;
@@ -41,4 +42,5 @@ pub use shortcuts::{handle_shortcuts, render_shortcuts_help};
 pub use site_modal::{render_site_modal, SiteModalState};
 pub use stats_modal::render_stats_modal;
 pub use top_bar::render_top_bar;
+pub use vcp_forecast_modal::render_vcp_forecast_modal;
 pub use wipe_modal::render_wipe_modal;

--- a/src/ui/stats_modal.rs
+++ b/src/ui/stats_modal.rs
@@ -252,6 +252,34 @@ pub fn render_stats_modal(ctx: &egui::Context, state: &mut AppState) {
 
             ui.separator();
 
+            // --- Diagnostics ---
+            ui.label(
+                RichText::new("Diagnostics")
+                    .size(12.0)
+                    .strong()
+                    .color(heading_color),
+            );
+            ui.indent("diag_section", |ui| {
+                let has_forecast = state.live_mode_state.current_volume_forecast.is_some()
+                    || state.live_mode_state.last_volume_forecast.is_some();
+                if ui
+                    .add_enabled(
+                        has_forecast,
+                        egui::Button::new("VCP forecast diagnostics").small(),
+                    )
+                    .on_hover_text(
+                        "Compare VCP-based predictions against observed sweeps for the current live volume",
+                    )
+                    .on_disabled_hover_text("Available after a live VCP message has been received")
+                    .clicked()
+                {
+                    state.vcp_forecast_open = true;
+                    state.stats_detail_open = false;
+                }
+            });
+
+            ui.separator();
+
             // --- Cache ---
             stat_row(
                 ui,

--- a/src/ui/vcp_forecast_modal.rs
+++ b/src/ui/vcp_forecast_modal.rs
@@ -376,7 +376,10 @@ fn render_snapshot(
                         value_color,
                     );
                 }
-                // Authoritative lag vs. S3 publish time (Last-Modified header).
+                // Lag vs. S3 publish time (Last-Modified header).
+                // The header is rendered with 1-second resolution, so individual
+                // values carry ±1s of quantization noise — treat magnitudes below
+                // that as indistinguishable from zero.
                 let wait_after_s3: Vec<f64> = arrivals
                     .iter()
                     .filter_map(|a| a.wait_after_s3_publish_ms())
@@ -386,18 +389,32 @@ fn render_snapshot(
                         ui,
                         "Wait after S3 publish (success - Last-Modified)",
                         &format!(
-                            "mean {mean:.0}ms  median {median:.0}ms  max {max_abs:.0}ms  (±1s noise)"
+                            "mean {mean:.0}ms  median {median:.0}ms  max {max_abs:.0}ms  (±1s quantized)"
                         ),
                         label_color,
                         value_color,
                     );
-                    // Negative min ⇒ client clock is ahead of S3 (clock skew).
-                    let min_wait = wait_after_s3.iter().copied().fold(f64::INFINITY, f64::min);
-                    if min_wait < 0.0 {
+                    // Values outside ±1s are real client-side wait (or real skew).
+                    // Values within ±1s are noise from Last-Modified truncation.
+                    let measurable: Vec<f64> =
+                        wait_after_s3.iter().copied().filter(|v| v.abs() > 1000.0).collect();
+                    if let Some((mean_m, _median_m, max_m)) = stats_on(&measurable) {
                         kv(
                             ui,
-                            "  clock skew estimate",
-                            &format!("client ~{:.0}ms ahead of S3", -min_wait),
+                            "  measurable waits (|>1s|)",
+                            &format!(
+                                "{}/{}  mean {mean_m:.0}ms  max {max_m:.0}ms",
+                                measurable.len(),
+                                wait_after_s3.len()
+                            ),
+                            label_color,
+                            value_color,
+                        );
+                    } else {
+                        kv(
+                            ui,
+                            "  measurable waits (|>1s|)",
+                            "none — all chunks within ±1s quantization noise",
                             label_color,
                             value_color,
                         );
@@ -993,24 +1010,33 @@ pub fn serialize_forecast(snap: &VolumeForecastSnapshot, arrivals: &[ChunkArriva
         .filter(|a| a.s3_last_modified_at.is_some())
         .count();
     if let Some((mean, median, max_abs)) = stats_on(&wait_after_s3_ms) {
-        let min_wait = wait_after_s3_ms
-            .iter()
-            .copied()
-            .fold(f64::INFINITY, f64::min);
-        let skew_note = if min_wait < 0.0 {
-            format!(
-                "  (min={min_wait:.0}ms — negative ⇒ client clock ~{:.0}ms ahead of S3; Last-Modified has 1-s precision)",
-                -min_wait
-            )
-        } else {
-            "  (Last-Modified has 1-s precision so values are ±1000ms noisy)".to_string()
-        };
         let _ = writeln!(
             out,
-            "wait_after_s3_publish_ms: mean={mean:.0}  median={median:.0}  max_abs={max_abs:.0}  (coverage {}/{}){skew_note}",
+            "wait_after_s3_publish_ms: mean={mean:.0}  median={median:.0}  max_abs={max_abs:.0}  (coverage {}/{}; ±1s quantized — Last-Modified is second-precision)",
             s3_coverage,
             arrivals.len()
         );
+        // Filter to measurable waits only — |values| > 1000 ms are outside the
+        // quantization noise band and reflect real client-side wait.
+        let measurable: Vec<f64> = wait_after_s3_ms
+            .iter()
+            .copied()
+            .filter(|v| v.abs() > 1000.0)
+            .collect();
+        if let Some((mean_m, _median_m, max_m)) = stats_on(&measurable) {
+            let _ = writeln!(
+                out,
+                "wait_after_s3_measurable: {}/{} chunks outside ±1s band  mean={mean_m:.0}ms  max={max_m:.0}ms",
+                measurable.len(),
+                wait_after_s3_ms.len()
+            );
+        } else {
+            let _ = writeln!(
+                out,
+                "wait_after_s3_measurable: 0/{} — all chunks within ±1s quantization noise (no measurable client-side wait)",
+                wait_after_s3_ms.len()
+            );
+        }
     } else {
         let _ = writeln!(
             out,

--- a/src/ui/vcp_forecast_modal.rs
+++ b/src/ui/vcp_forecast_modal.rs
@@ -180,21 +180,36 @@ fn render_snapshot(
                     label_color,
                     value_color,
                 );
-                match snap.inter_volume_gap_secs {
-                    Some(gap) => kv(
+                let gap_obs = snap
+                    .inter_volume_gap_secs
+                    .map(|g| format!("{g:+.2}s"))
+                    .unwrap_or_else(|| "—".into());
+                let gap_pred = snap
+                    .predicted_inter_volume_gap_secs
+                    .map(|g| format!("{g:+.2}s"))
+                    .unwrap_or_else(|| "—".into());
+                let gap_delta = match (
+                    snap.inter_volume_gap_secs,
+                    snap.predicted_inter_volume_gap_secs,
+                ) {
+                    (Some(o), Some(p)) => format!("{:+.2}s", o - p),
+                    _ => "—".into(),
+                };
+                kv(
+                    ui,
+                    "Inter-volume gap (obs / pred / Δ)",
+                    &format!("{gap_obs} / {gap_pred} / {gap_delta}"),
+                    label_color,
+                    value_color,
+                );
+                if let Some(prev_end) = snap.previous_volume_end {
+                    kv(
                         ui,
-                        "Inter-volume gap",
-                        &format!(
-                            "{:+.1}s (prev end {})",
-                            gap,
-                            snap.previous_volume_end
-                                .map(format_time)
-                                .unwrap_or_else(|| "—".into())
-                        ),
+                        "  prev volume end",
+                        &format_time(prev_end),
                         label_color,
                         value_color,
-                    ),
-                    None => kv(ui, "Inter-volume gap", "—", label_color, value_color),
+                    );
                 }
             });
 
@@ -340,6 +355,20 @@ fn render_snapshot(
                         value_color,
                     );
                 }
+                // Authoritative lag vs. S3 publish time (Last-Modified header).
+                let wait_after_s3: Vec<f64> = arrivals
+                    .iter()
+                    .filter_map(|a| a.wait_after_s3_publish_ms())
+                    .collect();
+                if let Some((mean, median, max_abs)) = stats_on(&wait_after_s3) {
+                    kv(
+                        ui,
+                        "Wait after S3 publish (success - Last-Modified)",
+                        &format!("mean {mean:.0}ms  median {median:.0}ms  max {max_abs:.0}ms"),
+                        label_color,
+                        value_color,
+                    );
+                }
             });
 
             ui.separator();
@@ -374,6 +403,8 @@ fn render_snapshot(
                             "pred_err",
                             "last_empty",
                             "wait_after_empty",
+                            "s3_last_mod",
+                            "wait_after_s3",
                             "fetch_ms",
                         ] {
                             ui.label(
@@ -454,6 +485,20 @@ fn arrival_row(
     mono(
         ui,
         a.wait_after_last_empty_ms()
+            .map(|ms| format!("{ms:.0}ms"))
+            .unwrap_or_else(|| "—".into()),
+        value_color,
+    );
+    mono(
+        ui,
+        a.s3_last_modified_at
+            .map(fmt_off)
+            .unwrap_or_else(|| "—".into()),
+        value_color,
+    );
+    mono(
+        ui,
+        a.wait_after_s3_publish_ms()
             .map(|ms| format!("{ms:.0}ms"))
             .unwrap_or_else(|| "—".into()),
         value_color,
@@ -865,6 +910,27 @@ pub fn serialize_forecast(snap: &VolumeForecastSnapshot, arrivals: &[ChunkArriva
     } else {
         let _ = writeln!(out, "wait_after_last_empty_ms: —  (no retries)");
     }
+    let wait_after_s3_ms: Vec<f64> = arrivals
+        .iter()
+        .filter_map(|a| a.wait_after_s3_publish_ms())
+        .collect();
+    let s3_coverage = arrivals
+        .iter()
+        .filter(|a| a.s3_last_modified_at.is_some())
+        .count();
+    if let Some((mean, median, max_abs)) = stats_on(&wait_after_s3_ms) {
+        let _ = writeln!(
+            out,
+            "wait_after_s3_publish_ms: mean={mean:.0}  median={median:.0}  max_abs={max_abs:.0}  (coverage {}/{})",
+            s3_coverage,
+            arrivals.len()
+        );
+    } else {
+        let _ = writeln!(
+            out,
+            "wait_after_s3_publish_ms: —  (Last-Modified unavailable for all chunks)"
+        );
+    }
     let fetch_ms: Vec<f64> = arrivals.iter().map(|a| a.fetch_latency_ms).collect();
     if let Some((mean, median, max_abs)) = stats_on(&fetch_ms) {
         let _ = writeln!(
@@ -877,13 +943,13 @@ pub fn serialize_forecast(snap: &VolumeForecastSnapshot, arrivals: &[ChunkArriva
         out.push('\n');
         let _ = writeln!(
             out,
-            "seq  type          empty  predicted_at  success_at  pred_err  last_empty   wait_after_empty  fetch_ms"
+            "seq  type          empty  predicted_at  success_at  pred_err  last_empty  wait_after_empty  s3_last_mod  wait_after_s3  fetch_ms"
         );
         for a in arrivals {
             let fmt_off = |t: f64| format!("+{:.2}s", t - snap.volume_start);
             let _ = writeln!(
                 out,
-                "{:>3}  {:<12}  {:>5}  {:>12}  {:>10}  {:>8}  {:>10}  {:>15}  {:>8}",
+                "{:>3}  {:<12}  {:>5}  {:>12}  {:>10}  {:>8}  {:>10}  {:>15}  {:>11}  {:>13}  {:>8}",
                 a.sequence,
                 a.chunk_type,
                 a.empty_polls,
@@ -898,6 +964,12 @@ pub fn serialize_forecast(snap: &VolumeForecastSnapshot, arrivals: &[ChunkArriva
                     .map(fmt_off)
                     .unwrap_or_else(|| "—".into()),
                 a.wait_after_last_empty_ms()
+                    .map(|ms| format!("{ms:.0}ms"))
+                    .unwrap_or_else(|| "—".into()),
+                a.s3_last_modified_at
+                    .map(fmt_off)
+                    .unwrap_or_else(|| "—".into()),
+                a.wait_after_s3_publish_ms()
                     .map(|ms| format!("{ms:.0}ms"))
                     .unwrap_or_else(|| "—".into()),
                 format!("{:.0}ms", a.fetch_latency_ms),

--- a/src/ui/vcp_forecast_modal.rs
+++ b/src/ui/vcp_forecast_modal.rs
@@ -223,15 +223,24 @@ fn render_snapshot(
                     .color(heading_color),
             );
 
+            ui.label(
+                RichText::new(
+                    "legend: tag = SAILS / MRLE / BASE / — (standard);  \
+                     src = LIB (projection library) / VCP (message rate) / FB (fallback);  \
+                     Δ values are actual − predicted",
+                )
+                .size(10.0)
+                .color(label_color),
+            );
             egui::Grid::new("vcp_forecast_grid")
                 .striped(true)
                 .min_col_width(44.0)
                 .spacing(Vec2::new(10.0, 4.0))
                 .show(ui, |ui| {
                     for header in [
-                        "elv", "ang", "wf", "prf", "S", "M", "B", "vcp_r", "fb_r", "used", "src",
+                        "elv", "ang", "wf", "prf", "tag", "vcp_r", "fb_r", "used", "src",
                         "pred_dur", "act_dur", "Δdur", "pred_ch", "act_ch", "Δch", "Δstart",
-                        "obs_rate", "timing", "status",
+                        "timing", "status",
                     ] {
                         ui.label(
                             RichText::new(header)
@@ -319,13 +328,25 @@ fn render_snapshot(
                 // Chunk-level aggregates
                 let total_empty = total_empty_polls(arrivals);
                 let any_retry = arrivals.iter().filter(|a| a.empty_polls > 0).count();
+                let total_requests = arrivals.len() as u32 + total_empty;
+                let waste_pct = if total_requests > 0 {
+                    100.0 * total_empty as f64 / total_requests as f64
+                } else {
+                    0.0
+                };
                 kv(
                     ui,
-                    "Empty polls (total)",
+                    "S3 requests (total / wasted)",
                     &format!(
-                        "{total_empty}  (chunks w/ ≥1 retry: {any_retry}/{})",
-                        arrivals.len()
+                        "{total_requests} total → {total_empty} wasted ({waste_pct:.1}%)"
                     ),
+                    label_color,
+                    value_color,
+                );
+                kv(
+                    ui,
+                    "Chunks with ≥1 retry",
+                    &format!("{any_retry}/{}", arrivals.len()),
                     label_color,
                     value_color,
                 );
@@ -364,10 +385,23 @@ fn render_snapshot(
                     kv(
                         ui,
                         "Wait after S3 publish (success - Last-Modified)",
-                        &format!("mean {mean:.0}ms  median {median:.0}ms  max {max_abs:.0}ms"),
+                        &format!(
+                            "mean {mean:.0}ms  median {median:.0}ms  max {max_abs:.0}ms  (±1s noise)"
+                        ),
                         label_color,
                         value_color,
                     );
+                    // Negative min ⇒ client clock is ahead of S3 (clock skew).
+                    let min_wait = wait_after_s3.iter().copied().fold(f64::INFINITY, f64::min);
+                    if min_wait < 0.0 {
+                        kv(
+                            ui,
+                            "  clock skew estimate",
+                            &format!("client ~{:.0}ms ahead of S3", -min_wait),
+                            label_color,
+                            value_color,
+                        );
+                    }
                 }
             });
 
@@ -389,6 +423,14 @@ fn render_snapshot(
                     );
                 });
             } else {
+                ui.label(
+                    RichText::new(
+                        "legend: elev shows elevation# (chunk-index/chunks-in-sweep);  \
+                         times are offsets from volume_start;  wait_after_s3 has ±1s precision",
+                    )
+                    .size(10.0)
+                    .color(label_color),
+                );
                 egui::Grid::new("vcp_forecast_arrivals_grid")
                     .striped(true)
                     .min_col_width(44.0)
@@ -397,10 +439,12 @@ fn render_snapshot(
                         for header in [
                             "seq",
                             "type",
+                            "elev",
                             "empty",
                             "predicted_at",
                             "success_at",
                             "pred_err",
+                            "first_empty",
                             "last_empty",
                             "wait_after_empty",
                             "s3_last_mod",
@@ -416,7 +460,16 @@ fn render_snapshot(
                         }
                         ui.end_row();
 
+                        let mut prev_elev: Option<u8> = None;
                         for a in arrivals {
+                            // Insert a blank visual break between elevations.
+                            if prev_elev.is_some() && a.elevation_number != prev_elev {
+                                for _ in 0..13 {
+                                    ui.label("");
+                                }
+                                ui.end_row();
+                            }
+                            prev_elev = a.elevation_number;
                             arrival_row(ui, a, snap.volume_start, label_color, value_color);
                         }
                     });
@@ -454,6 +507,7 @@ fn arrival_row(
 
     mono(ui, format!("{}", a.sequence), value_color);
     mono(ui, a.chunk_type.to_string(), label_color);
+    mono(ui, fmt_elev(a), label_color);
     let empty_color = if a.empty_polls > 0 {
         egui::Color32::from_rgb(220, 140, 60)
     } else {
@@ -472,6 +526,13 @@ fn arrival_row(
         ui,
         a.prediction_error_secs()
             .map(|e| format!("{e:+.2}s"))
+            .unwrap_or_else(|| "—".into()),
+        value_color,
+    );
+    mono(
+        ui,
+        a.first_empty_poll_at
+            .map(fmt_off)
             .unwrap_or_else(|| "—".into()),
         value_color,
     );
@@ -528,9 +589,7 @@ fn grid_row(
     mono(ui, format!("{:.2}°", s.elev_angle), value_color);
     mono(ui, s.waveform.clone(), value_color);
     mono(ui, format!("{}", s.prf_number), value_color);
-    mono(ui, yesno(s.is_sails), label_color);
-    mono(ui, yesno(s.is_mrle), label_color);
-    mono(ui, yesno(s.is_base_tilt), label_color);
+    mono(ui, cut_type_tag(s).to_string(), label_color);
     mono(
         ui,
         s.vcp_azimuth_rate
@@ -590,13 +649,6 @@ fn grid_row(
     );
     mono(
         ui,
-        s.observed_rate_dps
-            .map(|r| format!("{r:.2}"))
-            .unwrap_or_else(|| "—".into()),
-        value_color,
-    );
-    mono(
-        ui,
         match s.timing_source {
             Some(SweepTiming::Observed) => "Observed".to_string(),
             Some(SweepTiming::Anchored) => "Anchored".to_string(),
@@ -616,6 +668,18 @@ fn grid_row(
     );
     let _ = vol_start; // reserved for future per-row offset columns
     ui.end_row();
+}
+
+fn cut_type_tag(s: &SweepForecast) -> &'static str {
+    if s.is_sails {
+        "SAILS"
+    } else if s.is_mrle {
+        "MRLE"
+    } else if s.is_base_tilt {
+        "BASE"
+    } else {
+        "—"
+    }
 }
 
 fn kv(
@@ -638,11 +702,17 @@ fn kv(
     });
 }
 
-fn yesno(v: bool) -> String {
-    if v {
-        "Y".into()
-    } else {
-        "-".into()
+/// Format the elevation / chunk-in-sweep identifier for display.
+/// E.g. "1 (1/3)" for elevation 1, chunk 1 of 3. "—" for the volume Start chunk.
+fn fmt_elev(a: &ChunkArrivalStat) -> String {
+    match (
+        a.elevation_number,
+        a.chunk_index_in_sweep,
+        a.chunks_in_sweep,
+    ) {
+        (Some(e), Some(i), Some(n)) => format!("{} ({}/{})", e, i + 1, n),
+        (Some(e), _, _) => format!("{}", e),
+        _ => "—".into(),
     }
 }
 
@@ -715,12 +785,7 @@ pub fn serialize_forecast(snap: &VolumeForecastSnapshot, arrivals: &[ChunkArriva
         "VCP {} ({})  clear_air={}  elevations={}",
         snap.vcp_number, name, snap.is_clear_air, snap.expected_elevation_count
     );
-    let _ = writeln!(
-        out,
-        "volume_start={}  captured_at=+{:.1}s",
-        format_time(snap.volume_start),
-        snap.captured_at - snap.volume_start
-    );
+    let _ = writeln!(out, "volume_start={}", format_time(snap.volume_start));
     let predicted_dur = snap.predicted_volume_end - snap.volume_start;
     let _ = writeln!(
         out,
@@ -757,20 +822,22 @@ pub fn serialize_forecast(snap: &VolumeForecastSnapshot, arrivals: &[ChunkArriva
 
     let _ = writeln!(
         out,
-        "elv  angle  wf    prf S M B  vcp_r  fb_r  used  src | pred_dur act_dur  Δdur  | pred_ch act_ch Δch | Δstart obs_rate | timing     status"
+        "legend: tag = SAILS/MRLE/BASE/— (standard);  src = LIB (projection) / VCP (msg rate) / FB (fallback);  Δ = actual − predicted"
+    );
+    let _ = writeln!(
+        out,
+        "elv  angle  wf    prf tag    vcp_r  fb_r  used  src | pred_dur act_dur  Δdur  | pred_ch act_ch Δch | Δstart  | timing     status"
     );
 
     for s in &snap.sweeps {
         let _ = writeln!(
             out,
-            "{:>3}  {:>5.2}  {:<4} {:>3} {} {} {}  {:>5}  {:>5.2} {:>5.2} {:<3} | {:>6.1}s {:>6}s {:>5} | {:>6} {:>6} {:>3} | {:>6} {:>7} | {:<10} {}",
+            "{:>3}  {:>5.2}  {:<4} {:>3} {:<5}  {:>5}  {:>5.2} {:>5.2} {:<3} | {:>6.1}s {:>6}s {:>5} | {:>6} {:>6} {:>3} | {:>6}  | {:<10} {}",
             s.elev_number,
             s.elev_angle,
             trim_str(&s.waveform, 4),
             s.prf_number,
-            yesno(s.is_sails),
-            yesno(s.is_mrle),
-            yesno(s.is_base_tilt),
+            cut_type_tag(s),
             s.vcp_azimuth_rate
                 .map(|r| format!("{r:.2}"))
                 .unwrap_or_else(|| "—".into()),
@@ -796,9 +863,6 @@ pub fn serialize_forecast(snap: &VolumeForecastSnapshot, arrivals: &[ChunkArriva
             },
             s.actual_start
                 .map(|a| format!("{:+.2}s", a - s.predicted_start))
-                .unwrap_or_else(|| "—".into()),
-            s.observed_rate_dps
-                .map(|r| format!("{r:.2}"))
                 .unwrap_or_else(|| "—".into()),
             match s.timing_source {
                 Some(SweepTiming::Observed) => "Observed",
@@ -878,11 +942,21 @@ pub fn serialize_forecast(snap: &VolumeForecastSnapshot, arrivals: &[ChunkArriva
     // ── Chunk arrivals ───────────────────────────────────────────────
     let total_empty = total_empty_polls(arrivals);
     let any_retry = arrivals.iter().filter(|a| a.empty_polls > 0).count();
+    let total_requests = arrivals.len() as u32 + total_empty;
+    let waste_pct = if total_requests > 0 {
+        100.0 * total_empty as f64 / total_requests as f64
+    } else {
+        0.0
+    };
     let _ = writeln!(
         out,
-        "chunk_arrivals: count={} total_empty_polls={} chunks_with_retries={}/{}",
+        "s3_requests: {total_requests} total ({} successes + {total_empty} empty polls) → {waste_pct:.1}% wasted",
+        arrivals.len()
+    );
+    let _ = writeln!(
+        out,
+        "chunk_arrivals: count={} chunks_with_retries={}/{}",
         arrivals.len(),
-        total_empty,
         any_retry,
         arrivals.len()
     );
@@ -919,9 +993,21 @@ pub fn serialize_forecast(snap: &VolumeForecastSnapshot, arrivals: &[ChunkArriva
         .filter(|a| a.s3_last_modified_at.is_some())
         .count();
     if let Some((mean, median, max_abs)) = stats_on(&wait_after_s3_ms) {
+        let min_wait = wait_after_s3_ms
+            .iter()
+            .copied()
+            .fold(f64::INFINITY, f64::min);
+        let skew_note = if min_wait < 0.0 {
+            format!(
+                "  (min={min_wait:.0}ms — negative ⇒ client clock ~{:.0}ms ahead of S3; Last-Modified has 1-s precision)",
+                -min_wait
+            )
+        } else {
+            "  (Last-Modified has 1-s precision so values are ±1000ms noisy)".to_string()
+        };
         let _ = writeln!(
             out,
-            "wait_after_s3_publish_ms: mean={mean:.0}  median={median:.0}  max_abs={max_abs:.0}  (coverage {}/{})",
+            "wait_after_s3_publish_ms: mean={mean:.0}  median={median:.0}  max_abs={max_abs:.0}  (coverage {}/{}){skew_note}",
             s3_coverage,
             arrivals.len()
         );
@@ -929,6 +1015,16 @@ pub fn serialize_forecast(snap: &VolumeForecastSnapshot, arrivals: &[ChunkArriva
         let _ = writeln!(
             out,
             "wait_after_s3_publish_ms: —  (Last-Modified unavailable for all chunks)"
+        );
+    }
+    let slop_ms: Vec<f64> = arrivals
+        .iter()
+        .filter_map(|a| a.scheduler_slop_ms())
+        .collect();
+    if let Some((mean, median, max_abs)) = stats_on(&slop_ms) {
+        let _ = writeln!(
+            out,
+            "scheduler_slop_ms: mean={mean:+.0}  median={median:+.0}  max_abs={max_abs:.0}  (scheduled - predicted; should be near 0)"
         );
     }
     let fetch_ms: Vec<f64> = arrivals.iter().map(|a| a.fetch_latency_ms).collect();
@@ -943,15 +1039,27 @@ pub fn serialize_forecast(snap: &VolumeForecastSnapshot, arrivals: &[ChunkArriva
         out.push('\n');
         let _ = writeln!(
             out,
-            "seq  type          empty  predicted_at  success_at  pred_err  last_empty  wait_after_empty  s3_last_mod  wait_after_s3  fetch_ms"
+            "legend: all times are offsets from volume_start;  elev shows elevation# (chunk-index-in-sweep / chunks-in-sweep)"
         );
+        let _ = writeln!(
+            out,
+            "seq  type          elev        empty  predicted_at  success_at  pred_err  first_empty  last_empty  wait_after_empty  s3_last_mod  wait_after_s3  fetch_ms"
+        );
+        let mut prev_elev: Option<u8> = None;
         for a in arrivals {
+            // Blank line on elevation transitions (but not before the first row).
+            if prev_elev.is_some() && a.elevation_number != prev_elev {
+                out.push('\n');
+            }
+            prev_elev = a.elevation_number;
+
             let fmt_off = |t: f64| format!("+{:.2}s", t - snap.volume_start);
             let _ = writeln!(
                 out,
-                "{:>3}  {:<12}  {:>5}  {:>12}  {:>10}  {:>8}  {:>10}  {:>15}  {:>11}  {:>13}  {:>8}",
+                "{:>3}  {:<12}  {:<10}  {:>5}  {:>12}  {:>10}  {:>8}  {:>11}  {:>10}  {:>15}  {:>11}  {:>13}  {:>8}",
                 a.sequence,
                 a.chunk_type,
+                fmt_elev(a),
                 a.empty_polls,
                 a.predicted_available_at
                     .map(fmt_off)
@@ -959,6 +1067,9 @@ pub fn serialize_forecast(snap: &VolumeForecastSnapshot, arrivals: &[ChunkArriva
                 fmt_off(a.success_at),
                 a.prediction_error_secs()
                     .map(|e| format!("{e:+.2}s"))
+                    .unwrap_or_else(|| "—".into()),
+                a.first_empty_poll_at
+                    .map(fmt_off)
                     .unwrap_or_else(|| "—".into()),
                 a.last_empty_poll_at
                     .map(fmt_off)

--- a/src/ui/vcp_forecast_modal.rs
+++ b/src/ui/vcp_forecast_modal.rs
@@ -7,7 +7,8 @@
 
 use super::colors::ui as ui_colors;
 use crate::state::{
-    AppState, RateSource, SweepForecast, SweepStatus, SweepTiming, VolumeForecastSnapshot,
+    AppState, ChunkArrivalStat, RateSource, SweepForecast, SweepStatus, SweepTiming,
+    VolumeForecastSnapshot,
 };
 use eframe::egui::{self, RichText, Vec2};
 use std::fmt::Write as _;
@@ -23,12 +24,22 @@ pub fn render_vcp_forecast_modal(ctx: &egui::Context, state: &mut AppState) {
     }
 
     let dark = state.is_dark;
-    let snap_opt = state
-        .live_mode_state
-        .current_volume_forecast
-        .as_ref()
-        .or(state.live_mode_state.last_volume_forecast.as_ref())
-        .cloned();
+    let (snap_opt, arrivals) = {
+        let live = &state.live_mode_state;
+        if live.current_volume_forecast.is_some() {
+            (
+                live.current_volume_forecast.clone(),
+                live.chunk_arrivals.clone(),
+            )
+        } else if live.last_volume_forecast.is_some() {
+            (
+                live.last_volume_forecast.clone(),
+                live.last_chunk_arrivals.clone(),
+            )
+        } else {
+            (None, Vec::new())
+        }
+    };
 
     egui::Window::new("VCP forecast diagnostics")
         .collapsible(false)
@@ -59,7 +70,7 @@ pub fn render_vcp_forecast_modal(ctx: &egui::Context, state: &mut AppState) {
                 }
             }
             Some(snap) => {
-                render_snapshot(ui, ctx, &snap, dark, state);
+                render_snapshot(ui, ctx, &snap, &arrivals, dark, state);
             }
         });
 }
@@ -68,6 +79,7 @@ fn render_snapshot(
     ui: &mut egui::Ui,
     ctx: &egui::Context,
     snap: &VolumeForecastSnapshot,
+    arrivals: &[ChunkArrivalStat],
     dark: bool,
     state: &mut AppState,
 ) {
@@ -288,7 +300,96 @@ fn render_snapshot(
                         value_color,
                     );
                 }
+
+                // Chunk-level aggregates
+                let total_empty = total_empty_polls(arrivals);
+                let any_retry = arrivals.iter().filter(|a| a.empty_polls > 0).count();
+                kv(
+                    ui,
+                    "Empty polls (total)",
+                    &format!(
+                        "{total_empty}  (chunks w/ ≥1 retry: {any_retry}/{})",
+                        arrivals.len()
+                    ),
+                    label_color,
+                    value_color,
+                );
+                let pred_errs: Vec<f64> = arrivals
+                    .iter()
+                    .filter_map(|a| a.prediction_error_secs())
+                    .collect();
+                if let Some((mean, median, max_abs)) = stats_on(&pred_errs) {
+                    kv(
+                        ui,
+                        "Chunk prediction error (success - predicted)",
+                        &format!("mean {mean:+.2}s  median {median:+.2}s  max|{max_abs:.2}s|"),
+                        label_color,
+                        value_color,
+                    );
+                }
+                let wait_after_last_empty: Vec<f64> = arrivals
+                    .iter()
+                    .filter_map(|a| a.wait_after_last_empty_ms())
+                    .collect();
+                if let Some((mean, median, max_abs)) = stats_on(&wait_after_last_empty) {
+                    kv(
+                        ui,
+                        "Wait after last empty (success - last_empty)",
+                        &format!("mean {mean:.0}ms  median {median:.0}ms  max {max_abs:.0}ms"),
+                        label_color,
+                        value_color,
+                    );
+                }
             });
+
+            ui.separator();
+
+            // ── Chunk arrivals ─────────────────────────────────────────
+            ui.label(
+                RichText::new("Chunk arrivals")
+                    .size(12.0)
+                    .strong()
+                    .color(heading_color),
+            );
+            if arrivals.is_empty() {
+                ui.indent("arrivals_empty", |ui| {
+                    ui.label(
+                        RichText::new("— no chunks recorded yet")
+                            .size(11.0)
+                            .color(label_color),
+                    );
+                });
+            } else {
+                egui::Grid::new("vcp_forecast_arrivals_grid")
+                    .striped(true)
+                    .min_col_width(44.0)
+                    .spacing(Vec2::new(10.0, 4.0))
+                    .show(ui, |ui| {
+                        for header in [
+                            "seq",
+                            "type",
+                            "empty",
+                            "predicted_at",
+                            "success_at",
+                            "pred_err",
+                            "last_empty",
+                            "wait_after_empty",
+                            "fetch_ms",
+                        ] {
+                            ui.label(
+                                RichText::new(header)
+                                    .size(10.0)
+                                    .strong()
+                                    .color(heading_color),
+                            );
+                        }
+                        ui.end_row();
+
+                        for a in arrivals {
+                            arrival_row(ui, a, snap.volume_start, label_color, value_color);
+                        }
+                    });
+            }
 
             ui.add_space(6.0);
         });
@@ -296,7 +397,7 @@ fn render_snapshot(
     ui.separator();
     ui.horizontal(|ui| {
         if ui.button("Copy to clipboard").clicked() {
-            let text = serialize_forecast(snap);
+            let text = serialize_forecast(snap, arrivals);
             ctx.copy_text(text);
             state.status_message = "Forecast diagnostics copied to clipboard".to_string();
         }
@@ -306,6 +407,63 @@ fn render_snapshot(
             }
         });
     });
+}
+
+fn arrival_row(
+    ui: &mut egui::Ui,
+    a: &ChunkArrivalStat,
+    vol_start: f64,
+    label_color: egui::Color32,
+    value_color: egui::Color32,
+) {
+    let mono = |ui: &mut egui::Ui, text: String, color: egui::Color32| {
+        ui.label(RichText::new(text).size(10.0).monospace().color(color));
+    };
+    let fmt_off = |t: f64| format!("+{:.2}s", t - vol_start);
+
+    mono(ui, format!("{}", a.sequence), value_color);
+    mono(ui, a.chunk_type.to_string(), label_color);
+    let empty_color = if a.empty_polls > 0 {
+        egui::Color32::from_rgb(220, 140, 60)
+    } else {
+        value_color
+    };
+    mono(ui, format!("{}", a.empty_polls), empty_color);
+    mono(
+        ui,
+        a.predicted_available_at
+            .map(fmt_off)
+            .unwrap_or_else(|| "—".into()),
+        value_color,
+    );
+    mono(ui, fmt_off(a.success_at), value_color);
+    mono(
+        ui,
+        a.prediction_error_secs()
+            .map(|e| format!("{e:+.2}s"))
+            .unwrap_or_else(|| "—".into()),
+        value_color,
+    );
+    mono(
+        ui,
+        a.last_empty_poll_at
+            .map(fmt_off)
+            .unwrap_or_else(|| "—".into()),
+        value_color,
+    );
+    mono(
+        ui,
+        a.wait_after_last_empty_ms()
+            .map(|ms| format!("{ms:.0}ms"))
+            .unwrap_or_else(|| "—".into()),
+        value_color,
+    );
+    mono(ui, format!("{:.0}ms", a.fetch_latency_ms), value_color);
+    ui.end_row();
+}
+
+fn total_empty_polls(arrivals: &[ChunkArrivalStat]) -> u32 {
+    arrivals.iter().map(|a| a.empty_polls).sum()
 }
 
 // ── Grid row ────────────────────────────────────────────────────────────
@@ -503,7 +661,7 @@ fn format_time(secs: f64) -> String {
 
 // ── Plain-text serialization (clipboard payload) ────────────────────────
 
-pub fn serialize_forecast(snap: &VolumeForecastSnapshot) -> String {
+pub fn serialize_forecast(snap: &VolumeForecastSnapshot, arrivals: &[ChunkArrivalStat]) -> String {
     let mut out = String::new();
 
     let name = snap.vcp_name.unwrap_or("?");
@@ -671,6 +829,81 @@ pub fn serialize_forecast(snap: &VolumeForecastSnapshot) -> String {
             _ => "—".into(),
         },
     );
+
+    // ── Chunk arrivals ───────────────────────────────────────────────
+    let total_empty = total_empty_polls(arrivals);
+    let any_retry = arrivals.iter().filter(|a| a.empty_polls > 0).count();
+    let _ = writeln!(
+        out,
+        "chunk_arrivals: count={} total_empty_polls={} chunks_with_retries={}/{}",
+        arrivals.len(),
+        total_empty,
+        any_retry,
+        arrivals.len()
+    );
+    let pred_errs: Vec<f64> = arrivals
+        .iter()
+        .filter_map(|a| a.prediction_error_secs())
+        .collect();
+    if let Some((mean, median, max_abs)) = stats_on(&pred_errs) {
+        let _ = writeln!(
+            out,
+            "chunk_pred_err: mean={mean:+.2}s  median={median:+.2}s  max_abs={max_abs:.2}s"
+        );
+    } else {
+        let _ = writeln!(out, "chunk_pred_err: —");
+    }
+    let wait_after_empty_ms: Vec<f64> = arrivals
+        .iter()
+        .filter_map(|a| a.wait_after_last_empty_ms())
+        .collect();
+    if let Some((mean, median, max_abs)) = stats_on(&wait_after_empty_ms) {
+        let _ = writeln!(
+            out,
+            "wait_after_last_empty_ms: mean={mean:.0}  median={median:.0}  max_abs={max_abs:.0}"
+        );
+    } else {
+        let _ = writeln!(out, "wait_after_last_empty_ms: —  (no retries)");
+    }
+    let fetch_ms: Vec<f64> = arrivals.iter().map(|a| a.fetch_latency_ms).collect();
+    if let Some((mean, median, max_abs)) = stats_on(&fetch_ms) {
+        let _ = writeln!(
+            out,
+            "fetch_latency_ms: mean={mean:.0}  median={median:.0}  max_abs={max_abs:.0}"
+        );
+    }
+
+    if !arrivals.is_empty() {
+        out.push('\n');
+        let _ = writeln!(
+            out,
+            "seq  type          empty  predicted_at  success_at  pred_err  last_empty   wait_after_empty  fetch_ms"
+        );
+        for a in arrivals {
+            let fmt_off = |t: f64| format!("+{:.2}s", t - snap.volume_start);
+            let _ = writeln!(
+                out,
+                "{:>3}  {:<12}  {:>5}  {:>12}  {:>10}  {:>8}  {:>10}  {:>15}  {:>8}",
+                a.sequence,
+                a.chunk_type,
+                a.empty_polls,
+                a.predicted_available_at
+                    .map(fmt_off)
+                    .unwrap_or_else(|| "—".into()),
+                fmt_off(a.success_at),
+                a.prediction_error_secs()
+                    .map(|e| format!("{e:+.2}s"))
+                    .unwrap_or_else(|| "—".into()),
+                a.last_empty_poll_at
+                    .map(fmt_off)
+                    .unwrap_or_else(|| "—".into()),
+                a.wait_after_last_empty_ms()
+                    .map(|ms| format!("{ms:.0}ms"))
+                    .unwrap_or_else(|| "—".into()),
+                format!("{:.0}ms", a.fetch_latency_ms),
+            );
+        }
+    }
 
     out
 }

--- a/src/ui/vcp_forecast_modal.rs
+++ b/src/ui/vcp_forecast_modal.rs
@@ -1,0 +1,684 @@
+//! VCP forecast diagnostics modal.
+//!
+//! Shows the current (or most recently completed) live volume's forecast
+//! snapshot side-by-side with observed actuals, and provides a copy-to-
+//! clipboard button so the plain-text output can be pasted into a chat
+//! message for iterating on the forecasting algorithms.
+
+use super::colors::ui as ui_colors;
+use crate::state::{
+    AppState, RateSource, SweepForecast, SweepStatus, SweepTiming, VolumeForecastSnapshot,
+};
+use eframe::egui::{self, RichText, Vec2};
+use std::fmt::Write as _;
+
+pub fn render_vcp_forecast_modal(ctx: &egui::Context, state: &mut AppState) {
+    if !state.vcp_forecast_open {
+        return;
+    }
+
+    if super::modal_helper::modal_backdrop(ctx, "vcp_forecast_backdrop", 160) {
+        state.vcp_forecast_open = false;
+        return;
+    }
+
+    let dark = state.is_dark;
+    let snap_opt = state
+        .live_mode_state
+        .current_volume_forecast
+        .as_ref()
+        .or(state.live_mode_state.last_volume_forecast.as_ref())
+        .cloned();
+
+    egui::Window::new("VCP forecast diagnostics")
+        .collapsible(false)
+        .resizable(false)
+        .anchor(egui::Align2::CENTER_CENTER, Vec2::ZERO)
+        .fixed_size(Vec2::new(860.0, 560.0))
+        .order(egui::Order::Foreground)
+        .show(ctx, |ui| match snap_opt {
+            None => {
+                ui.add_space(8.0);
+                ui.label(
+                    RichText::new("No live volume yet.")
+                        .size(13.0)
+                        .color(ui_colors::label(dark)),
+                );
+                ui.add_space(4.0);
+                ui.label(
+                    RichText::new(
+                        "Start live mode and wait for a VCP message to arrive; \
+                         this modal will then show predicted vs. observed per-elevation stats.",
+                    )
+                    .size(11.0)
+                    .color(ui_colors::label(dark)),
+                );
+                ui.add_space(8.0);
+                if ui.button("Close").clicked() {
+                    state.vcp_forecast_open = false;
+                }
+            }
+            Some(snap) => {
+                render_snapshot(ui, ctx, &snap, dark, state);
+            }
+        });
+}
+
+fn render_snapshot(
+    ui: &mut egui::Ui,
+    ctx: &egui::Context,
+    snap: &VolumeForecastSnapshot,
+    dark: bool,
+    state: &mut AppState,
+) {
+    let label_color = ui_colors::label(dark);
+    let value_color = ui_colors::value(dark);
+    let heading_color = ui_colors::ACTIVE;
+
+    egui::ScrollArea::vertical()
+        .max_height(480.0)
+        .show(ui, |ui| {
+            // ── Volume metadata ─────────────────────────────────────────
+            ui.label(
+                RichText::new("Volume")
+                    .size(12.0)
+                    .strong()
+                    .color(heading_color),
+            );
+            ui.indent("vol_section", |ui| {
+                let name = snap.vcp_name.unwrap_or("?");
+                kv(
+                    ui,
+                    "VCP",
+                    &format!("{} ({})", snap.vcp_number, name),
+                    label_color,
+                    value_color,
+                );
+                kv(
+                    ui,
+                    "Mode",
+                    if snap.is_clear_air {
+                        "clear air"
+                    } else {
+                        "precip"
+                    },
+                    label_color,
+                    value_color,
+                );
+                kv(
+                    ui,
+                    "Elevations",
+                    &format!("{}", snap.expected_elevation_count),
+                    label_color,
+                    value_color,
+                );
+                kv(
+                    ui,
+                    "Volume start",
+                    &format_time(snap.volume_start),
+                    label_color,
+                    value_color,
+                );
+                let predicted_dur = snap.predicted_volume_end - snap.volume_start;
+                kv(
+                    ui,
+                    "Predicted end",
+                    &format!(
+                        "{} (+{:.1}s)",
+                        format_time(snap.predicted_volume_end),
+                        predicted_dur
+                    ),
+                    label_color,
+                    value_color,
+                );
+                match snap.actual_volume_end {
+                    Some(end) => {
+                        let drift = end - snap.predicted_volume_end;
+                        kv(
+                            ui,
+                            "Actual end",
+                            &format!(
+                                "{} (+{:.1}s, drift {:+.1}s)",
+                                format_time(end),
+                                end - snap.volume_start,
+                                drift
+                            ),
+                            label_color,
+                            value_color,
+                        );
+                    }
+                    None => kv(ui, "Actual end", "—", label_color, value_color),
+                }
+                kv(
+                    ui,
+                    "Projections at start",
+                    if snap.chunk_projections_available_at_start {
+                        "yes"
+                    } else {
+                        "no"
+                    },
+                    label_color,
+                    value_color,
+                );
+                let (m_a, m_b, m_lib) = rate_source_tally(snap);
+                kv(
+                    ui,
+                    "Rate sources",
+                    &format!("VCP={m_a}  fallback={m_b}  library={m_lib}"),
+                    label_color,
+                    value_color,
+                );
+                match snap.inter_volume_gap_secs {
+                    Some(gap) => kv(
+                        ui,
+                        "Inter-volume gap",
+                        &format!(
+                            "{:+.1}s (prev end {})",
+                            gap,
+                            snap.previous_volume_end
+                                .map(format_time)
+                                .unwrap_or_else(|| "—".into())
+                        ),
+                        label_color,
+                        value_color,
+                    ),
+                    None => kv(ui, "Inter-volume gap", "—", label_color, value_color),
+                }
+            });
+
+            ui.separator();
+
+            // ── Per-elevation table ─────────────────────────────────────
+            ui.label(
+                RichText::new("Per-elevation")
+                    .size(12.0)
+                    .strong()
+                    .color(heading_color),
+            );
+
+            egui::Grid::new("vcp_forecast_grid")
+                .striped(true)
+                .min_col_width(44.0)
+                .spacing(Vec2::new(10.0, 4.0))
+                .show(ui, |ui| {
+                    for header in [
+                        "elv", "ang", "wf", "prf", "S", "M", "B", "vcp_r", "fb_r", "used", "src",
+                        "pred_dur", "act_dur", "Δdur", "pred_ch", "act_ch", "Δch", "Δstart",
+                        "obs_rate", "timing", "status",
+                    ] {
+                        ui.label(
+                            RichText::new(header)
+                                .size(10.0)
+                                .strong()
+                                .color(heading_color),
+                        );
+                    }
+                    ui.end_row();
+
+                    for s in &snap.sweeps {
+                        grid_row(ui, s, snap.volume_start, label_color, value_color);
+                    }
+                });
+
+            ui.separator();
+
+            // ── Summary ─────────────────────────────────────────────────
+            ui.label(
+                RichText::new("Summary")
+                    .size(12.0)
+                    .strong()
+                    .color(heading_color),
+            );
+            ui.indent("summary", |ui| {
+                let (complete, in_progress, future) = count_statuses(snap);
+                kv(
+                    ui,
+                    "Counts",
+                    &format!("complete={complete} in_progress={in_progress} future={future}"),
+                    label_color,
+                    value_color,
+                );
+                let dur_errs: Vec<f64> = snap
+                    .sweeps
+                    .iter()
+                    .filter_map(|s| s.actual_duration().map(|d| d - s.predicted_duration))
+                    .collect();
+                if let Some((mean, median, max_abs)) = stats_on(&dur_errs) {
+                    kv(
+                        ui,
+                        "Duration error (actual - predicted)",
+                        &format!("mean {mean:+.2}s  median {median:+.2}s  max|{max_abs:.2}s|"),
+                        label_color,
+                        value_color,
+                    );
+                } else {
+                    kv(
+                        ui,
+                        "Duration error",
+                        "— (no complete sweeps yet)",
+                        label_color,
+                        value_color,
+                    );
+                }
+                let chunk_errs: Vec<f64> = snap
+                    .sweeps
+                    .iter()
+                    .filter_map(|s| match (s.actual_chunks, s.predicted_chunks) {
+                        (Some(a), Some(p)) => Some(a as f64 - p as f64),
+                        _ => None,
+                    })
+                    .collect();
+                if let Some((mean, _median, max_abs)) = stats_on(&chunk_errs) {
+                    kv(
+                        ui,
+                        "Chunk count error",
+                        &format!("mean {mean:+.2}  max|{max_abs:.0}|"),
+                        label_color,
+                        value_color,
+                    );
+                } else {
+                    kv(ui, "Chunk count error", "—", label_color, value_color);
+                }
+                if let Some(end) = snap.actual_volume_end {
+                    kv(
+                        ui,
+                        "Volume-end drift",
+                        &format!("{:+.2}s", end - snap.predicted_volume_end),
+                        label_color,
+                        value_color,
+                    );
+                }
+            });
+
+            ui.add_space(6.0);
+        });
+
+    ui.separator();
+    ui.horizontal(|ui| {
+        if ui.button("Copy to clipboard").clicked() {
+            let text = serialize_forecast(snap);
+            ctx.copy_text(text);
+            state.status_message = "Forecast diagnostics copied to clipboard".to_string();
+        }
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            if ui.button("Close").clicked() {
+                state.vcp_forecast_open = false;
+            }
+        });
+    });
+}
+
+// ── Grid row ────────────────────────────────────────────────────────────
+
+fn grid_row(
+    ui: &mut egui::Ui,
+    s: &SweepForecast,
+    vol_start: f64,
+    label_color: egui::Color32,
+    value_color: egui::Color32,
+) {
+    let mono = |ui: &mut egui::Ui, text: String, color: egui::Color32| {
+        ui.label(RichText::new(text).size(10.0).monospace().color(color));
+    };
+
+    mono(ui, format!("{}", s.elev_number), value_color);
+    mono(ui, format!("{:.2}°", s.elev_angle), value_color);
+    mono(ui, s.waveform.clone(), value_color);
+    mono(ui, format!("{}", s.prf_number), value_color);
+    mono(ui, yesno(s.is_sails), label_color);
+    mono(ui, yesno(s.is_mrle), label_color);
+    mono(ui, yesno(s.is_base_tilt), label_color);
+    mono(
+        ui,
+        s.vcp_azimuth_rate
+            .map(|r| format!("{r:.2}"))
+            .unwrap_or_else(|| "—".into()),
+        value_color,
+    );
+    mono(ui, format!("{:.2}", s.fallback_azimuth_rate), value_color);
+    mono(ui, format!("{:.2}", s.azimuth_rate_used), value_color);
+    mono(ui, s.rate_source.short().to_string(), label_color);
+
+    mono(ui, format!("{:.1}s", s.predicted_duration), value_color);
+    mono(
+        ui,
+        s.actual_duration()
+            .map(|d| format!("{d:.1}s"))
+            .unwrap_or_else(|| "—".into()),
+        value_color,
+    );
+    mono(
+        ui,
+        s.actual_duration()
+            .map(|d| format!("{:+.2}s", d - s.predicted_duration))
+            .unwrap_or_else(|| "—".into()),
+        value_color,
+    );
+
+    mono(
+        ui,
+        s.predicted_chunks
+            .map(|c| format!("{c}"))
+            .unwrap_or_else(|| "—".into()),
+        value_color,
+    );
+    mono(
+        ui,
+        s.actual_chunks
+            .map(|c| format!("{c}"))
+            .unwrap_or_else(|| "—".into()),
+        value_color,
+    );
+    mono(
+        ui,
+        match (s.actual_chunks, s.predicted_chunks) {
+            (Some(a), Some(p)) => format!("{:+}", a as i32 - p as i32),
+            _ => "—".into(),
+        },
+        value_color,
+    );
+
+    mono(
+        ui,
+        s.actual_start
+            .map(|a| format!("{:+.2}s", a - s.predicted_start))
+            .unwrap_or_else(|| "—".into()),
+        value_color,
+    );
+    mono(
+        ui,
+        s.observed_rate_dps
+            .map(|r| format!("{r:.2}"))
+            .unwrap_or_else(|| "—".into()),
+        value_color,
+    );
+    mono(
+        ui,
+        match s.timing_source {
+            Some(SweepTiming::Observed) => "Observed".to_string(),
+            Some(SweepTiming::Anchored) => "Anchored".to_string(),
+            Some(SweepTiming::Estimated) => "Estimated".to_string(),
+            None => "—".into(),
+        },
+        label_color,
+    );
+    mono(
+        ui,
+        match s.status {
+            SweepStatus::Complete => "Complete".to_string(),
+            SweepStatus::InProgress { .. } => "InProg".to_string(),
+            SweepStatus::Future => "Future".to_string(),
+        },
+        label_color,
+    );
+    let _ = vol_start; // reserved for future per-row offset columns
+    ui.end_row();
+}
+
+fn kv(
+    ui: &mut egui::Ui,
+    label: &str,
+    value: &str,
+    label_color: egui::Color32,
+    value_color: egui::Color32,
+) {
+    ui.horizontal(|ui| {
+        ui.label(RichText::new(label).size(11.0).color(label_color));
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            ui.label(
+                RichText::new(value)
+                    .size(11.0)
+                    .monospace()
+                    .color(value_color),
+            );
+        });
+    });
+}
+
+fn yesno(v: bool) -> String {
+    if v {
+        "Y".into()
+    } else {
+        "-".into()
+    }
+}
+
+fn rate_source_tally(snap: &VolumeForecastSnapshot) -> (usize, usize, usize) {
+    let mut a = 0;
+    let mut b = 0;
+    let mut lib = 0;
+    for s in &snap.sweeps {
+        match s.rate_source {
+            RateSource::VcpMessage => a += 1,
+            RateSource::MethodBFallback => b += 1,
+            RateSource::ProjectionLibrary => lib += 1,
+        }
+    }
+    (a, b, lib)
+}
+
+fn count_statuses(snap: &VolumeForecastSnapshot) -> (usize, usize, usize) {
+    let mut complete = 0;
+    let mut in_progress = 0;
+    let mut future = 0;
+    for s in &snap.sweeps {
+        match s.status {
+            SweepStatus::Complete => complete += 1,
+            SweepStatus::InProgress { .. } => in_progress += 1,
+            SweepStatus::Future => future += 1,
+        }
+    }
+    (complete, in_progress, future)
+}
+
+/// Returns (mean, median, max_abs) for a sample of error values.
+fn stats_on(values: &[f64]) -> Option<(f64, f64, f64)> {
+    if values.is_empty() {
+        return None;
+    }
+    let mean: f64 = values.iter().sum::<f64>() / values.len() as f64;
+    let mut sorted: Vec<f64> = values.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let median = if sorted.len().is_multiple_of(2) {
+        (sorted[sorted.len() / 2 - 1] + sorted[sorted.len() / 2]) / 2.0
+    } else {
+        sorted[sorted.len() / 2]
+    };
+    let max_abs = values.iter().map(|v| v.abs()).fold(0.0f64, f64::max);
+    Some((mean, median, max_abs))
+}
+
+/// Format a Unix-seconds timestamp as `YYYY-MM-DD HH:MM:SSZ`.
+fn format_time(secs: f64) -> String {
+    let ms = (secs * 1000.0) as i64;
+    let date = js_sys::Date::new(&wasm_bindgen::JsValue::from_f64(ms as f64));
+    let iso = date.to_iso_string().as_string().unwrap_or_default();
+    // "2026-04-21T18:14:03.000Z" → "2026-04-21 18:14:03Z"
+    if iso.len() >= 20 {
+        format!("{} {}Z", &iso[0..10], &iso[11..19])
+    } else {
+        iso
+    }
+}
+
+// ── Plain-text serialization (clipboard payload) ────────────────────────
+
+pub fn serialize_forecast(snap: &VolumeForecastSnapshot) -> String {
+    let mut out = String::new();
+
+    let name = snap.vcp_name.unwrap_or("?");
+    let _ = writeln!(
+        out,
+        "VCP {} ({})  clear_air={}  elevations={}",
+        snap.vcp_number, name, snap.is_clear_air, snap.expected_elevation_count
+    );
+    let _ = writeln!(
+        out,
+        "volume_start={}  captured_at=+{:.1}s",
+        format_time(snap.volume_start),
+        snap.captured_at - snap.volume_start
+    );
+    let predicted_dur = snap.predicted_volume_end - snap.volume_start;
+    let _ = writeln!(
+        out,
+        "predicted_end={} (+{:.1}s)  actual_end={}  drift={}",
+        format_time(snap.predicted_volume_end),
+        predicted_dur,
+        snap.actual_volume_end
+            .map(|e| format!("{} (+{:.1}s)", format_time(e), e - snap.volume_start))
+            .unwrap_or_else(|| "—".into()),
+        snap.actual_volume_end
+            .map(|e| format!("{:+.1}s", e - snap.predicted_volume_end))
+            .unwrap_or_else(|| "—".into())
+    );
+    let _ = writeln!(
+        out,
+        "inter_volume_gap={} (prev_end={})  predicted_gap={}",
+        snap.inter_volume_gap_secs
+            .map(|g| format!("{g:+.2}s"))
+            .unwrap_or_else(|| "—".into()),
+        snap.previous_volume_end
+            .map(format_time)
+            .unwrap_or_else(|| "—".into()),
+        snap.predicted_inter_volume_gap_secs
+            .map(|g| format!("{g:+.2}s"))
+            .unwrap_or_else(|| "—".into())
+    );
+    let (m_a, m_b, m_lib) = rate_source_tally(snap);
+    let _ = writeln!(
+        out,
+        "projections_at_start={}  rates: vcp={}  fallback={}  library={}",
+        snap.chunk_projections_available_at_start, m_a, m_b, m_lib
+    );
+    out.push('\n');
+
+    let _ = writeln!(
+        out,
+        "elv  angle  wf    prf S M B  vcp_r  fb_r  used  src | pred_dur act_dur  Δdur  | pred_ch act_ch Δch | Δstart obs_rate | timing     status"
+    );
+
+    for s in &snap.sweeps {
+        let _ = writeln!(
+            out,
+            "{:>3}  {:>5.2}  {:<4} {:>3} {} {} {}  {:>5}  {:>5.2} {:>5.2} {:<3} | {:>6.1}s {:>6}s {:>5} | {:>6} {:>6} {:>3} | {:>6} {:>7} | {:<10} {}",
+            s.elev_number,
+            s.elev_angle,
+            trim_str(&s.waveform, 4),
+            s.prf_number,
+            yesno(s.is_sails),
+            yesno(s.is_mrle),
+            yesno(s.is_base_tilt),
+            s.vcp_azimuth_rate
+                .map(|r| format!("{r:.2}"))
+                .unwrap_or_else(|| "—".into()),
+            s.fallback_azimuth_rate,
+            s.azimuth_rate_used,
+            s.rate_source.short(),
+            s.predicted_duration,
+            s.actual_duration()
+                .map(|d| format!("{d:.1}"))
+                .unwrap_or_else(|| "—".into()),
+            s.actual_duration()
+                .map(|d| format!("{:+.2}s", d - s.predicted_duration))
+                .unwrap_or_else(|| "—".into()),
+            s.predicted_chunks
+                .map(|c| format!("{c}"))
+                .unwrap_or_else(|| "—".into()),
+            s.actual_chunks
+                .map(|c| format!("{c}"))
+                .unwrap_or_else(|| "—".into()),
+            match (s.actual_chunks, s.predicted_chunks) {
+                (Some(a), Some(p)) => format!("{:+}", a as i32 - p as i32),
+                _ => "—".into(),
+            },
+            s.actual_start
+                .map(|a| format!("{:+.2}s", a - s.predicted_start))
+                .unwrap_or_else(|| "—".into()),
+            s.observed_rate_dps
+                .map(|r| format!("{r:.2}"))
+                .unwrap_or_else(|| "—".into()),
+            match s.timing_source {
+                Some(SweepTiming::Observed) => "Observed",
+                Some(SweepTiming::Anchored) => "Anchored",
+                Some(SweepTiming::Estimated) => "Estimated",
+                None => "—",
+            },
+            match s.status {
+                SweepStatus::Complete => "Complete",
+                SweepStatus::InProgress { .. } => "InProgress",
+                SweepStatus::Future => "Future",
+            },
+        );
+    }
+
+    out.push('\n');
+
+    let (complete, in_progress, future) = count_statuses(snap);
+    let _ = writeln!(
+        out,
+        "summary: complete={complete}  in_progress={in_progress}  future={future}"
+    );
+
+    let dur_errs: Vec<f64> = snap
+        .sweeps
+        .iter()
+        .filter_map(|s| s.actual_duration().map(|d| d - s.predicted_duration))
+        .collect();
+    if let Some((mean, median, max_abs)) = stats_on(&dur_errs) {
+        let _ = writeln!(
+            out,
+            "duration_err: mean={mean:+.2}s  median={median:+.2}s  max_abs={max_abs:.2}s"
+        );
+    } else {
+        let _ = writeln!(out, "duration_err: —");
+    }
+
+    let chunk_errs: Vec<f64> = snap
+        .sweeps
+        .iter()
+        .filter_map(|s| match (s.actual_chunks, s.predicted_chunks) {
+            (Some(a), Some(p)) => Some(a as f64 - p as f64),
+            _ => None,
+        })
+        .collect();
+    if let Some((mean, _median, max_abs)) = stats_on(&chunk_errs) {
+        let _ = writeln!(out, "chunk_err:    mean={mean:+.2}  max_abs={max_abs:.0}");
+    } else {
+        let _ = writeln!(out, "chunk_err: —");
+    }
+
+    if let Some(end) = snap.actual_volume_end {
+        let _ = writeln!(
+            out,
+            "volume_end_drift: {:+.2}s",
+            end - snap.predicted_volume_end
+        );
+    }
+    let _ = writeln!(
+        out,
+        "inter_volume_gap: observed={}  predicted={}  delta={}",
+        snap.inter_volume_gap_secs
+            .map(|g| format!("{g:+.2}s"))
+            .unwrap_or_else(|| "—".into()),
+        snap.predicted_inter_volume_gap_secs
+            .map(|g| format!("{g:+.2}s"))
+            .unwrap_or_else(|| "—".into()),
+        match (
+            snap.inter_volume_gap_secs,
+            snap.predicted_inter_volume_gap_secs,
+        ) {
+            (Some(o), Some(p)) => format!("{:+.2}s", o - p),
+            _ => "—".into(),
+        },
+    );
+
+    out
+}
+
+fn trim_str(s: &str, max_len: usize) -> String {
+    if s.chars().count() <= max_len {
+        s.to_string()
+    } else {
+        s.chars().take(max_len).collect()
+    }
+}


### PR DESCRIPTION
## Summary
Adds a new diagnostics modal that captures and displays VCP-based sweep forecasts side-by-side with observed actuals, enabling iterative improvement of forecasting algorithms through real session data.

## Key Changes

- **New VCP Forecast Modal UI** (`src/ui/vcp_forecast_modal.rs`):
  - Renders a 860×560 window showing volume metadata, per-elevation predictions vs. actuals in a detailed grid, and summary statistics
  - Displays volume timing, elevation counts, rate sources, and inter-volume gaps
  - Per-sweep columns include: elevation, angle, waveform, PRF, flags (SAILS/MRLE/base tilt), azimuth rates, durations, chunk counts, timing sources, and status
  - Computes and displays error statistics (mean, median, max absolute) for duration and chunk count predictions
  - Includes "Copy to clipboard" button that serializes the snapshot to plain-text format for sharing in chat/collaboration

- **Forecast Snapshot Capture** (`src/state/vcp_forecast.rs`):
  - New `VolumeForecastSnapshot` struct capturing volume-level metadata and per-sweep predictions at volume start
  - `SweepForecast` struct storing predicted vs. actual values for each elevation with rate source tracking
  - `RateSource` enum distinguishing between VCP message rates, Method B fallback rates, and projection library rates

- **Live Mode State Extensions** (`src/state/live_mode.rs`):
  - Added `current_volume_forecast` to hold the active snapshot
  - Added `last_volume_forecast` to preserve the previous volume's snapshot after completion
  - Added `previous_volume_end_secs` to track inter-volume gaps across resets
  - New `try_capture_forecast()` method that creates a snapshot when both VCP pattern and volume start are known
  - New `fill_forecast_actuals()` method that populates actual values from completed sweep metadata
  - New `capture_mid_prediction()` method that re-projects predictions when an elevation becomes in-progress
  - Snapshot is sealed and moved to `last_volume_forecast` in `handle_volume_complete()`

- **UI Integration** (`src/ui/stats_modal.rs`):
  - Added "VCP forecast diagnostics" button in the Diagnostics section of the stats modal
  - Button is enabled when either current or last volume forecast is available

- **State Management** (`src/state/mod.rs`, `src/ui/mod.rs`):
  - Exported new `vcp_forecast` module and types
  - Added `vcp_forecast_modal` to UI module exports
  - Added `vcp_forecast_open` flag to AppState for modal visibility

- **Main Loop Integration** (`src/main.rs`):
  - Calls `try_capture_forecast()` when volume header time is first set

## Notable Implementation Details

- **Rate Selection Cascade**: Predictions use library projection rates when available, fall back to VCP message rates, then to Method B fallback rates
- **Timing Flexibility**: Snapshot can be captured in either order—when VCP arrives or when volume start is set—via `try_capture_forecast()` guards
- **Dual Snapshot Storage**: Keeps both current and last volume forecasts so the modal remains useful immediately after volume completion
- **Plain-Text Serialization**: Snapshot exports to a formatted table with summary statistics, designed for easy pasting into collaborative tools
- **Mid-Prediction Capture**: When an elevation transitions to in-progress, the forecaster re-projects based on actual chunk arrival data
- **Error Statistics**: Computes mean, median, and max absolute error for duration and chunk count across completed sweeps

https://claude.ai/code/session_01X1iWaAd7KSKJgAoCPyxjfG