### PR TITLE
Support "B" waveform key and improve chunk polling timing

### DIFF
--- a/src/data/vcp.rs
+++ b/src/data/vcp.rs
@@ -250,6 +250,9 @@ pub fn is_clear_air_vcp(vcp: u16) -> bool {
 /// Based on empirical analysis of 851 sweep measurements across VCPs 12, 34, 35, 212.
 /// PRF numbers map to categories: 1-2 = Low, 3 = Med, 4-5 = High.
 pub fn fallback_azimuth_rate(is_clear_air: bool, waveform: &str, prf_number: u8) -> f64 {
+    // Accept both "B" (short code used by `ExtractedVcp.waveform`) and
+    // "Batch" (library Debug format) so we don't silently drop into the
+    // default branch when callers happen to use the short form.
     if is_clear_air {
         match (waveform, prf_number) {
             ("CS", 1) => 5.0,
@@ -257,10 +260,10 @@ pub fn fallback_azimuth_rate(is_clear_air: bool, waveform: &str, prf_number: u8)
             ("CS", _) => 5.0, // Default CS clear-air
             ("CDW", _) => 15.7,
             ("CDWO", _) => 8.5,
-            ("Batch", 3) => 14.6,
-            ("Batch", 4) => 17.8,
-            ("Batch", 5) => 16.9,
-            ("Batch", _) => 18.1,
+            ("B" | "Batch", 3) => 14.6,
+            ("B" | "Batch", 4) => 17.8,
+            ("B" | "Batch", 5) => 16.9,
+            ("B" | "Batch", _) => 18.1,
             _ => 10.0, // Conservative default for unknown clear-air waveforms
         }
     } else {
@@ -270,10 +273,10 @@ pub fn fallback_azimuth_rate(is_clear_air: bool, waveform: &str, prf_number: u8)
             ("CS", _) => 21.1, // Default CS precip
             ("CDW", _) => 18.8,
             ("CDWO", _) => 28.5,
-            ("Batch", 3) => 26.2,
-            ("Batch", 4) => 26.9,
-            ("Batch", 5) => 27.7,
-            ("Batch", _) => 26.8,
+            ("B" | "Batch", 3) => 26.2,
+            ("B" | "Batch", 4) => 26.9,
+            ("B" | "Batch", 5) => 27.7,
+            ("B" | "Batch", _) => 26.8,
             _ => 22.0, // Conservative default for unknown precip waveforms
         }
     }
@@ -364,7 +367,7 @@ mod tests {
     #[test]
     fn fallback_azimuth_rate_all_positive() {
         for is_clear_air in [true, false] {
-            for waveform in ["CS", "CDW", "CDWO", "Batch", "Unknown"] {
+            for waveform in ["CS", "CDW", "CDWO", "B", "Batch", "Unknown"] {
                 for prf in 0..=8 {
                     let rate = fallback_azimuth_rate(is_clear_air, waveform, prf);
                     assert!(
@@ -374,6 +377,22 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn fallback_azimuth_rate_matches_short_and_long_batch_keys() {
+        // Production callers pass "B" (see ExtractedVcp.waveform); make sure
+        // it reaches the Batch arms, not the generic default.
+        for prf in [3u8, 4, 5, 6] {
+            let short = fallback_azimuth_rate(false, "B", prf);
+            let long = fallback_azimuth_rate(false, "Batch", prf);
+            assert_eq!(short, long, "short/long keys disagree at prf={prf}");
+            assert_ne!(short, 22.0, "prf={prf} fell through to default");
+        }
+        assert_eq!(fallback_azimuth_rate(false, "B", 3), 26.2);
+        assert_eq!(fallback_azimuth_rate(false, "B", 4), 26.9);
+        assert_eq!(fallback_azimuth_rate(false, "B", 5), 27.7);
+        assert_eq!(fallback_azimuth_rate(true, "B", 3), 14.6);
     }
 
     #[test]

--- a/src/nexrad/realtime.rs
+++ b/src/nexrad/realtime.rs
@@ -220,6 +220,11 @@ async fn streaming_loop(
     const CHUNK_POLL_MAX_RETRIES: u32 = 25; // 25 × 500ms = 12.5s
     const CHUNK_POLL_GRACE_MS: u32 = 2500; // 2.5s final grace → 15s total
 
+    // Pad added to the first poll wait per chunk; collapses the "fire a hair
+    // early → empty poll → sleep 500ms → fire" path on chunks whose
+    // predictions are tight. Retry waits are unaffected.
+    const POLL_DELAY_AFTER_PREDICTED_MS: u32 = 300;
+
     let hint = get_cached_volume(&site_id);
     let init_future = acquire_streaming_state(&site_id, hint);
     let timeout_future = sleep_ms(ACQUIRE_TIMEOUT_SECS * 1000);
@@ -517,14 +522,23 @@ async fn streaming_loop(
         // first iteration for a given chunk — subsequent retry iterations
         // re-enter here with a near-zero wait, which would overwrite the
         // original estimate.
+        let is_first_iter_for_chunk = cur_predicted_at.is_none();
         let time_until_next_opt = iter.time_until_next().and_then(|d| d.to_std().ok());
-        if cur_predicted_at.is_none() {
+        if is_first_iter_for_chunk {
             if let Some(d) = time_until_next_opt {
                 cur_predicted_at = Some(current_timestamp_f64() + d.as_secs_f64());
             }
         }
         if let Some(wait_duration) = time_until_next_opt {
-            let wait_ms = wait_duration.as_millis() as u32;
+            let mut wait_ms = wait_duration.as_millis() as u32;
+            // Pad the first (prediction-driven) wait per chunk so we fire
+            // slightly after `predicted_available_at`. Retry waits after an
+            // empty poll come through `sleep_ms(CHUNK_POLL_INTERVAL_MS)` in
+            // the `Ok(None)` arm, not here, so the pad applies exactly once
+            // per chunk.
+            if is_first_iter_for_chunk && wait_ms > 0 {
+                wait_ms = wait_ms.saturating_add(POLL_DELAY_AFTER_PREDICTED_MS);
+            }
             if wait_ms > 0 && !interruptible_sleep(&state, &ctx, wait_ms).await {
                 log::debug!("Realtime streaming stopped");
                 break;

--- a/src/state/live_mode.rs
+++ b/src/state/live_mode.rs
@@ -676,9 +676,15 @@ impl LiveModeState {
 
             // Prefer library projection bounds when usable; otherwise use the
             // VCP-weighted cumulative offset (same cascade as VcpPositionModel).
+            // The last chunk publishes at the *start* of its bucket; the sweep
+            // runs for one more bucket after that. Add `sweep_dur / N` to max_t.
             let (predicted_start, predicted_end) = match proj {
-                Some((min_t, max_t, _, rate)) if min_t < f64::MAX => {
-                    let end = if max_t > f64::MIN {
+                Some((min_t, max_t, chunk_count, rate)) if min_t < f64::MAX => {
+                    let end = if max_t > f64::MIN && rate > 0.0 && chunk_count > 0 {
+                        let sweep_dur = (360.0 / rate - 0.67).max(0.0);
+                        let bucket = sweep_dur / chunk_count as f64;
+                        max_t + bucket
+                    } else if max_t > f64::MIN {
                         max_t
                     } else if rate > 0.0 {
                         min_t + (360.0 / rate - 0.67).max(0.0)

--- a/src/state/vcp_forecast.rs
+++ b/src/state/vcp_forecast.rs
@@ -104,7 +104,9 @@ pub struct VolumeForecastSnapshot {
     pub previous_volume_end: Option<f64>,
     /// `volume_start - previous_volume_end` when both are known.
     pub inter_volume_gap_secs: Option<f64>,
-    /// Reserved for when the forecaster predicts the gap; always `None` today.
+    /// Forecaster's predicted gap: `predicted_available_at` on the new
+    /// volume's Start chunk minus the previous volume's observed end,
+    /// when both are known.
     pub predicted_inter_volume_gap_secs: Option<f64>,
 }
 

--- a/src/ui/vcp_forecast_modal.rs
+++ b/src/ui/vcp_forecast_modal.rs
@@ -1050,7 +1050,7 @@ pub fn serialize_forecast(snap: &VolumeForecastSnapshot, arrivals: &[ChunkArriva
     if let Some((mean, median, max_abs)) = stats_on(&slop_ms) {
         let _ = writeln!(
             out,
-            "scheduler_slop_ms: mean={mean:+.0}  median={median:+.0}  max_abs={max_abs:.0}  (scheduled - predicted; should be near 0)"
+            "scheduler_slop_ms: mean={mean:+.0}  median={median:+.0}  max_abs={max_abs:.0}  (scheduled - predicted; expected ≈ POLL_DELAY_AFTER_PREDICTED_MS)"
         );
     }
     let fetch_ms: Vec<f64> = arrivals.iter().map(|a| a.fetch_latency_ms).collect();


### PR DESCRIPTION
## Summary
This PR addresses two issues in the NEXRAD real-time streaming and VCP handling:
1. The `fallback_azimuth_rate` function now accepts both "B" (short form used by production code) and "Batch" (library debug format) as equivalent waveform keys
2. Chunk polling now includes a configurable delay after the predicted availability time to reduce empty polls

## Key Changes

### VCP Waveform Key Handling (`src/data/vcp.rs`)
- Updated `fallback_azimuth_rate()` to accept both "B" and "Batch" waveform strings using pattern matching (`"B" | "Batch"`)
- This prevents silent fallback to default azimuth rates when production callers use the short "B" form
- Added comprehensive test `fallback_azimuth_rate_matches_short_and_long_batch_keys()` to verify both forms produce identical results and don't fall through to defaults
- Updated existing test to include "B" in the waveform test cases

### Chunk Polling Timing (`src/nexrad/realtime.rs`)
- Introduced `POLL_DELAY_AFTER_PREDICTED_MS` constant (300ms) to pad the first poll wait per chunk
- This delay is applied only to prediction-driven waits on the first iteration per chunk, not to retry waits after empty polls
- Prevents the "fire slightly early → empty poll → sleep 500ms → fire" pattern by firing slightly after the predicted availability time
- Added detailed comments explaining the timing logic and why the pad applies exactly once per chunk

### Forecast End Time Calculation (`src/state/live_mode.rs`)
- Enhanced `predicted_end` calculation to account for the sweep duration extending beyond the last chunk
- Adds `sweep_dur / chunk_count` to `max_t` when all required parameters are available (rate > 0, chunk_count > 0)
- Falls back to previous behavior if parameters are insufficient
- Improves accuracy of volume end time predictions

### Documentation Updates
- Clarified `predicted_inter_volume_gap_secs` field documentation in `VolumeForecastSnapshot` to explain it represents the forecaster's predicted gap
- Updated scheduler slop metric description to indicate expected value is approximately `POLL_DELAY_AFTER_PREDICTED_MS`

https://claude.ai/code/session_015sxrNB8vnXMsMpJ74uiiHH