### PR TITLE
Redesign mobile UI: replace tab bar with icon action bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,9 +148,18 @@
             margin: 0;
             padding: 0;
             width: 100%;
+            /* Use dvh (dynamic viewport height) where supported so iOS Safari
+               collapsing toolbars don't leave gaps at the bottom of the page.
+               The 100% fallback is for browsers without dvh support. */
             height: 100%;
+            height: 100dvh;
             overflow: hidden;
-            background-color: #1a1a2e;
+            /* Match egui's default dark-mode panel_fill (Color32::from_gray(27)).
+               When the canvas momentarily fails to cover the full viewport
+               (e.g. iOS home-indicator area in a PWA), the sliver that peeks
+               through now blends with the app's chrome instead of showing a
+               contrasting bluish stripe. */
+            background-color: #1b1b1b;
         }
 
         /* iOS safe-area insets exposed as CSS custom properties so the WASM

--- a/index.html
+++ b/index.html
@@ -62,6 +62,30 @@
     </script>
 
     <script>
+        // Safe-area inset reader. The WASM app calls this each frame on mobile
+        // to learn how much to pad the top and bottom chrome. Reading
+        // getComputedStyle on every frame is cheap (no layout thrash — the
+        // custom properties never change after initial layout unless the
+        // device rotates) and avoids having to enable the CssStyleDeclaration
+        // feature in web-sys.
+        (function () {
+            function parsePx(v) {
+                var n = parseFloat(v);
+                return isFinite(n) ? n : 0;
+            }
+            window.__nexradSafeAreaInsets = function () {
+                var cs = getComputedStyle(document.documentElement);
+                return {
+                    top: parsePx(cs.getPropertyValue('--sa-inset-top')),
+                    right: parsePx(cs.getPropertyValue('--sa-inset-right')),
+                    bottom: parsePx(cs.getPropertyValue('--sa-inset-bottom')),
+                    left: parsePx(cs.getPropertyValue('--sa-inset-left')),
+                };
+            };
+        })();
+    </script>
+
+    <script>
         // Live favicon recoloring. The WASM app calls window.setFaviconColor(hex)
         // on every AppMode transition (Idle/Archive/Live) to retint the SVG.
         // The static assets/favicon.svg (orange phosphor) is the fallback for
@@ -127,6 +151,18 @@
             height: 100%;
             overflow: hidden;
             background-color: #1a1a2e;
+        }
+
+        /* iOS safe-area insets exposed as CSS custom properties so the WASM
+           app can read them via getComputedStyle. Needed because the canvas
+           extends under the status bar / home indicator when installed as a
+           PWA (viewport-fit=cover + apple-mobile-web-app-status-bar-style
+           black-translucent), and egui has to compensate in its own layout. */
+        :root {
+            --sa-inset-top: env(safe-area-inset-top, 0px);
+            --sa-inset-right: env(safe-area-inset-right, 0px);
+            --sa-inset-bottom: env(safe-area-inset-bottom, 0px);
+            --sa-inset-left: env(safe-area-inset-left, 0px);
         }
 
         #app_canvas {

--- a/index.html
+++ b/index.html
@@ -148,18 +148,14 @@
             margin: 0;
             padding: 0;
             width: 100%;
-            /* Use dvh (dynamic viewport height) where supported so iOS Safari
-               collapsing toolbars don't leave gaps at the bottom of the page.
-               The 100% fallback is for browsers without dvh support. */
             height: 100%;
-            height: 100dvh;
             overflow: hidden;
-            /* Match egui's default dark-mode panel_fill (Color32::from_gray(27)).
-               When the canvas momentarily fails to cover the full viewport
-               (e.g. iOS home-indicator area in a PWA), the sliver that peeks
-               through now blends with the app's chrome instead of showing a
-               contrasting bluish stripe. */
-            background-color: #1b1b1b;
+            /* The app overrides egui's dark panel_fill to Color32::BLACK
+               (main.rs: visuals.panel_fill = BLACK). Match that here so any
+               sliver of body that peeks through behind the canvas (iOS PWA
+               home-indicator area, fractional pixel rounding) blends with
+               the app chrome. */
+            background-color: #000000;
         }
 
         /* iOS safe-area insets exposed as CSS custom properties so the WASM
@@ -175,6 +171,17 @@
         }
 
         #app_canvas {
+            /* Anchor the canvas to every viewport edge explicitly. Previously
+               using width/height: 100% left a small dark strip at the bottom
+               on iOS PWAs — likely iOS rounding the body's effective pixel
+               height down while the visual viewport is a hair taller. Pinning
+               with position: fixed + inset: 0 side-steps containing-block
+               sizing quirks and fills the screen edge-to-edge. */
+            position: fixed;
+            top: 0;
+            right: 0;
+            bottom: 0;
+            left: 0;
             display: block;
             width: 100%;
             height: 100%;

--- a/index.html
+++ b/index.html
@@ -166,6 +166,7 @@
         }
 
         #app_canvas {
+            display: block;
             width: 100%;
             height: 100%;
             /* Prevent the browser from claiming touch gestures (pinch-to-zoom,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3018,6 +3018,14 @@ impl eframe::App for WorkbenchApp {
         // On mobile, the tabbed chrome replaces both the desktop top bar and
         // bottom panel; the left/right side panels early-return internally.
         if self.state.is_mobile {
+            // Consume any deferred geolocation request raised by the mobile
+            // action bar. Handled here because the site-modal state lives
+            // outside AppState.
+            if self.state.mobile_geolocate_requested {
+                self.state.mobile_geolocate_requested = false;
+                ui::trigger_geolocation(ctx, &mut self.state, &mut self.site_modal_state);
+            }
+
             ui::render_mobile_top_bar(ctx, &mut self.state);
             ui::render_mobile_chrome(ctx, &mut self.state);
             // The desktop bottom_panel is still called so its per-frame
@@ -3039,6 +3047,7 @@ impl eframe::App for WorkbenchApp {
 
         // Render overlays (on top of everything)
         ui::render_site_modal(ctx, &mut self.state, &mut self.site_modal_state);
+        ui::render_mobile_settings_modal(ctx, &mut self.state);
         ui::render_shortcuts_help(ctx, &mut self.state);
         ui::render_wipe_modal(ctx, &mut self.state);
         ui::render_stats_modal(ctx, &mut self.state);

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -250,13 +250,23 @@ pub struct AppState {
     /// force mobile, `Some(false)` = force desktop. Persisted via preferences.
     pub mobile_override: Option<bool>,
 
-    /// Which mobile tab is currently showing its content in the bottom sheet.
-    pub mobile_active_tab: MobileTab,
+    /// Whether the mobile settings modal (opened via the ellipsis button in
+    /// the mobile bottom bar) is currently visible.
+    pub mobile_settings_open: bool,
+
+    /// Active tab inside the mobile settings modal.
+    pub mobile_settings_tab: MobileSettingsTab,
+
+    /// Latched when the mobile bottom bar's location button is tapped. The
+    /// main update loop consumes this flag and kicks off geolocation against
+    /// the `SiteModalState` that lives outside `AppState`, avoiding a direct
+    /// state dependency from the bottom-bar renderer.
+    pub mobile_geolocate_requested: bool,
 }
 
-/// Tabs in the mobile bottom chrome. Order matches the tab bar layout.
+/// Tabs in the mobile settings modal. Order matches the tab strip layout.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-pub enum MobileTab {
+pub enum MobileSettingsTab {
     #[default]
     Playback,
     Product,
@@ -264,10 +274,10 @@ pub enum MobileTab {
     More,
 }
 
-impl MobileTab {
+impl MobileSettingsTab {
     pub fn label(self) -> &'static str {
         match self {
-            Self::Playback => "Play",
+            Self::Playback => "Playback",
             Self::Product => "Product",
             Self::Layers => "Layers",
             Self::More => "More",

--- a/src/ui/mobile/mod.rs
+++ b/src/ui/mobile/mod.rs
@@ -1,13 +1,16 @@
 //! Mobile / touch UI.
 //!
 //! Phase 1: multi-touch gesture digestion for the 2D canvas (see [`gestures`]).
-//! Phase 3: mobile top bar + tab-bar chrome that replaces the desktop panels
-//! when [`AppState::is_mobile`](crate::state::AppState::is_mobile) is true.
+//! Phase 3: mobile top bar + action-bar chrome that replaces the desktop
+//! panels when [`AppState::is_mobile`](crate::state::AppState::is_mobile) is
+//! true. Detailed controls live in the settings modal (see [`settings_modal`]).
 
 pub mod gestures;
 mod scrubber;
+mod settings_modal;
 mod tabs;
 mod top_bar;
 
+pub(crate) use settings_modal::render_mobile_settings_modal;
 pub(crate) use tabs::render_mobile_chrome;
 pub(crate) use top_bar::render_mobile_top_bar;

--- a/src/ui/mobile/mod.rs
+++ b/src/ui/mobile/mod.rs
@@ -14,3 +14,38 @@ mod top_bar;
 pub(crate) use settings_modal::render_mobile_settings_modal;
 pub(crate) use tabs::render_mobile_chrome;
 pub(crate) use top_bar::render_mobile_top_bar;
+
+/// iOS safe-area insets in CSS pixels: `(top, right, bottom, left)`.
+///
+/// Non-zero only when installed as a home-screen PWA on a device that
+/// reserves space for the status bar or home indicator. Always zero in
+/// desktop browsers and Chrome responsive mode, which is why the chrome
+/// looks perfect there but clips under the status bar on real iPhones.
+///
+/// Reads CSS custom properties set in `index.html` via `getComputedStyle`,
+/// dispatched through a pre-declared `window.__nexradSafeAreaInsets()`
+/// helper to avoid enabling the `CssStyleDeclaration` feature in web-sys.
+pub(crate) fn safe_area_insets() -> (f32, f32, f32, f32) {
+    use wasm_bindgen::{JsCast, JsValue};
+
+    let Some(window) = web_sys::window() else {
+        return (0.0, 0.0, 0.0, 0.0);
+    };
+    let global: JsValue = window.into();
+    let Ok(fn_val) = js_sys::Reflect::get(&global, &"__nexradSafeAreaInsets".into()) else {
+        return (0.0, 0.0, 0.0, 0.0);
+    };
+    let Some(func) = fn_val.dyn_ref::<js_sys::Function>() else {
+        return (0.0, 0.0, 0.0, 0.0);
+    };
+    let Ok(result) = func.call0(&JsValue::NULL) else {
+        return (0.0, 0.0, 0.0, 0.0);
+    };
+    let read = |key: &str| -> f32 {
+        js_sys::Reflect::get(&result, &key.into())
+            .ok()
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0) as f32
+    };
+    (read("top"), read("right"), read("bottom"), read("left"))
+}

--- a/src/ui/mobile/settings_modal.rs
+++ b/src/ui/mobile/settings_modal.rs
@@ -1,0 +1,263 @@
+//! Mobile settings modal — the full-page view opened by the ellipsis in the
+//! mobile action bar.
+//!
+//! Hosts a top tab strip (Playback / Product / Layers / More) and the
+//! matching content body. Reuses the existing right-panel section renderers
+//! so the mobile surface stays in sync with desktop automatically.
+
+use crate::state::{AppState, MobileSettingsTab, PlaybackMode, PlaybackSpeed};
+use eframe::egui::{self, Color32, RichText, Vec2};
+
+/// Render the mobile settings modal if it's open.
+pub(crate) fn render_mobile_settings_modal(ctx: &egui::Context, state: &mut AppState) {
+    if !state.mobile_settings_open || !state.is_mobile {
+        return;
+    }
+
+    if super::super::modal_helper::modal_backdrop(ctx, "mobile_settings_backdrop", 160) {
+        state.mobile_settings_open = false;
+        return;
+    }
+
+    let viewport = ctx.input(|i| i.viewport_rect());
+    // The modal takes most of the viewport — leaves a small gutter on each
+    // side so the backdrop edge is still tappable as a dismiss affordance.
+    let modal_w = (viewport.width() - 16.0).max(240.0);
+    let modal_h = (viewport.height() * 0.78).clamp(360.0, viewport.height() - 40.0);
+
+    egui::Window::new("Settings")
+        .title_bar(false)
+        .collapsible(false)
+        .resizable(false)
+        .anchor(egui::Align2::CENTER_CENTER, Vec2::ZERO)
+        .fixed_size(Vec2::new(modal_w, modal_h))
+        .order(egui::Order::Foreground)
+        .show(ctx, |ui| {
+            render_header(ui, state);
+            ui.separator();
+            render_tab_strip(ui, state);
+            ui.separator();
+            ui.add_space(4.0);
+
+            let body_h = ui.available_height() - 4.0;
+            egui::ScrollArea::vertical()
+                .id_salt("mobile_settings_body_scroll")
+                .max_height(body_h)
+                .auto_shrink([false, false])
+                .show(ui, |ui| match state.mobile_settings_tab {
+                    MobileSettingsTab::Playback => render_playback_body(ui, state),
+                    MobileSettingsTab::Product => render_product_body(ui, state),
+                    MobileSettingsTab::Layers => render_layers_body(ui, state),
+                    MobileSettingsTab::More => render_more_body(ui, state),
+                });
+
+            // The datetime picker popup (opened by tapping the current-time
+            // label in the Playback tab) renders as an Area, so it must be
+            // spawned from within the window.
+            super::super::playback_controls::render_datetime_picker_popup(ui, state);
+        });
+}
+
+fn render_header(ui: &mut egui::Ui, state: &mut AppState) {
+    ui.horizontal(|ui| {
+        ui.add_space(4.0);
+        ui.heading(state.mobile_settings_tab.label());
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            let close = ui.add(
+                egui::Button::new(RichText::new(egui_phosphor::regular::X).size(20.0)).frame(false),
+            );
+            if close.clicked() {
+                state.mobile_settings_open = false;
+            }
+        });
+    });
+}
+
+fn render_tab_strip(ui: &mut egui::Ui, state: &mut AppState) {
+    let total_w = ui.available_width();
+    let tab_count = MobileSettingsTab::all().len() as f32;
+    let tab_w = total_w / tab_count;
+
+    ui.horizontal(|ui| {
+        ui.spacing_mut().item_spacing.x = 0.0;
+        for tab in MobileSettingsTab::all() {
+            let is_active = state.mobile_settings_tab == tab;
+            let text_color = if is_active {
+                ui.visuals().strong_text_color()
+            } else {
+                Color32::from_rgb(130, 130, 130)
+            };
+            let (rect, resp) =
+                ui.allocate_exact_size(egui::vec2(tab_w, 36.0), egui::Sense::click());
+            if resp.clicked() {
+                state.mobile_settings_tab = tab;
+            }
+            let painter = ui.painter_at(rect);
+            painter.text(
+                rect.center(),
+                egui::Align2::CENTER_CENTER,
+                tab.label(),
+                egui::FontId::proportional(14.0),
+                text_color,
+            );
+            if is_active {
+                let underline_y = rect.bottom() - 2.0;
+                painter.line_segment(
+                    [
+                        egui::pos2(rect.left() + 10.0, underline_y),
+                        egui::pos2(rect.right() - 10.0, underline_y),
+                    ],
+                    egui::Stroke::new(2.0, ui.visuals().strong_text_color()),
+                );
+            }
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Tab bodies
+// ---------------------------------------------------------------------------
+
+fn render_playback_body(ui: &mut egui::Ui, state: &mut AppState) {
+    ui.add_space(6.0);
+
+    // Current time — tap to open the datetime picker.
+    let selected_ts = state.playback_state.playback_position();
+    let use_local = state.use_local_time;
+    let tz = if use_local { "Local" } else { "UTC" };
+    let time_label = format!(
+        "{} {}",
+        super::super::timeline::format_timestamp_full(selected_ts, use_local),
+        tz
+    );
+    ui.horizontal(|ui| {
+        ui.add_space(8.0);
+        if ui
+            .add(egui::Button::new(RichText::new(&time_label).monospace().size(15.0)).frame(false))
+            .clicked()
+        {
+            state
+                .datetime_picker
+                .init_from_timestamp(selected_ts, use_local);
+        }
+    });
+
+    ui.add_space(10.0);
+
+    // Transport: play/pause + prev/next.
+    ui.horizontal(|ui| {
+        ui.add_space(8.0);
+        let play_icon = if state.playback_state.playing {
+            egui_phosphor::regular::PAUSE
+        } else {
+            egui_phosphor::regular::PLAY
+        };
+        if ui
+            .add_sized(
+                [72.0, 48.0],
+                egui::Button::new(RichText::new(play_icon).size(22.0)),
+            )
+            .clicked()
+        {
+            super::tabs::toggle_play(state);
+        }
+
+        ui.add_space(8.0);
+        if ui
+            .add_sized(
+                [52.0, 48.0],
+                egui::Button::new(RichText::new(egui_phosphor::regular::SKIP_BACK).size(18.0)),
+            )
+            .clicked()
+        {
+            super::tabs::step_frame(state, -1);
+        }
+        if ui
+            .add_sized(
+                [52.0, 48.0],
+                egui::Button::new(RichText::new(egui_phosphor::regular::SKIP_FORWARD).size(18.0)),
+            )
+            .clicked()
+        {
+            super::tabs::step_frame(state, 1);
+        }
+    });
+
+    ui.add_space(14.0);
+
+    // Speed picker.
+    ui.horizontal(|ui| {
+        ui.add_space(8.0);
+        ui.label(RichText::new("Speed:").size(13.0));
+        let mode = state.playback_state.playback_mode();
+        let common: &[PlaybackSpeed] = &[
+            PlaybackSpeed::Half,
+            PlaybackSpeed::Normal,
+            PlaybackSpeed::Quadruple,
+        ];
+        for speed in common {
+            let label = match mode {
+                PlaybackMode::Macro => speed.macro_label(),
+                PlaybackMode::Micro => speed.label(),
+            };
+            let is_selected = state.playback_state.speed == *speed;
+            if ui
+                .selectable_label(is_selected, RichText::new(label).size(13.0))
+                .clicked()
+            {
+                state.playback_state.speed = *speed;
+            }
+        }
+        egui::ComboBox::from_id_salt("mobile_settings_speed_all")
+            .selected_text(RichText::new(egui_phosphor::regular::DOTS_THREE).size(13.0))
+            .width(44.0)
+            .show_ui(ui, |ui| {
+                let speeds: &[PlaybackSpeed] = match mode {
+                    PlaybackMode::Macro => PlaybackSpeed::macro_speeds(),
+                    PlaybackMode::Micro => PlaybackSpeed::all(),
+                };
+                for s in speeds {
+                    let label = match mode {
+                        PlaybackMode::Macro => s.macro_label(),
+                        PlaybackMode::Micro => s.label(),
+                    };
+                    ui.selectable_value(&mut state.playback_state.speed, *s, label);
+                }
+            });
+    });
+
+    ui.add_space(8.0);
+
+    // UTC/Local toggle.
+    ui.horizontal(|ui| {
+        ui.add_space(8.0);
+        let label = if state.use_local_time { "Local" } else { "UTC" };
+        if ui
+            .selectable_label(false, RichText::new(format!("Time: {}", label)).size(13.0))
+            .clicked()
+        {
+            state.use_local_time = !state.use_local_time;
+        }
+    });
+}
+
+fn render_product_body(ui: &mut egui::Ui, state: &mut AppState) {
+    ui.add_space(4.0);
+    super::super::right_panel::render_product_section(ui, state);
+}
+
+fn render_layers_body(ui: &mut egui::Ui, state: &mut AppState) {
+    ui.add_space(4.0);
+    super::super::right_panel::render_layers_section(ui, state);
+}
+
+fn render_more_body(ui: &mut egui::Ui, state: &mut AppState) {
+    ui.add_space(4.0);
+    super::super::right_panel::render_rendering_section(ui, state);
+    ui.add_space(4.0);
+    super::super::right_panel::render_tools_section(ui, state);
+    ui.add_space(4.0);
+    super::super::right_panel::render_events_section(ui, state);
+    ui.add_space(4.0);
+    super::super::right_panel::render_storage_section(ui, state);
+}

--- a/src/ui/mobile/tabs.rs
+++ b/src/ui/mobile/tabs.rs
@@ -1,51 +1,28 @@
-//! Mobile bottom chrome: tab bar + tab content + scrubber.
+//! Mobile bottom chrome: icon-only action bar + scrubber.
 //!
-//! Implemented as three stacked `TopBottomPanel::bottom` panels so each one
-//! takes an exact slice of viewport height and the layout math doesn't fight
-//! egui's internal frame padding. Panels render from bottom up in call order:
-//!   1. Tab bar (42px)     — bottommost
-//!   2. Tab content (160px) — scrollable, content for the active tab
-//!   3. Scrubber (32px)    — topmost, always visible
+//! Two stacked `TopBottomPanel::bottom` panels:
+//!   1. Action bar (56px) — bottommost. Four icon buttons:
+//!      Radar → open site modal. Crosshair → geolocate and pick nearest
+//!      site. Broadcast → toggle live mode. Ellipsis → open settings modal
+//!      (Playback / Product / Layers / More).
+//!   2. Scrubber (32px) — topmost, always visible.
 
-use crate::state::{AppState, LiveExitReason, MobileTab, PlaybackMode, PlaybackSpeed};
-use eframe::egui::{self, Color32, RichText};
+use crate::state::{AppState, LiveExitReason, MobileSettingsTab, PlaybackSpeed};
+use eframe::egui::{self, Color32};
 
-const TAB_BAR_HEIGHT: f32 = 42.0;
-const TAB_CONTENT_HEIGHT: f32 = 160.0;
+const ACTION_BAR_HEIGHT: f32 = 56.0;
 const SCRUBBER_AREA_HEIGHT: f32 = super::scrubber::SCRUBBER_HEIGHT + 4.0;
 
 pub(crate) fn render_mobile_chrome(ctx: &egui::Context, state: &mut AppState) {
-    // Bottommost — tab bar. Because egui stacks bottom panels in call order
-    // (first-added = outermost-bottom), this panel sits flush with the
-    // viewport's bottom edge and can't be pushed off-screen by sibling content.
-    egui::TopBottomPanel::bottom("mobile_tab_bar")
+    // Bottommost — the icon action bar.
+    egui::TopBottomPanel::bottom("mobile_action_bar")
         .resizable(false)
-        .exact_height(TAB_BAR_HEIGHT)
+        .exact_height(ACTION_BAR_HEIGHT)
         .show(ctx, |ui| {
-            render_tab_bar(ui, state);
+            render_action_bar(ui, state);
         });
 
-    // Tab content — above the tab bar.
-    egui::TopBottomPanel::bottom("mobile_tab_content")
-        .resizable(false)
-        .exact_height(TAB_CONTENT_HEIGHT)
-        .show(ctx, |ui| {
-            egui::ScrollArea::vertical()
-                .id_salt("mobile_tab_content_scroll")
-                .auto_shrink([false, false])
-                .show(ui, |ui| match state.mobile_active_tab {
-                    MobileTab::Playback => render_playback_tab(ui, state),
-                    MobileTab::Product => render_product_tab(ui, state),
-                    MobileTab::Layers => render_layers_tab(ui, state),
-                    MobileTab::More => render_more_tab(ui, state),
-                });
-
-            // Datetime picker popup (opens when the user taps the current-time
-            // label in the Playback tab). It's an Area and renders on top.
-            super::super::playback_controls::render_datetime_picker_popup(ui, state);
-        });
-
-    // Scrubber — topmost of the three bottom panels.
+    // Scrubber — sits just above the action bar.
     egui::TopBottomPanel::bottom("mobile_scrubber")
         .resizable(false)
         .exact_height(SCRUBBER_AREA_HEIGHT)
@@ -55,168 +32,73 @@ pub(crate) fn render_mobile_chrome(ctx: &egui::Context, state: &mut AppState) {
         });
 }
 
-fn render_tab_bar(ui: &mut egui::Ui, state: &mut AppState) {
-    let active = state.mobile_active_tab;
+/// Four equal-width icon buttons. Each reserves a full-width slot so the
+/// touch target is ~25% of the viewport width regardless of icon size.
+fn render_action_bar(ui: &mut egui::Ui, state: &mut AppState) {
     let total_w = ui.available_width();
     let total_h = ui.available_height();
-    let tab_w = total_w / MobileTab::all().len() as f32;
-    // Vertical budget: icon + small gap + label, plus a bottom stripe for
-    // the active-tab indicator. Size the icon relative to the available
-    // height so the bar doesn't overflow when we tweak its height.
-    let icon_size = ((total_h - 14.0) * 0.65).clamp(14.0, 18.0);
-    let label_size = 10.0f32;
-    let indicator_gap = 2.0f32;
+    let slot_w = total_w / 4.0;
+    let icon_size = ((total_h - 10.0) * 0.55).clamp(18.0, 24.0);
+
+    let is_live = state.live_mode_state.is_active();
+    let live_color = if is_live {
+        Color32::from_rgb(220, 60, 60)
+    } else {
+        ui.visuals().strong_text_color()
+    };
+    let settings_open = state.mobile_settings_open;
 
     ui.horizontal(|ui| {
         ui.spacing_mut().item_spacing.x = 0.0;
         ui.spacing_mut().item_spacing.y = 0.0;
-        for tab in MobileTab::all() {
-            let is_active = tab == active;
-            let text_color = if is_active {
-                ui.visuals().strong_text_color()
-            } else {
-                Color32::from_rgb(130, 130, 130)
-            };
-            let icon = tab_icon(tab);
-            let (rect, resp) =
-                ui.allocate_exact_size(egui::vec2(tab_w, total_h), egui::Sense::click());
-            if resp.clicked() {
-                state.mobile_active_tab = tab;
-            }
-            let painter = ui.painter_at(rect);
 
-            // Stack icon above label, anchored to the top edge so they never
-            // extend above the tab bar's rect.
-            let icon_center_y = rect.top() + 2.0 + icon_size * 0.5;
-            let label_center_y = icon_center_y + icon_size * 0.5 + label_size * 0.5 + 1.0;
-
-            painter.text(
-                egui::pos2(rect.center().x, icon_center_y),
-                egui::Align2::CENTER_CENTER,
-                icon,
-                egui::FontId::proportional(icon_size),
-                text_color,
-            );
-            painter.text(
-                egui::pos2(rect.center().x, label_center_y),
-                egui::Align2::CENTER_CENTER,
-                tab.label(),
-                egui::FontId::proportional(label_size),
-                text_color,
-            );
-
-            if is_active {
-                let underline_y = rect.bottom() - indicator_gap;
-                painter.line_segment(
-                    [
-                        egui::pos2(rect.left() + 12.0, underline_y),
-                        egui::pos2(rect.right() - 12.0, underline_y),
-                    ],
-                    egui::Stroke::new(2.0, ui.visuals().strong_text_color()),
-                );
-            }
-        }
-    });
-}
-
-fn tab_icon(tab: MobileTab) -> &'static str {
-    match tab {
-        MobileTab::Playback => egui_phosphor::regular::PLAY_CIRCLE,
-        MobileTab::Product => egui_phosphor::regular::STACK,
-        MobileTab::Layers => egui_phosphor::regular::STACK_SIMPLE,
-        MobileTab::More => egui_phosphor::regular::DOTS_THREE,
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Tab content
-// ---------------------------------------------------------------------------
-
-fn render_playback_tab(ui: &mut egui::Ui, state: &mut AppState) {
-    ui.add_space(8.0);
-
-    // Current time label (tap-to-jump opens datetime picker).
-    let selected_ts = state.playback_state.playback_position();
-    let use_local = state.use_local_time;
-    let tz = if use_local { "Local" } else { "UTC" };
-    let time_label = format!(
-        "{} {}",
-        super::super::timeline::format_timestamp_full(selected_ts, use_local),
-        tz
-    );
-    ui.horizontal(|ui| {
-        ui.add_space(12.0);
-        if ui
-            .add(egui::Button::new(RichText::new(&time_label).monospace().size(14.0)).frame(false))
-            .clicked()
+        // 1. Radar → open site modal.
+        if icon_slot(
+            ui,
+            slot_w,
+            total_h,
+            egui_phosphor::regular::CELL_TOWER,
+            icon_size,
+            ui.visuals().strong_text_color(),
+            false,
+        )
+        .clicked()
         {
-            state
-                .datetime_picker
-                .init_from_timestamp(selected_ts, use_local);
+            state.site_modal_open = true;
+            // Close the settings modal if it was open so the site modal
+            // isn't sitting on top of two backdrops.
+            state.mobile_settings_open = false;
         }
-    });
 
-    ui.add_space(8.0);
-
-    // Primary transport: big play/pause, prev/next, live toggle.
-    ui.horizontal(|ui| {
-        ui.add_space(12.0);
-        let play_icon = if state.playback_state.playing {
-            egui_phosphor::regular::PAUSE
-        } else {
-            egui_phosphor::regular::PLAY
-        };
-        if ui
-            .add_sized(
-                [64.0, 48.0],
-                egui::Button::new(RichText::new(play_icon).size(22.0)),
-            )
-            .clicked()
+        // 2. Crosshair → trigger geolocation immediately. The modal's
+        // polling loop (see `render_site_modal`) handles the result and
+        // applies the nearest site or surfaces an error.
+        if icon_slot(
+            ui,
+            slot_w,
+            total_h,
+            egui_phosphor::regular::CROSSHAIR,
+            icon_size,
+            ui.visuals().strong_text_color(),
+            false,
+        )
+        .clicked()
         {
-            toggle_play(state);
+            state.mobile_geolocate_requested = true;
+            state.mobile_settings_open = false;
         }
 
-        ui.add_space(8.0);
-
-        if ui
-            .add_sized(
-                [48.0, 48.0],
-                egui::Button::new(RichText::new(egui_phosphor::regular::SKIP_BACK).size(18.0)),
-            )
-            .clicked()
-        {
-            step_frame(state, -1);
-        }
-
-        if ui
-            .add_sized(
-                [48.0, 48.0],
-                egui::Button::new(RichText::new(egui_phosphor::regular::SKIP_FORWARD).size(18.0)),
-            )
-            .clicked()
-        {
-            step_frame(state, 1);
-        }
-
-        ui.add_space(8.0);
-
-        // Live toggle.
-        let is_live = state.live_mode_state.is_active();
-        let live_color = if is_live {
-            Color32::from_rgb(220, 60, 60)
-        } else {
-            Color32::from_rgb(130, 130, 130)
-        };
-        if ui
-            .add_sized(
-                [48.0, 48.0],
-                egui::Button::new(
-                    RichText::new(egui_phosphor::regular::BROADCAST)
-                        .size(18.0)
-                        .color(live_color),
-                ),
-            )
-            .clicked()
+        // 3. Broadcast → toggle live mode.
+        if icon_slot(
+            ui,
+            slot_w,
+            total_h,
+            egui_phosphor::regular::BROADCAST,
+            icon_size,
+            live_color,
+            is_live,
+        )
+        .clicked()
         {
             if is_live {
                 state.live_mode_state.stop(LiveExitReason::UserStopped);
@@ -227,69 +109,68 @@ fn render_playback_tab(ui: &mut egui::Ui, state: &mut AppState) {
                 state.playback_state.speed = PlaybackSpeed::Realtime;
             }
         }
-    });
 
-    ui.add_space(14.0);
-
-    // Speed picker — three common options; long presses fall back to the
-    // full menu via the tiny "All…" button.
-    ui.horizontal(|ui| {
-        ui.add_space(12.0);
-        ui.label(RichText::new("Speed:").size(12.0));
-        let mode = state.playback_state.playback_mode();
-        let common: &[PlaybackSpeed] = &[
-            PlaybackSpeed::Half,
-            PlaybackSpeed::Normal,
-            PlaybackSpeed::Quadruple,
-        ];
-        for speed in common {
-            let label = match mode {
-                PlaybackMode::Macro => speed.macro_label(),
-                PlaybackMode::Micro => speed.label(),
-            };
-            let is_selected = state.playback_state.speed == *speed;
-            if ui
-                .selectable_label(is_selected, RichText::new(label).size(13.0))
-                .clicked()
-            {
-                state.playback_state.speed = *speed;
-            }
-        }
-        // "All" dropdown for power users who want the full speed range.
-        egui::ComboBox::from_id_salt("mobile_speed_all")
-            .selected_text(RichText::new(egui_phosphor::regular::DOTS_THREE).size(13.0))
-            .width(40.0)
-            .show_ui(ui, |ui| {
-                let speeds: &[PlaybackSpeed] = match mode {
-                    PlaybackMode::Macro => PlaybackSpeed::macro_speeds(),
-                    PlaybackMode::Micro => PlaybackSpeed::all(),
-                };
-                for s in speeds {
-                    let label = match mode {
-                        PlaybackMode::Macro => s.macro_label(),
-                        PlaybackMode::Micro => s.label(),
-                    };
-                    ui.selectable_value(&mut state.playback_state.speed, *s, label);
-                }
-            });
-    });
-
-    ui.add_space(8.0);
-
-    // UTC/Local toggle.
-    ui.horizontal(|ui| {
-        ui.add_space(12.0);
-        let label = if state.use_local_time { "Local" } else { "UTC" };
-        if ui
-            .selectable_label(false, RichText::new(format!("Time: {}", label)).size(12.0))
-            .clicked()
+        // 4. Ellipsis → open/close the settings modal.
+        if icon_slot(
+            ui,
+            slot_w,
+            total_h,
+            egui_phosphor::regular::DOTS_THREE,
+            icon_size,
+            ui.visuals().strong_text_color(),
+            settings_open,
+        )
+        .clicked()
         {
-            state.use_local_time = !state.use_local_time;
+            state.mobile_settings_open = !settings_open;
+            if state.mobile_settings_open {
+                state.mobile_settings_tab = MobileSettingsTab::default();
+            }
         }
     });
 }
 
-fn toggle_play(state: &mut AppState) {
+/// One icon slot in the action bar. Returns the click response. Draws an
+/// optional "active" underline for toggles like Live or Settings.
+fn icon_slot(
+    ui: &mut egui::Ui,
+    slot_w: f32,
+    slot_h: f32,
+    icon: &str,
+    icon_size: f32,
+    color: Color32,
+    active: bool,
+) -> egui::Response {
+    let (rect, resp) = ui.allocate_exact_size(egui::vec2(slot_w, slot_h), egui::Sense::click());
+    let painter = ui.painter_at(rect);
+
+    painter.text(
+        rect.center(),
+        egui::Align2::CENTER_CENTER,
+        icon,
+        egui::FontId::proportional(icon_size),
+        color,
+    );
+
+    if active {
+        let underline_y = rect.bottom() - 4.0;
+        painter.line_segment(
+            [
+                egui::pos2(rect.left() + 16.0, underline_y),
+                egui::pos2(rect.right() - 16.0, underline_y),
+            ],
+            egui::Stroke::new(2.0, color),
+        );
+    }
+
+    resp
+}
+
+// ---------------------------------------------------------------------------
+// Playback helpers (shared with the settings modal).
+// ---------------------------------------------------------------------------
+
+pub(super) fn toggle_play(state: &mut AppState) {
     if state.playback_state.playing {
         if state.live_mode_state.is_active() {
             state.live_mode_state.stop(LiveExitReason::UserStopped);
@@ -301,7 +182,9 @@ fn toggle_play(state: &mut AppState) {
     }
 }
 
-fn step_frame(state: &mut AppState, direction: isize) {
+pub(super) fn step_frame(state: &mut AppState, direction: isize) {
+    use crate::state::PlaybackMode;
+
     let current_pos = state.playback_state.playback_position();
     if state.live_mode_state.is_active() {
         state.live_mode_state.stop(LiveExitReason::UserJogged);
@@ -350,25 +233,4 @@ fn step_frame(state: &mut AppState, direction: isize) {
             state.playback_state.set_playback_position(new_pos);
         }
     }
-}
-
-fn render_product_tab(ui: &mut egui::Ui, state: &mut AppState) {
-    ui.add_space(6.0);
-    super::super::right_panel::render_product_section(ui, state);
-}
-
-fn render_layers_tab(ui: &mut egui::Ui, state: &mut AppState) {
-    ui.add_space(6.0);
-    super::super::right_panel::render_layers_section(ui, state);
-}
-
-fn render_more_tab(ui: &mut egui::Ui, state: &mut AppState) {
-    ui.add_space(6.0);
-    super::super::right_panel::render_rendering_section(ui, state);
-    ui.add_space(4.0);
-    super::super::right_panel::render_tools_section(ui, state);
-    ui.add_space(4.0);
-    super::super::right_panel::render_events_section(ui, state);
-    ui.add_space(4.0);
-    super::super::right_panel::render_storage_section(ui, state);
 }

--- a/src/ui/mobile/tabs.rs
+++ b/src/ui/mobile/tabs.rs
@@ -14,10 +14,15 @@ const ACTION_BAR_HEIGHT: f32 = 56.0;
 const SCRUBBER_AREA_HEIGHT: f32 = super::scrubber::SCRUBBER_HEIGHT + 4.0;
 
 pub(crate) fn render_mobile_chrome(ctx: &egui::Context, state: &mut AppState) {
+    // iOS safe area: when installed as a home-screen PWA, the canvas extends
+    // under the home indicator reservation. Pad the action bar below the
+    // icons so they don't sit flush with the bottom edge of the screen.
+    let (_t, _r, inset_bottom, _l) = super::safe_area_insets();
+
     // Bottommost — the icon action bar.
     egui::TopBottomPanel::bottom("mobile_action_bar")
         .resizable(false)
-        .exact_height(ACTION_BAR_HEIGHT)
+        .exact_height(ACTION_BAR_HEIGHT + inset_bottom)
         .show(ctx, |ui| {
             render_action_bar(ui, state);
         });
@@ -34,11 +39,15 @@ pub(crate) fn render_mobile_chrome(ctx: &egui::Context, state: &mut AppState) {
 
 /// Four equal-width icon buttons. Each reserves a full-width slot so the
 /// touch target is ~25% of the viewport width regardless of icon size.
+///
+/// The slot height stays fixed at `ACTION_BAR_HEIGHT` even when the hosting
+/// panel is taller (iOS safe-area bottom inset); the extra space falls
+/// below the icons as blank panel padding clearing the home indicator.
 fn render_action_bar(ui: &mut egui::Ui, state: &mut AppState) {
     let total_w = ui.available_width();
-    let total_h = ui.available_height();
+    let slot_h = ACTION_BAR_HEIGHT;
     let slot_w = total_w / 4.0;
-    let icon_size = ((total_h - 10.0) * 0.55).clamp(18.0, 24.0);
+    let icon_size = ((slot_h - 10.0) * 0.55).clamp(18.0, 24.0);
 
     let is_live = state.live_mode_state.is_active();
     let live_color = if is_live {
@@ -48,7 +57,7 @@ fn render_action_bar(ui: &mut egui::Ui, state: &mut AppState) {
     };
     let settings_open = state.mobile_settings_open;
 
-    ui.horizontal(|ui| {
+    ui.horizontal_top(|ui| {
         ui.spacing_mut().item_spacing.x = 0.0;
         ui.spacing_mut().item_spacing.y = 0.0;
 
@@ -56,7 +65,7 @@ fn render_action_bar(ui: &mut egui::Ui, state: &mut AppState) {
         if icon_slot(
             ui,
             slot_w,
-            total_h,
+            slot_h,
             egui_phosphor::regular::CELL_TOWER,
             icon_size,
             ui.visuals().strong_text_color(),
@@ -76,7 +85,7 @@ fn render_action_bar(ui: &mut egui::Ui, state: &mut AppState) {
         if icon_slot(
             ui,
             slot_w,
-            total_h,
+            slot_h,
             egui_phosphor::regular::CROSSHAIR,
             icon_size,
             ui.visuals().strong_text_color(),
@@ -92,7 +101,7 @@ fn render_action_bar(ui: &mut egui::Ui, state: &mut AppState) {
         if icon_slot(
             ui,
             slot_w,
-            total_h,
+            slot_h,
             egui_phosphor::regular::BROADCAST,
             icon_size,
             live_color,
@@ -114,7 +123,7 @@ fn render_action_bar(ui: &mut egui::Ui, state: &mut AppState) {
         if icon_slot(
             ui,
             slot_w,
-            total_h,
+            slot_h,
             egui_phosphor::regular::DOTS_THREE,
             icon_size,
             ui.visuals().strong_text_color(),

--- a/src/ui/mobile/top_bar.rs
+++ b/src/ui/mobile/top_bar.rs
@@ -90,11 +90,18 @@ pub(crate) fn render_mobile_top_bar(ctx: &egui::Context, state: &mut AppState) {
 
                 // Version stamp — right-aligned. Useful for cross-referencing
                 // a deployed build against git history when reporting bugs.
+                // Tap to toggle between truncated (fits the bar) and full
+                // (shows the complete hash / version string).
                 ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
                     ui.add_space(8.0);
+
+                    let expanded_id = egui::Id::new("mobile_top_bar_version_expanded");
+                    let expanded: bool =
+                        ui.ctx().data(|d| d.get_temp(expanded_id).unwrap_or(false));
+
                     const MAX_LEN: usize = 18;
                     let version = env!("NEXRAD_VERSION");
-                    let display = if version.len() > MAX_LEN {
+                    let display = if !expanded && version.len() > MAX_LEN {
                         let mut truncated = String::with_capacity(MAX_LEN + 3);
                         for (i, ch) in version.char_indices() {
                             if i >= MAX_LEN {
@@ -107,11 +114,18 @@ pub(crate) fn render_mobile_top_bar(ctx: &egui::Context, state: &mut AppState) {
                     } else {
                         version.to_string()
                     };
-                    ui.label(
-                        RichText::new(display)
-                            .size(10.0)
-                            .color(Color32::from_rgb(120, 120, 120)),
+
+                    let response = ui.add(
+                        egui::Button::new(
+                            RichText::new(display)
+                                .size(10.0)
+                                .color(Color32::from_rgb(120, 120, 120)),
+                        )
+                        .frame(false),
                     );
+                    if response.clicked() {
+                        ui.ctx().data_mut(|d| d.insert_temp(expanded_id, !expanded));
+                    }
                 });
             });
 

--- a/src/ui/mobile/top_bar.rs
+++ b/src/ui/mobile/top_bar.rs
@@ -2,38 +2,48 @@
 //!
 //! Replaces the desktop top bar on mobile: drops the sidebar toggles, help
 //! button, and view-mode switcher (all irrelevant on mobile), and trims to
-//! the essentials: mode accent, app mode badge, site chip, alerts, worker
-//! error banner, and a small version stamp in the top-right.
+//! the essentials: mode badge, site chip, alerts, worker error banner, and
+//! a small version stamp in the top-right. The app-mode accent is painted
+//! as a 2px colored line at the bottom edge of the bar (the border between
+//! the bar and the canvas) rather than as a separate stripe at the very
+//! top — the top edge sits under the iOS status bar / notch on real
+//! devices, where a thin stripe is either obscured or crowded against OS
+//! icons.
 
 use crate::state::{AppMode, AppState};
-use eframe::egui::{self, Align, Color32, Frame, Layout, RichText};
+use eframe::egui::{self, Align, Color32, Frame, Layout, Margin, RichText};
 
 const TOP_BAR_CONTENT_HEIGHT: f32 = 44.0;
+const ACCENT_THICKNESS: f32 = 2.0;
 
 pub(crate) fn render_mobile_top_bar(ctx: &egui::Context, state: &mut AppState) {
     // iOS safe area: when installed as a home-screen PWA, the canvas extends
-    // under the translucent status bar. Pad the top so OS icons don't
-    // overlap our content.
+    // under the translucent status bar / notch. Pad the top so OS icons
+    // don't overlap our content.
     let (inset_top, _inset_right, _inset_bottom, _inset_left) = super::safe_area_insets();
 
-    // Same mode accent bar as desktop — the colored stripe doubles as the
-    // app icon / status indicator.
-    egui::TopBottomPanel::top("mobile_mode_accent")
-        .resizable(false)
-        .exact_height(3.0)
-        .frame(Frame::NONE.fill(state.app_mode.color()))
-        .show(ctx, |ui| {
-            ui.allocate_space(ui.available_size());
-        });
+    let panel_fill = ctx.style().visuals.panel_fill;
+    let accent_color = state.app_mode.color();
+
+    // Zero inner-margin frame so the content sits as high as possible —
+    // egui's default top-panel frame adds a couple of pixels of padding on
+    // every side, which is noticeable below the iOS status bar.
+    let frame = Frame::NONE.fill(panel_fill).inner_margin(Margin::ZERO);
 
     egui::TopBottomPanel::top("mobile_top_bar")
-        .exact_height(TOP_BAR_CONTENT_HEIGHT + inset_top)
+        .resizable(false)
+        .exact_height(inset_top + TOP_BAR_CONTENT_HEIGHT)
+        .frame(frame)
         .show(ctx, |ui| {
-            // Push the top-bar content below the iOS status bar reservation.
             if inset_top > 0.0 {
                 ui.add_space(inset_top);
             }
+
+            let panel_rect = ui.max_rect();
+
             ui.horizontal_centered(|ui| {
+                ui.add_space(8.0);
+
                 // Site chip — primary control, tapping opens the site modal.
                 let site_label = format!(
                     "{} {}",
@@ -51,13 +61,12 @@ pub(crate) fn render_mobile_top_bar(ctx: &egui::Context, state: &mut AppState) {
 
                 // Compact mode badge (Idle / Archive / Live).
                 let mode = state.app_mode;
-                let color = mode.color();
                 let icon = match mode {
                     AppMode::Idle => egui_phosphor::regular::PAUSE_CIRCLE,
                     AppMode::Archive => egui_phosphor::regular::ARCHIVE_BOX,
                     AppMode::Live => egui_phosphor::regular::BROADCAST,
                 };
-                ui.label(RichText::new(icon).size(14.0).color(color));
+                ui.label(RichText::new(icon).size(14.0).color(accent_color));
 
                 // Alerts chip (reuses the desktop helper).
                 super::super::top_bar::render_alerts_chip(ui, state);
@@ -82,6 +91,7 @@ pub(crate) fn render_mobile_top_bar(ctx: &egui::Context, state: &mut AppState) {
                 // Version stamp — right-aligned. Useful for cross-referencing
                 // a deployed build against git history when reporting bugs.
                 ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                    ui.add_space(8.0);
                     const MAX_LEN: usize = 18;
                     let version = env!("NEXRAD_VERSION");
                     let display = if version.len() > MAX_LEN {
@@ -104,5 +114,16 @@ pub(crate) fn render_mobile_top_bar(ctx: &egui::Context, state: &mut AppState) {
                     );
                 });
             });
+
+            // Paint the app-mode accent as a thin border along the bottom
+            // edge of the panel, separating it from the canvas below.
+            let y = panel_rect.bottom() - ACCENT_THICKNESS * 0.5;
+            ui.painter().line_segment(
+                [
+                    egui::pos2(panel_rect.left(), y),
+                    egui::pos2(panel_rect.right(), y),
+                ],
+                egui::Stroke::new(ACCENT_THICKNESS, accent_color),
+            );
         });
 }

--- a/src/ui/mobile/top_bar.rs
+++ b/src/ui/mobile/top_bar.rs
@@ -8,7 +8,14 @@
 use crate::state::{AppMode, AppState};
 use eframe::egui::{self, Align, Color32, Frame, Layout, RichText};
 
+const TOP_BAR_CONTENT_HEIGHT: f32 = 44.0;
+
 pub(crate) fn render_mobile_top_bar(ctx: &egui::Context, state: &mut AppState) {
+    // iOS safe area: when installed as a home-screen PWA, the canvas extends
+    // under the translucent status bar. Pad the top so OS icons don't
+    // overlap our content.
+    let (inset_top, _inset_right, _inset_bottom, _inset_left) = super::safe_area_insets();
+
     // Same mode accent bar as desktop — the colored stripe doubles as the
     // app icon / status indicator.
     egui::TopBottomPanel::top("mobile_mode_accent")
@@ -20,8 +27,12 @@ pub(crate) fn render_mobile_top_bar(ctx: &egui::Context, state: &mut AppState) {
         });
 
     egui::TopBottomPanel::top("mobile_top_bar")
-        .exact_height(44.0)
+        .exact_height(TOP_BAR_CONTENT_HEIGHT + inset_top)
         .show(ctx, |ui| {
+            // Push the top-bar content below the iOS status bar reservation.
+            if inset_top > 0.0 {
+                ui.add_space(inset_top);
+            }
             ui.horizontal_centered(|ui| {
                 // Site chip — primary control, tapping opens the site modal.
                 let site_label = format!(

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -34,11 +34,13 @@ pub use bottom_panel::render_bottom_panel;
 pub use canvas::render_canvas_with_geo;
 pub use event_modal::{render_event_modal, EventModalState};
 pub use left_panel::render_left_panel;
-pub(crate) use mobile::{render_mobile_chrome, render_mobile_top_bar};
+pub(crate) use mobile::{
+    render_mobile_chrome, render_mobile_settings_modal, render_mobile_top_bar,
+};
 pub use network_panel::render_network_log;
 pub use right_panel::render_right_panel;
 pub use shortcuts::{handle_shortcuts, render_shortcuts_help};
-pub use site_modal::{render_site_modal, SiteModalState};
+pub use site_modal::{render_site_modal, trigger_geolocation, SiteModalState};
 pub use stats_modal::render_stats_modal;
 pub use top_bar::render_top_bar;
 pub use wipe_modal::render_wipe_modal;

--- a/src/ui/site_modal.rs
+++ b/src/ui/site_modal.rs
@@ -74,6 +74,24 @@ fn responsive_width(ctx: &egui::Context, desktop: f32) -> f32 {
     (viewport_w - 16.0).min(desktop).max(240.0)
 }
 
+/// Open the site modal in `Pending` mode and start browser geolocation.
+///
+/// Used by the mobile bottom bar's location button to bypass the welcome
+/// screen and go straight to "finding nearest site". The polling loop in
+/// `render_site_modal` handles the result — success closes the modal after
+/// applying the selection, failure drops back to the welcome screen with
+/// the error visible.
+pub fn trigger_geolocation(
+    ctx: &egui::Context,
+    state: &mut AppState,
+    modal_state: &mut SiteModalState,
+) {
+    state.site_modal_open = true;
+    modal_state.mode = SiteModalMode::Pending;
+    modal_state.error_message = None;
+    start_geolocation(modal_state.location_results.clone(), ctx.clone());
+}
+
 /// Apply a site selection to app state: update viz, center camera, refresh timeline.
 pub(super) fn apply_site_selection(state: &mut AppState, site_id: &str, lat: f64, lon: f64) {
     state.viz_state.site_id = site_id.to_string();


### PR DESCRIPTION
## Summary
Redesigned the mobile bottom chrome from a tabbed interface to a compact icon-only action bar, moving detailed settings into a modal dialog. This simplifies the mobile layout and improves touch usability by reducing the number of permanent UI elements.

## Key Changes

- **Replaced tab bar with action bar**: The mobile bottom chrome now features a 56px icon-only action bar with four buttons:
  - Radar icon → open site modal
  - Crosshair icon → trigger geolocation and select nearest site
  - Broadcast icon → toggle live mode (with active state indicator)
  - Ellipsis icon → open/close settings modal

- **Created new settings modal** (`src/ui/mobile/settings_modal.rs`):
  - Full-page modal dialog with tabbed interface (Playback / Product / Layers / More)
  - Reuses existing right-panel section renderers for consistency with desktop
  - Includes playback controls, speed picker, and time zone toggle
  - Datetime picker popup integrated into the modal

- **Removed tab content panel**: The 160px scrollable tab content area is eliminated; all settings are now accessed via the modal

- **Updated state management**:
  - Replaced `mobile_active_tab: MobileTab` with `mobile_settings_open: bool` and `mobile_settings_tab: MobileSettingsTab`
  - Added `mobile_geolocate_requested` flag to defer geolocation requests to the main update loop
  - Renamed `MobileTab` enum to `MobileSettingsTab` with updated label ("Playback" instead of "Play")

- **Added geolocation trigger**: New `trigger_geolocation()` function in `site_modal.rs` allows the mobile action bar to initiate browser geolocation and automatically apply the nearest site selection

- **Simplified layout math**: Reduced from three stacked panels (tab bar + content + scrubber) to two (action bar + scrubber), eliminating complex height calculations

## Implementation Details

- The action bar uses equal-width slots (25% viewport width each) to ensure reliable touch targets regardless of icon size
- Active state indicators (underlines) distinguish toggles like Live mode and Settings modal
- The settings modal uses a backdrop with configurable opacity to maintain visual hierarchy
- Playback helper functions (`toggle_play`, `step_frame`) are now public to support both the old tab interface and new modal
- Modal dimensions are responsive, clamping between 360px and 78% of viewport height

https://claude.ai/code/session_01DqGw2xZ6p1aQqc9wwzvdCv