### PR TITLE
Improve real-time timing estimation, unify network retry, and assorted UX polish

### DIFF
--- a/docs/TIMING.md
+++ b/docs/TIMING.md
@@ -1,0 +1,372 @@
+# Timing model
+
+Every timestamp in the codebase falls into one of three categories. This
+document defines them, traces where each value comes from, lists which
+fields hold which category, and pins the invariants that the UI relies on.
+
+## Why three categories
+
+NEXRAD data takes a non-trivial path from "the radar physically scans"
+to "we can download the chunk." Three distinct times exist:
+
+| Category | When | Source |
+| --- | --- | --- |
+| **ACTUAL** | What was observed | Parsed from radial/message headers, or the literal wall clock |
+| **PROJECTED COLLECTION** | When the radar will physically scan a future chunk | VCP physics + history, anchored on a real collection time |
+| **PROJECTED AVAILABILITY** | When a chunk will be downloadable from S3 | Empirical S3 deltas + a lag estimate |
+
+The two projected categories differ by the NEXRAD ingest lag (~5–15 s on
+typical sites). Conflating them — for example, drawing a "future sweep"
+placeholder at its projected S3-arrival time rather than its projected
+collection time — produces a UI that's offset late by the pipeline lag.
+
+The three principles the UI obeys:
+
+1. The radar canvas and the current-time indicator show **ACTUAL** times only.
+2. Timeline placeholders for future sweeps and chunks use **PROJECTED COLLECTION** times.
+3. The download scheduler and "next in N s" countdown use **PROJECTED AVAILABILITY** times.
+
+## 1. ACTUAL times
+
+### 1a. Collection times (from radial headers, parsed in the worker)
+
+NEXRAD Message 31 carries each radial's collection time as
+`days-since-epoch + ms-since-midnight`. The decoder exposes this via
+`Radial::collection_timestamp() -> i64` (milliseconds since Unix epoch).
+We always divide by 1000.0 to produce `f64` seconds with millisecond
+precision; ms precision is appropriate because radials arrive ~40 ms
+apart at typical scan rates, finer than whole-second resolution.
+
+| Field | What it is | Source |
+| --- | --- | --- |
+| `volume_header_time_secs` | Time of the radial with `RadialStatus::ScanStart` (the volume's first radial) | `record_decode.rs::extract_volume_start_time` |
+| `chunk_min_time_secs` / `chunk_max_time_secs` | Earliest and latest radial collection times within one chunk | `ingest_phases.rs::compute_chunk_time_spans` |
+| `PrecomputedSweep.sweep_start_secs` / `sweep_end_secs` / `radial_times` | Per-sweep min/max + per-radial vector | `record_decode.rs::build_precomputed_sweep` |
+| `SweepMeta.start` / `SweepMeta.end` | Persisted in the scan_index entry; same data as PrecomputedSweep | `ingest_phases.rs::build_sweep_meta` |
+
+These are the authoritative "when did the radar physically scan this"
+values. They drive:
+- The radar canvas's "Time:" label and "Age" display
+- The timeline's completed scan blocks and sweep blocks
+- The in-progress scan's left edge (`live_mode_state.current_volume_start`)
+- The projector's anchor (`latest_chunk_collection_end_secs`)
+- The empirical availability-lag stat (`s3_last_modified − chunk_max`)
+
+### 1b. S3 upload times (when the chunk became downloadable)
+
+`ChunkIdentifier::upload_date_time()` returns S3's `Last-Modified` HTTP
+header for the chunk object. Surfaced as:
+
+- `ChunkArrivalStat.s3_last_modified_at` — recorded for every chunk
+  fetch in the streaming loop
+- `StreamingState.last_chunk_time` — internal, used to compute
+  S3-upload deltas for `ChunkTimingStats`
+
+S3 `Last-Modified` has **1-second resolution** by HTTP convention, so any
+single derived measurement (lag, ETA error) is ±1 s noisy. Medians and
+averages across many samples wash this out.
+
+### 1c. Wall clock
+
+`js_sys::Date::now() / 1000.0`, wrapped in:
+- `current_timestamp() -> i64` and `current_timestamp_f64() -> f64` (`realtime.rs`)
+- `TimeModel::wall_clock_time()` (`state/playback.rs`)
+
+Used for: the timeline's "now" marker, the live-mode playhead position,
+"Age" computation, scheduler timing measurements (`scheduled_at`,
+`success_at`, `first_empty_poll_at`).
+
+---
+
+## 2. PROJECTED COLLECTION times
+
+> When the radar will physically scan a future chunk.
+
+Drives timeline placeholders for not-yet-arrived data: the in-progress
+volume block's right edge, future-sweep dashed outlines, and the
+next-chunk placeholder slot.
+
+### Algorithm (`scan_timing_projection.rs::project_scan_timing`)
+
+```
+anchor_collection = latest_chunk_collection_end_secs           (preferred — current chunk's max radial time)
+                 ?? (anchor.upload_time − median_lag)           (fallback when no M chunk yet this volume)
+                 ?? (anchor.upload_time − 5s)                   (fallback when no lag stats yet)
+
+for seq in (anchor.sequence + 1)..=final:
+    physics_interval = ChunkTimingModel::estimate_chunk_interval_secs(prev_meta, next_meta)
+    interval         = 0.7 * physics_interval + 0.3 * historical_avg_for(next.characteristics)
+                       (only when ChunkTimingStats has a sample for the next chunk's bucket;
+                        else pure physics)
+    cumulative      += interval
+    projected_collection_time[seq] = anchor_collection + cumulative
+```
+
+### The physics term — `ChunkTimingModel`
+
+`estimate_chunk_interval_secs(prev_meta, next_meta)` covers three cases:
+
+- **Inter-volume gap** (between volumes): 8.5 s constant
+- **Inter-sweep gap** (between sweeps within a volume):
+  `INTER_SWEEP_BASE_GAP_SECS (0.7 s) + elevation_slew + chunk_duration + waveform_transition_penalty`
+- **Intra-sweep** (within a sweep): pure `chunk_duration` derived from the VCP's azimuth rate
+
+The **waveform transition penalty** is an empirically-tuned table at
+`chunk_timing_model.rs::waveform_transition_penalty_secs` — CS→CDW = 4.0 s,
+B→CDWO = 3.5 s, etc. — accounting for hardware reconfiguration cost
+between sweeps with different waveforms.
+
+### The historical blend — `ChunkTimingStats`
+
+`get_average_timing(next_chunk_characteristics)` returns the rolling
+average of the last 10 observed S3-upload deltas for that bucket. Buckets
+are keyed on `ChunkCharacteristics = { chunk_type, waveform_type,
+channel_configuration, is_first_in_sweep }`.
+
+The lookup is keyed on the **arriving** chunk's characteristics, not the
+anchor's (commit `eac0f3f`). Writes record under the arriving chunk's
+key, so reading under the anchor's key would silently miss and fall back
+to pure physics.
+
+The 70/30 blend hedges against systematic physics bias while not
+over-fitting to a small sample window.
+
+### Anchor plumbing (the recently-fixed bit)
+
+The anchor must be the **current chunk's collection-end time**, not the
+volume's start time, because the projector adds cumulative intervals
+starting from the anchor *forward*. Plumbing path:
+
+```
+worker (worker_api/ingest.rs)
+  └─ emits chunk_max_time_secs in ChunkIngestResponse
+
+main.rs ingest handler
+  └─ self.streaming.record_chunk_collection_end_secs(chunk_max_secs)
+
+StreamingManager::record_chunk_collection_end_secs
+  └─ RealtimeChannel::record_chunk_collection_end_secs
+
+RealtimeChannel
+  └─ stores in shared RealtimeState.pending_chunk_collection_end_secs
+
+streaming loop (realtime.rs)
+  └─ drain_pending_ingest_observations at top of iteration
+       └─ iter.record_chunk_collection_end_secs(secs)
+
+StreamingState.latest_chunk_collection_end_secs
+  └─ passed to project_scan_timing as anchor_collection_time_secs
+```
+
+Reset on every Start chunk (new volume).
+
+### Consumers
+
+- `ChunkProjectionInfo.projected_collection_time_secs` (per-chunk)
+- `RealtimeResult::ChunkReceived.projected_volume_end_collection_secs` (volume end)
+- `LiveModeState.projected_volume_end_collection_secs`, fed to:
+  - `VcpPositionModel::from_live` → `volume_end` (timeline right-edge of in-progress volume)
+  - `try_capture_forecast` → `SweepForecast.predicted_start/end/duration`
+  - `capture_mid_prediction` → `forecast.mid_predicted_start/end`
+- `render_realtime_progress` (`ui/timeline/overlays.rs`) — places the
+  in-progress block, future sweeps, and per-chunk placeholders on the
+  X axis
+
+---
+
+## 3. PROJECTED AVAILABILITY times
+
+> When a chunk will be downloadable from S3.
+
+There are **two independent paths** that compute this differently —
+intentionally, because they answer different questions.
+
+### 3a. Per-chunk projection availability
+
+For each future chunk in the per-volume projection. Drives the live
+diagnostics modal's predicted-vs-observed comparison.
+
+```
+availability_lag = anchor.upload_time − anchor_collection                (when anchor collection is known)
+                ?? ChunkTimingStats::median_availability_lag_secs()       (median across all buckets)
+                ?? 5.0s                                                    (cold-start default)
+
+projected_available_at[i] = projected_collection_time[i] + availability_lag
+```
+
+This is a **single scalar lag** applied to all forward chunks of one
+projection. We don't yet model per-characteristics lag. (See "open
+gaps" at the end.)
+
+### 3b. Scheduler / "next in N s" wait time
+
+What `iter.time_until_next()` returns to the streaming loop and what
+drives the user-facing countdown. **Doesn't go through the projector at
+all** — driven by historical S3 deltas with physics fallback.
+
+`estimate_next_chunk_time.rs::estimate_chunk_processing_time`:
+
+```
+if current chunk is Start:
+    return START_TO_FIRST_INTERMEDIATE_GAP_SECS  (1.5 s)
+
+if ChunkTimingStats has samples for next_chunk.characteristics:
+    return historical_avg_S3_delta + (avg_attempts − 1) seconds
+                                    ↑ retry budget — if past chunks usually
+                                      took N polls, allocate N−1 extra seconds
+
+else if VCP physics is available:
+    return ChunkTimingModel::estimate_chunk_interval_secs(current, next)
+            (no historical blend in this path — pure physics fallback)
+
+else:
+    return legacy_static_table[waveform][channel_config]
+```
+
+The streaming loop takes this wait, schedules the first poll at
+`predicted_available_at + POLL_DELAY_AFTER_PREDICTED_MS (400 ms)`, then
+on `Ok(None)` retries every `CHUNK_POLL_INTERVAL_MS (500 ms)` up to
+`CHUNK_POLL_MAX_RETRIES (25)` times, then a `CHUNK_POLL_GRACE_MS (2.5 s)`
+final grace.
+
+The 400 ms pad covers WASM/setTimeout slop plus a small bias hedge; was
+600 ms before commit `eac0f3f` fixed the historical-stats keying.
+
+### Consumers
+
+- `RealtimeResult::ChunkReceived.time_until_next` →
+  `LiveModeState.next_chunk_available_at_secs` →
+  `countdown_remaining_secs(now)`
+- `playback_controls.rs` — "next in {N} s"
+- `top_bar.rs` — "(N chunks) next in {N} s"
+- Timeline next-chunk placeholder text label (`overlays.rs`)
+- The streaming loop itself for actual scheduling
+
+### 3c. The ScanKey provisional timestamp
+
+When the Start chunk arrives in real-time, its scan-start timestamp is
+`upload_date_time(start_chunk) − median_availability_lag` (`realtime.rs::
+provisional_scan_start_secs`). Falls back to wall-clock if no upload time
+is available. This places `ScanKey.scan_start` within ~1 s of the true
+volume-header time before any M chunk has arrived (which is what allows
+us to anchor the projection's collection axis on a meaningful value
+even at volume start).
+
+`ScanKey.scan_start` is whole-second (`provisional_scan_start_secs(...).
+round() as i64`, `UnixMillis::from_secs(...)`). See "Precision" below.
+
+---
+
+## 4. ChunkTimingStats — the rolling-observations cache
+
+The only piece that learns from runtime data. Keyed by
+`ChunkCharacteristics`, holds the last 10 samples per bucket. Each sample
+carries:
+
+| Field | Written by | Read by |
+| --- | --- | --- |
+| `duration` (S3-upload delta) | `StreamingState::update_timing_stats` in the streaming loop, on every chunk fetch | `get_average_timing` — used by both the projector blend and the scheduler |
+| `availability_lag` (`upload − collection`) | `StreamingState::record_availability_lag_for_current`, called from main.rs after each ingest | `median_availability_lag_secs()` — used by projector lag fallback and `provisional_scan_start_secs` |
+| `attempts` (polls before success) | `StreamingState::update_timing_stats` | `get_average_attempts` — used in scheduler wait-time formula |
+
+Persisted to localStorage with schema `version: 2`; v1 payloads are
+dropped on load (the lag field can't be backfilled).
+
+---
+
+## 5. Cross-cutting invariants
+
+| Where | Time category | Why |
+| --- | --- | --- |
+| Radar canvas + "Time:" / "Age:" labels | ACTUAL only | Principle 1 — display only what was observed |
+| Live playhead + "now" marker | Wall clock (ACTUAL) | Canvas resolves whichever sweep has `end ≤ playback_position`, so wall-clock tracking shows real data without stutter at chunk boundaries |
+| Timeline scan blocks (downloaded scans) | ACTUAL | Read from `SweepMeta.start/end` |
+| In-progress volume block left edge | ACTUAL `current_volume_start` | Volume-header time, parsed |
+| In-progress volume block right edge | PROJECTED COLLECTION | When the radar will *finish* scanning |
+| Future-sweep dashed outlines on timeline | PROJECTED COLLECTION | When the radar will scan, not when it'll upload |
+| Next-chunk placeholder on timeline (X position) | PROJECTED COLLECTION | Placement reflects scan timing |
+| Next-chunk placeholder text countdown | PROJECTED AVAILABILITY | "When can we download it" |
+| "Next in N s" countdown anywhere | PROJECTED AVAILABILITY | Same |
+| Scheduler poll timing | PROJECTED AVAILABILITY | When to hit S3 |
+| `ScanKey.scan_start` (real-time path) | ACTUAL provisional (`upload − median_lag`); whole-second resolution | Stable IDB key close to true volume-start time |
+| `ScanKey.scan_start` (archive path) | ACTUAL parsed from filename | Authoritative |
+
+---
+
+## 6. Precision
+
+ACTUAL collection times (radial-derived) are **millisecond-precise**
+end-to-end:
+
+- Source: `Radial::collection_timestamp() -> i64` is ms-since-epoch
+- Conversion: `ts as f64 / 1000.0` preserves precision (ms values fit
+  comfortably within f64's ~15 decimal digits)
+- IDB persistence: `PrecomputedSweep`'s binary blob stores
+  `sweep_start_secs`, `sweep_end_secs`, and per-radial times as f64
+- ChunkTimingStats samples are stored as `i64` ms
+
+S3 upload times are **whole-second** by HTTP `Last-Modified` convention.
+Single derived measurements (per-chunk lag, prediction error) are ±1 s
+noisy from this side; medians and rolling averages smooth it.
+
+Wall clock is sub-millisecond from `js_sys::Date::now()` but is only
+displayed at second-or-coarser precision (the user-facing "now" line).
+
+`ScanKey.scan_start` is **whole-second** in both real-time and archive
+paths. This is intentional — it's a key, used for stable identification
+across sessions. **Don't compare `SweepMeta.start` against
+`ScanKey.scan_start` expecting an exact match**: the sweep is ms-precise
+and the key is rounded to seconds. The first sweep of a volume can end
+up with `start` slightly before or slightly after `scan_start` depending
+on rounding direction.
+
+---
+
+## 7. Quick "where do I look when X is wrong"
+
+- **Canvas time / age is wrong** → check `viz_state.timestamp` and the
+  sweep's `SweepMeta.start/end`; both should be ACTUAL.
+- **Future placeholder is in the wrong place on the timeline** → check
+  `latest_chunk_collection_end_secs` is being plumbed and that
+  `project_scan_timing` is using it as the anchor.
+- **"Next in N s" is wrong** → check `estimate_chunk_processing_time`
+  and the historical-stats lookup keying. Pure physics fallback is also
+  a smell — implies stats aren't warming up.
+- **Scan disappears from timeline mid-volume** → check
+  `render_realtime_progress`'s early-return guard
+  (`expected_end < view_start`) and what's feeding
+  `VcpPositionModel.volume_end`. If `projected_volume_end_collection_secs`
+  is sliding into the past, the projection anchor is wrong.
+- **Lag prediction is biased** → inspect `ChunkTimingStats` median lag
+  in the debug panel; if cold, the 5 s default kicks in.
+- **Stats not warming up** → confirm
+  `record_availability_lag_for_current` is being called;
+  `chunk_max_time_secs` and `s3_last_modified_at` must both be available
+  in main.rs's ingest handler.
+
+---
+
+## 8. Open gaps
+
+1. **Per-characteristics lag isn't used.** Each `TimingStat` carries
+   `availability_lag` keyed by characteristics, but only the *global*
+   median is exposed via `median_availability_lag_secs()`. If e.g. Start
+   chunks systematically have a different lag than M chunks, the
+   projector won't pick that up.
+2. **Projection availability uses a constant scalar lag across all
+   forward chunks** (3a). A more sophisticated model would use a
+   per-chunk lag estimate so e.g. an in-progress sweep's tail chunks get
+   the right lag. The scheduler (3b) wins on per-chunk accuracy because
+   it uses per-characteristics historical S3 deltas, so this hasn't been
+   a problem in practice.
+3. **Scheduler still drives off `duration_ms` (S3 deltas), not the split
+   residuals.** A future change could switch the scheduler to
+   `physics + collection_residual + lag_delta` for cleaner attribution
+   when predictions go wrong, but the current empirically-tuned path
+   works well enough that a rewrite carries regression risk.
+4. **No IDB rename to re-anchor `ScanKey.scan_start` on the parsed
+   `volume_header_time` once the first M chunk arrives.** Currently the
+   provisional scan-start (`upload − median_lag`) stays for the whole
+   volume's lifetime in IDB. The residual error is ~1 s and the rename
+   would require a cross-store atomic transaction; deferred as a
+   follow-up.

--- a/src/alerts/api.rs
+++ b/src/alerts/api.rs
@@ -10,6 +10,7 @@ use wasm_bindgen_futures::JsFuture;
 
 use super::channel::{AlertsChannel, AlertsEvent};
 use super::parse::parse_response;
+use crate::net::retry::{parse_retry_after, with_retry, Verdict, DEFAULT_POLICY};
 
 /// Endpoint for currently-active alerts across the US. The API returns
 /// GeoJSON; the `Accept` header requests the weather.gov content type.
@@ -48,14 +49,29 @@ enum FetchOutcome {
 }
 
 async fn fetch_inner(if_none_match: Option<String>) -> Result<FetchOutcome, String> {
-    let window = web_sys::window().ok_or_else(|| "no window".to_string())?;
+    with_retry(&DEFAULT_POLICY, "alerts", |_attempt| {
+        let etag = if_none_match.clone();
+        async move { fetch_attempt(etag).await }
+    })
+    .await
+}
+
+/// Run a single fetch attempt and classify its outcome.
+async fn fetch_attempt(if_none_match: Option<String>) -> Verdict<FetchOutcome> {
+    let window = match web_sys::window() {
+        Some(w) => w,
+        None => return Verdict::Terminal("no window".into()),
+    };
 
     // Build a Request with the custom headers we need.
     let init = web_sys::RequestInit::new();
     init.set_method("GET");
     init.set_mode(web_sys::RequestMode::Cors);
 
-    let headers = web_sys::Headers::new().map_err(|_| "failed to allocate headers".to_string())?;
+    let headers = match web_sys::Headers::new() {
+        Ok(h) => h,
+        Err(_) => return Verdict::Terminal("failed to allocate headers".into()),
+    };
     let _ = headers.set("Accept", ACCEPT);
     let _ = headers.set("User-Agent", USER_AGENT);
     if let Some(etag) = if_none_match.as_ref() {
@@ -63,38 +79,64 @@ async fn fetch_inner(if_none_match: Option<String>) -> Result<FetchOutcome, Stri
     }
     init.set_headers(&JsValue::from(headers));
 
-    let request = web_sys::Request::new_with_str_and_init(ALERTS_URL, &init)
-        .map_err(|e| format!("request init failed: {:?}", e))?;
+    let request = match web_sys::Request::new_with_str_and_init(ALERTS_URL, &init) {
+        Ok(r) => r,
+        Err(e) => return Verdict::Terminal(format!("request init failed: {:?}", e)),
+    };
 
-    let resp_value = JsFuture::from(window.fetch_with_request(&request))
-        .await
-        .map_err(|e| format!("network error: {}", err_text(e)))?;
+    // Network-layer error (DNS, connection refused, CORS preflight failure, …)
+    // is retryable.
+    let resp_value = match JsFuture::from(window.fetch_with_request(&request)).await {
+        Ok(v) => v,
+        Err(e) => {
+            log::debug!("alerts: network error: {}", err_text(e));
+            return Verdict::Retry { after: None };
+        }
+    };
 
-    let resp: web_sys::Response = resp_value
-        .dyn_into()
-        .map_err(|_| "invalid response object".to_string())?;
+    let resp: web_sys::Response = match resp_value.dyn_into() {
+        Ok(r) => r,
+        Err(_) => return Verdict::Terminal("invalid response object".into()),
+    };
 
     let status = resp.status();
     if status == 304 {
-        return Ok(FetchOutcome::NotModified);
+        return Verdict::Ok(FetchOutcome::NotModified);
+    }
+    if status == 408 || status == 429 || (500..=599).contains(&status) {
+        let after = resp
+            .headers()
+            .get("Retry-After")
+            .ok()
+            .flatten()
+            .and_then(|s| parse_retry_after(&s));
+        return Verdict::Retry { after };
     }
     if !resp.ok() {
-        return Err(format!("HTTP {}", status));
+        return Verdict::Terminal(format!("HTTP {}", status));
     }
 
     let etag = resp.headers().get("ETag").ok().flatten();
 
-    let text_promise = resp
-        .text()
-        .map_err(|e| format!("failed to read body: {}", err_text(e)))?;
-    let text_value = JsFuture::from(text_promise)
-        .await
-        .map_err(|e| format!("failed to read body: {}", err_text(e)))?;
-    let body = text_value
-        .as_string()
-        .ok_or_else(|| "body not a string".to_string())?;
+    let text_promise = match resp.text() {
+        Ok(p) => p,
+        Err(e) => return Verdict::Terminal(format!("failed to read body: {}", err_text(e))),
+    };
+    let text_value = match JsFuture::from(text_promise).await {
+        Ok(v) => v,
+        Err(e) => {
+            // Body read failure mid-stream — same network-class issue as the
+            // initial fetch, retry it.
+            log::debug!("alerts: body read error: {}", err_text(e));
+            return Verdict::Retry { after: None };
+        }
+    };
+    let body = match text_value.as_string() {
+        Some(s) => s,
+        None => return Verdict::Terminal("body not a string".into()),
+    };
 
-    Ok(FetchOutcome::Updated { body, etag })
+    Verdict::Ok(FetchOutcome::Updated { body, etag })
 }
 
 fn err_text(v: JsValue) -> String {

--- a/src/data/keys.rs
+++ b/src/data/keys.rs
@@ -68,10 +68,19 @@ impl fmt::Display for UnixMillis {
 ///
 /// A scan is uniquely identified by site + start time. The start time
 /// is derived from the first record's timestamp (from VCP metadata or
-/// first radial collection time).
+/// first radial collection time) in the historical/archive path. In the
+/// real-time streaming path, the start is set to `upload_date_time −
+/// median availability lag` when the Start chunk arrives (see
+/// `realtime.rs::provisional_scan_start_secs`), which typically lands
+/// within ~1 s of the true collection time.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ScanKey {
     pub site: SiteId,
+    /// ACTUAL category: Unix-millis volume collection start time. In
+    /// real-time mode this is a close estimate (upload minus median lag)
+    /// rather than the parsed value until/unless an IDB rename refines
+    /// it, but consumers should treat it as actual collection time for
+    /// display and comparison purposes.
     pub scan_start: UnixMillis,
 }
 
@@ -189,10 +198,15 @@ pub struct PrecomputedSweep {
     pub offset: f32,
     pub radial_count: u32,
     pub mean_elevation: f32,
+    /// ACTUAL category: earliest radial collection time (Unix seconds).
+    /// Parsed directly from radial headers, so this is the authoritative
+    /// start-of-sweep time used throughout the timeline and canvas.
     pub sweep_start_secs: f64,
+    /// ACTUAL category: latest radial collection time (Unix seconds).
     pub sweep_end_secs: f64,
     pub azimuths: Vec<f32>,
-    /// Per-radial collection timestamps in Unix seconds (parallel to azimuths).
+    /// ACTUAL category: per-radial collection timestamps in Unix seconds,
+    /// parallel to `azimuths`.
     pub radial_times: Vec<f64>,
     pub gate_values: GateValues,
 }
@@ -398,9 +412,13 @@ impl ScanCompleteness {
 /// Lightweight sweep metadata persisted in the scan index.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SweepMeta {
-    /// Start timestamp (Unix seconds with sub-second precision).
+    /// ACTUAL category: sweep start time (Unix seconds, sub-second
+    /// precision), derived from the earliest radial's collection
+    /// timestamp. Authoritative — the canvas and timeline use this
+    /// directly for placing the sweep.
     pub start: f64,
-    /// End timestamp (Unix seconds with sub-second precision).
+    /// ACTUAL category: sweep end time (Unix seconds, sub-second
+    /// precision), latest radial's collection timestamp.
     pub end: f64,
     /// Elevation angle in degrees.
     pub elevation: f32,

--- a/src/geo/layer.rs
+++ b/src/geo/layer.rs
@@ -1,11 +1,13 @@
 //! Geographic layer data structures.
 
 use super::{MapProjection, ProjectionFingerprint};
-use eframe::egui::{Color32, Pos2};
+use eframe::egui::{Align2, Color32, Pos2, Vec2};
+use eframe::epaint::Galley;
 use geo_types::Coord;
 use shapefile::dbase::FieldValue;
 use std::cell::RefCell;
 use std::io::Cursor;
+use std::sync::Arc;
 
 /// Type of geographic layer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -71,21 +73,90 @@ pub enum GeoFeature {
     LineString(Vec<Coord<f64>>),
     /// Multiple line strings (for complex boundaries)
     MultiLineString(Vec<Vec<Coord<f64>>>),
-    /// A closed polygon with optional label
+    /// A closed polygon with optional label.
+    ///
+    /// `label_anchor` is the precomputed centroid (in lat/lon) used as the
+    /// label anchor point — calculated once at load time so the label
+    /// renderer can skip the per-frame shoelace pass.
     Polygon {
         exterior: Vec<Coord<f64>>,
         #[allow(dead_code)]
         holes: Vec<Vec<Coord<f64>>>,
         label: Option<String>,
+        label_anchor: Coord<f64>,
     },
-    /// Multiple polygons with optional label
+    /// Multiple polygons with optional label.
+    ///
+    /// `label_anchor` is the precomputed centroid of the largest polygon
+    /// (by bounding-box area), matching the label-placement choice at
+    /// render time. Computed once at load.
     MultiPolygon {
         #[allow(clippy::type_complexity)]
         polygons: Vec<(Vec<Coord<f64>>, Vec<Vec<Coord<f64>>>)>,
         label: Option<String>,
+        label_anchor: Coord<f64>,
     },
     /// A single point (for cities, landmarks)
     Point(Coord<f64>, Option<String>),
+}
+
+/// Computes the true geometric centroid of a polygon using the shoelace formula.
+/// Falls back to vertex average for degenerate (≤2 verts or zero area) polygons.
+pub fn compute_polygon_centroid(coords: &[Coord<f64>]) -> Coord<f64> {
+    if coords.is_empty() {
+        return Coord { x: 0.0, y: 0.0 };
+    }
+    if coords.len() < 3 {
+        let (sum_x, sum_y) = coords
+            .iter()
+            .fold((0.0, 0.0), |(sx, sy), c| (sx + c.x, sy + c.y));
+        return Coord {
+            x: sum_x / coords.len() as f64,
+            y: sum_y / coords.len() as f64,
+        };
+    }
+
+    let mut signed_area = 0.0;
+    let mut cx = 0.0;
+    let mut cy = 0.0;
+
+    for i in 0..coords.len() {
+        let j = (i + 1) % coords.len();
+        let cross = coords[i].x * coords[j].y - coords[j].x * coords[i].y;
+        signed_area += cross;
+        cx += (coords[i].x + coords[j].x) * cross;
+        cy += (coords[i].y + coords[j].y) * cross;
+    }
+
+    signed_area *= 0.5;
+
+    if signed_area.abs() < 1e-10 {
+        let (sum_x, sum_y) = coords
+            .iter()
+            .fold((0.0, 0.0), |(sx, sy), c| (sx + c.x, sy + c.y));
+        return Coord {
+            x: sum_x / coords.len() as f64,
+            y: sum_y / coords.len() as f64,
+        };
+    }
+
+    Coord {
+        x: cx / (6.0 * signed_area),
+        y: cy / (6.0 * signed_area),
+    }
+}
+
+/// Bounding-box area of a polygon. Used to pick the label-bearing ring of
+/// a `MultiPolygon`.
+fn polygon_bbox_area(coords: &[Coord<f64>]) -> f64 {
+    if coords.is_empty() {
+        return 0.0;
+    }
+    let (min_x, max_x, min_y, max_y) = coords.iter().fold(
+        (f64::MAX, f64::MIN, f64::MAX, f64::MIN),
+        |(mn_x, mx_x, mn_y, mx_y), c| (mn_x.min(c.x), mx_x.max(c.x), mn_y.min(c.y), mx_y.max(c.y)),
+    );
+    (max_x - min_x) * (max_y - min_y)
 }
 
 /// A geographic layer containing multiple features.
@@ -107,6 +178,52 @@ pub struct GeoLayer {
     /// Invisible (idle) views hit the cache every frame and skip all
     /// trig on feature coords.
     cache: RefCell<LayerProjectionCache>,
+    /// Cache of laid-out label galleys + their lat/lon anchors. Rebuilt
+    /// only when the camera has settled and the label-cache token (zoom
+    /// bucket, theme) has changed. Per-frame label rendering reprojects
+    /// the cached anchors and reuses the cached galleys with halo offsets,
+    /// avoiding text layout on every frame.
+    label_cache: RefCell<LayerLabelCache>,
+}
+
+/// Single retained label, ready to paint at the projected position of its
+/// `anchor`. Built once per camera-settle event; reused every frame in
+/// between.
+#[derive(Debug, Clone)]
+pub(crate) struct LabelEntry {
+    /// Lat/lon anchor — projected each frame to obtain the screen position
+    /// at which the label is drawn.
+    pub anchor: Coord<f64>,
+    /// How the galley should be aligned around the projected anchor.
+    pub align: Align2,
+    /// Pixel offset from the anchor's screen position before alignment.
+    /// Used by point labels that sit a few pixels to the right of their
+    /// marker dot.
+    pub pixel_offset: Vec2,
+    /// Pre-laid-out text. Reused every frame — `Arc::clone` is cheap.
+    pub galley: Arc<Galley>,
+    /// Foreground text color (halo offsets paint in black).
+    pub color: Color32,
+}
+
+/// Inputs that, when changed, force a label-cache rebuild on next settle:
+/// font sizes scale with zoom, and label colors flip with theme. The
+/// projection fingerprint is *not* part of the token because pan/zoom
+/// within a bucket should reuse the same galleys.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) struct LabelCacheToken {
+    /// `(zoom * 4.0).round() as u16` — quarter-zoom resolution. Coarse
+    /// enough to absorb tiny floating-point jitter, fine enough that font
+    /// sizes update visibly during sustained zoom.
+    pub zoom_bucket: u16,
+    pub dark: bool,
+    pub show_labels: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct LayerLabelCache {
+    pub token: Option<LabelCacheToken>,
+    pub entries: Vec<LabelEntry>,
 }
 
 /// Cached screen-space projection of a single feature's line/ring
@@ -159,6 +276,38 @@ fn project_feature(feature: &GeoFeature, projection: &MapProjection) -> FeatureP
     }
 }
 
+impl GeoFeature {
+    /// Returns the lat/lon point at which a label for this feature should
+    /// be anchored, if it carries a label. Polygons return their precomputed
+    /// centroid; points return their location.
+    pub fn label_anchor(&self) -> Option<Coord<f64>> {
+        match self {
+            GeoFeature::Polygon {
+                label: Some(_),
+                label_anchor,
+                ..
+            } => Some(*label_anchor),
+            GeoFeature::MultiPolygon {
+                label: Some(_),
+                label_anchor,
+                ..
+            } => Some(*label_anchor),
+            GeoFeature::Point(coord, Some(_)) => Some(*coord),
+            _ => None,
+        }
+    }
+
+    /// The label text, if any.
+    pub fn label_text(&self) -> Option<&str> {
+        match self {
+            GeoFeature::Polygon { label: Some(s), .. }
+            | GeoFeature::MultiPolygon { label: Some(s), .. }
+            | GeoFeature::Point(_, Some(s)) => Some(s.as_str()),
+            _ => None,
+        }
+    }
+}
+
 impl GeoLayer {
     /// Creates a new empty layer of the specified type.
     pub fn new(layer_type: GeoLayerType) -> Self {
@@ -169,7 +318,18 @@ impl GeoLayer {
             line_width: None,
             visible: true,
             cache: RefCell::new(LayerProjectionCache::default()),
+            label_cache: RefCell::new(LayerLabelCache::default()),
         }
+    }
+
+    /// Borrow the label cache mutably for rebuild.
+    pub(crate) fn label_cache_mut(&self) -> std::cell::RefMut<'_, LayerLabelCache> {
+        self.label_cache.borrow_mut()
+    }
+
+    /// Borrow the label cache for paint.
+    pub(crate) fn label_cache(&self) -> std::cell::Ref<'_, LayerLabelCache> {
+        self.label_cache.borrow()
     }
 
     /// Ensures the cache of projected screen points matches the current
@@ -305,10 +465,13 @@ fn convert_shapefile_shape(shape: &shapefile::Shape, label: Option<String>) -> O
             }
 
             if outer_rings.len() == 1 {
+                let exterior = outer_rings.remove(0);
+                let label_anchor = compute_polygon_centroid(&exterior);
                 Some(GeoFeature::Polygon {
-                    exterior: outer_rings.remove(0),
+                    exterior,
                     holes: current_holes,
                     label,
+                    label_anchor,
                 })
             } else {
                 #[allow(clippy::type_complexity)]
@@ -316,7 +479,20 @@ fn convert_shapefile_shape(shape: &shapefile::Shape, label: Option<String>) -> O
                     .into_iter()
                     .map(|ext| (ext, Vec::new()))
                     .collect();
-                Some(GeoFeature::MultiPolygon { polygons, label })
+                let label_anchor = polygons
+                    .iter()
+                    .max_by(|(a, _), (b, _)| {
+                        polygon_bbox_area(a)
+                            .partial_cmp(&polygon_bbox_area(b))
+                            .unwrap_or(std::cmp::Ordering::Equal)
+                    })
+                    .map(|(ext, _)| compute_polygon_centroid(ext))
+                    .unwrap_or(Coord { x: 0.0, y: 0.0 });
+                Some(GeoFeature::MultiPolygon {
+                    polygons,
+                    label,
+                    label_anchor,
+                })
             }
         }
         shapefile::Shape::NullShape => None,

--- a/src/geo/mod.rs
+++ b/src/geo/mod.rs
@@ -16,4 +16,4 @@ pub use geo_line_renderer::GeoLineRenderer;
 pub use globe_renderer::GlobeRenderer;
 pub use layer::{GeoFeature, GeoLayer, GeoLayerSet, GeoLayerType};
 pub use projection::{MapProjection, ProjectionFingerprint};
-pub use renderer::render_geo_layers;
+pub use renderer::{render_geo_layers, text_with_halo, GeoPass};

--- a/src/geo/renderer.rs
+++ b/src/geo/renderer.rs
@@ -1,12 +1,17 @@
 //! Geographic layer rendering.
 //!
-//! Renders geographic features to the egui canvas.
+//! Renders geographic features to the egui canvas. Lines and point markers
+//! repaint every frame using the projection cache; labels follow a tiered
+//! invalidation strategy — galleys are laid out once per camera-settle
+//! event and reprojected to screen positions every frame thereafter.
 
-use super::layer::FeatureProjection;
+use super::layer::{FeatureProjection, GeoLayerType, LabelCacheToken, LabelEntry, LayerLabelCache};
 use super::{GeoFeature, GeoLayer, GeoLayerSet, MapProjection};
 use crate::state::GeoLayerVisibility;
 use eframe::egui::{Align2, Color32, FontId, Painter, Pos2, Stroke, Vec2};
+use eframe::epaint::Galley;
 use geo_types::Coord;
+use std::sync::Arc;
 
 /// Which geo rendering pass to execute. Split so lines/markers can draw
 /// below the radar texture while labels draw on top of it for legibility.
@@ -16,10 +21,26 @@ pub enum GeoPass {
     Labels,
 }
 
+const HALO_OFFSETS: [Vec2; 8] = [
+    Vec2::new(-1.0, -1.0),
+    Vec2::new(0.0, -1.0),
+    Vec2::new(1.0, -1.0),
+    Vec2::new(-1.0, 0.0),
+    Vec2::new(1.0, 0.0),
+    Vec2::new(-1.0, 1.0),
+    Vec2::new(0.0, 1.0),
+    Vec2::new(1.0, 1.0),
+];
+
 /// Draws `text` with a 1px black outline by repeating the draw call at eight
 /// surrounding offsets before drawing the colored text on top. Cheap enough
 /// for the label counts we render and keeps labels legible against any
 /// underlying radar color.
+///
+/// This is the immediate-mode entry point used outside the geo layer cache
+/// (sweep overlay, alerts, etc.). Cached label rendering uses the lower-
+/// level [`paint_galley_with_halo`] which avoids re-laying-out text every
+/// frame.
 pub fn text_with_halo(
     painter: &Painter,
     pos: Pos2,
@@ -28,26 +49,43 @@ pub fn text_with_halo(
     font: FontId,
     color: Color32,
 ) {
-    const OFFSETS: [(f32, f32); 8] = [
-        (-1.0, -1.0),
-        (0.0, -1.0),
-        (1.0, -1.0),
-        (-1.0, 0.0),
-        (1.0, 0.0),
-        (-1.0, 1.0),
-        (0.0, 1.0),
-        (1.0, 1.0),
-    ];
-    for (dx, dy) in OFFSETS {
-        painter.text(
-            pos + Vec2::new(dx, dy),
-            align,
-            text,
-            font.clone(),
-            Color32::BLACK,
-        );
+    for offset in HALO_OFFSETS {
+        painter.text(pos + offset, align, text, font.clone(), Color32::BLACK);
     }
     painter.text(pos, align, text, font, color);
+}
+
+/// Paint a pre-laid-out galley at `pos` (pre-aligned), with the same 8-way
+/// halo as [`text_with_halo`]. Reuses the same `Arc<Galley>` for both the
+/// halo passes and the foreground pass so text layout never repeats.
+fn paint_galley_with_halo(
+    painter: &Painter,
+    pos: Pos2,
+    galley: &Arc<Galley>,
+    color: Color32,
+    halo_color: Color32,
+) {
+    for offset in HALO_OFFSETS {
+        painter.galley_with_override_text_color(pos + offset, galley.clone(), halo_color);
+    }
+    painter.galley_with_override_text_color(pos, galley.clone(), color);
+}
+
+/// Translate a galley's natural top-left position into the position needed
+/// for a given alignment around `pos`. Mirrors `Painter::text`'s alignment
+/// behavior so cached galleys land where the immediate-mode path would.
+fn aligned_galley_pos(pos: Pos2, galley_size: Vec2, align: Align2) -> Pos2 {
+    let x = match align.x() {
+        eframe::egui::Align::Min => pos.x,
+        eframe::egui::Align::Center => pos.x - galley_size.x / 2.0,
+        eframe::egui::Align::Max => pos.x - galley_size.x,
+    };
+    let y = match align.y() {
+        eframe::egui::Align::Min => pos.y,
+        eframe::egui::Align::Center => pos.y - galley_size.y / 2.0,
+        eframe::egui::Align::Max => pos.y - galley_size.y,
+    };
+    Pos2::new(x, y)
 }
 
 /// Renders all visible geographic layers to the canvas.
@@ -55,7 +93,9 @@ pub fn text_with_halo(
 /// Visibility is passed in separately (rather than via a cloned
 /// [`GeoLayerSet`]) so the large coord data never gets cloned per
 /// frame. Each layer holds a projection-keyed cache of screen points
-/// that is refreshed lazily here.
+/// (refreshed on the Lines pass) and a settle-debounced label cache
+/// (refreshed on the Labels pass when camera motion has stopped).
+#[allow(clippy::too_many_arguments)]
 pub fn render_geo_layers(
     painter: &Painter,
     layers: &GeoLayerSet,
@@ -64,11 +104,21 @@ pub fn render_geo_layers(
     zoom: f32,
     show_labels: bool,
     pass: GeoPass,
+    dark: bool,
+    camera_settled: bool,
 ) {
-    // Render layers in order (back to front)
     for (layer, visible) in layers_with_visibility(layers, visibility) {
         if visible && layer.visible && zoom >= layer.layer_type.min_zoom() {
-            render_layer(painter, layer, projection, show_labels, zoom, pass);
+            render_layer(
+                painter,
+                layer,
+                projection,
+                show_labels,
+                zoom,
+                pass,
+                dark,
+                camera_settled,
+            );
         }
     }
 }
@@ -89,6 +139,7 @@ fn layers_with_visibility<'a>(
 }
 
 /// Renders a single geographic layer.
+#[allow(clippy::too_many_arguments)]
 fn render_layer(
     painter: &Painter,
     layer: &GeoLayer,
@@ -96,7 +147,27 @@ fn render_layer(
     show_labels: bool,
     zoom: f32,
     pass: GeoPass,
+    dark: bool,
+    camera_settled: bool,
 ) {
+    match pass {
+        GeoPass::Lines => render_lines_pass(painter, layer, projection, zoom),
+        GeoPass::Labels => render_labels_pass(
+            painter,
+            layer,
+            projection,
+            show_labels,
+            zoom,
+            dark,
+            camera_settled,
+        ),
+    }
+}
+
+/// Lines pass: draw line geometry and point markers using the projection
+/// cache. Repaints every frame; per-feature visibility is rejected by
+/// bounding-box checks.
+fn render_lines_pass(painter: &Painter, layer: &GeoLayer, projection: &MapProjection, zoom: f32) {
     let color = layer.effective_color();
     let line_width = layer.effective_line_width();
     let stroke = Stroke::new(line_width, color);
@@ -105,268 +176,193 @@ fn render_layer(
     let entries = layer.cached_entries();
 
     for (feature, entry) in layer.features.iter().zip(entries.iter()) {
-        render_feature(
-            painter,
-            feature,
-            entry,
-            projection,
-            stroke,
-            color,
-            show_labels,
-            zoom,
-            layer.layer_type,
-            pass,
-        );
-    }
-}
-
-/// Renders a single geographic feature.
-#[allow(clippy::too_many_arguments)]
-fn render_feature(
-    painter: &Painter,
-    feature: &GeoFeature,
-    entry: &FeatureProjection,
-    projection: &MapProjection,
-    stroke: Stroke,
-    color: Color32,
-    show_labels: bool,
-    zoom: f32,
-    layer_type: super::GeoLayerType,
-    pass: GeoPass,
-) {
-    let draw_lines = pass == GeoPass::Lines;
-    let draw_labels = pass == GeoPass::Labels && show_labels;
-    match (feature, entry) {
-        (GeoFeature::Point(coord, label), _) => {
-            // Pass the label through only when labels are enabled so the
-            // marker still draws even with the user's label toggle off.
-            let effective_label = if show_labels { label.as_deref() } else { None };
-            render_point(
-                painter,
-                coord,
-                projection,
-                color,
-                effective_label,
-                zoom,
-                pass,
-            );
-        }
-        (GeoFeature::LineString(coords), FeatureProjection::Single(points)) if draw_lines => {
-            render_projected_line(painter, coords, points, projection, stroke);
-        }
-        (GeoFeature::MultiLineString(lines), FeatureProjection::Multi(parts)) if draw_lines => {
-            for (coords, points) in lines.iter().zip(parts.iter()) {
+        match (feature, entry) {
+            (GeoFeature::Point(coord, _), _) => {
+                render_point_marker(painter, coord, projection, color, zoom);
+            }
+            (GeoFeature::LineString(coords), FeatureProjection::Single(points)) => {
                 render_projected_line(painter, coords, points, projection, stroke);
             }
-        }
-        (
-            GeoFeature::Polygon {
-                exterior,
-                holes: _,
-                label,
-            },
-            FeatureProjection::Single(points),
-        ) => {
-            if draw_lines {
-                render_projected_line(painter, exterior, points, projection, stroke);
-            }
-            if draw_labels {
-                if let Some(text) = label {
-                    render_polygon_label(painter, exterior, projection, text, zoom, layer_type);
+            (GeoFeature::MultiLineString(lines), FeatureProjection::Multi(parts)) => {
+                for (coords, points) in lines.iter().zip(parts.iter()) {
+                    render_projected_line(painter, coords, points, projection, stroke);
                 }
             }
-        }
-        (GeoFeature::MultiPolygon { polygons, label }, FeatureProjection::Multi(parts)) => {
-            if draw_lines {
+            (GeoFeature::Polygon { exterior, .. }, FeatureProjection::Single(points)) => {
+                render_projected_line(painter, exterior, points, projection, stroke);
+            }
+            (GeoFeature::MultiPolygon { polygons, .. }, FeatureProjection::Multi(parts)) => {
                 for ((exterior, _holes), points) in polygons.iter().zip(parts.iter()) {
                     render_projected_line(painter, exterior, points, projection, stroke);
                 }
             }
-            if draw_labels {
-                if let Some(text) = label {
-                    if let Some((largest_exterior, _)) = polygons.iter().max_by(|(a, _), (b, _)| {
-                        let area_a = polygon_bbox_area(a);
-                        let area_b = polygon_bbox_area(b);
-                        area_a
-                            .partial_cmp(&area_b)
-                            .unwrap_or(std::cmp::Ordering::Equal)
-                    }) {
-                        render_polygon_label(
-                            painter,
-                            largest_exterior,
-                            projection,
-                            text,
-                            zoom,
-                            layer_type,
-                        );
-                    }
-                }
-            }
+            _ => {}
         }
-        // Cache/feature type mismatch — shouldn't happen in practice, but
-        // skip rather than reproject.
-        _ => {}
     }
 }
 
-/// Computes the true geometric centroid of a polygon using the shoelace formula.
-/// This gives better results than a simple vertex average for irregular shapes.
-fn compute_polygon_centroid(coords: &[Coord<f64>]) -> Coord<f64> {
-    if coords.is_empty() {
-        return Coord { x: 0.0, y: 0.0 };
-    }
-    if coords.len() < 3 {
-        // For degenerate cases, fall back to simple average
-        let (sum_x, sum_y) = coords
-            .iter()
-            .fold((0.0, 0.0), |(sx, sy), c| (sx + c.x, sy + c.y));
-        return Coord {
-            x: sum_x / coords.len() as f64,
-            y: sum_y / coords.len() as f64,
-        };
-    }
-
-    let mut signed_area = 0.0;
-    let mut cx = 0.0;
-    let mut cy = 0.0;
-
-    for i in 0..coords.len() {
-        let j = (i + 1) % coords.len();
-        let cross = coords[i].x * coords[j].y - coords[j].x * coords[i].y;
-        signed_area += cross;
-        cx += (coords[i].x + coords[j].x) * cross;
-        cy += (coords[i].y + coords[j].y) * cross;
-    }
-
-    signed_area *= 0.5;
-
-    // Avoid division by zero for degenerate polygons
-    if signed_area.abs() < 1e-10 {
-        let (sum_x, sum_y) = coords
-            .iter()
-            .fold((0.0, 0.0), |(sx, sy), c| (sx + c.x, sy + c.y));
-        return Coord {
-            x: sum_x / coords.len() as f64,
-            y: sum_y / coords.len() as f64,
-        };
-    }
-
-    Coord {
-        x: cx / (6.0 * signed_area),
-        y: cy / (6.0 * signed_area),
-    }
-}
-
-/// Computes the bounding box area of a polygon (for finding largest polygon).
-fn polygon_bbox_area(coords: &[Coord<f64>]) -> f64 {
-    if coords.is_empty() {
-        return 0.0;
-    }
-    let (min_x, max_x, min_y, max_y) = coords.iter().fold(
-        (f64::MAX, f64::MIN, f64::MAX, f64::MIN),
-        |(min_x, max_x, min_y, max_y), c| {
-            (
-                min_x.min(c.x),
-                max_x.max(c.x),
-                min_y.min(c.y),
-                max_y.max(c.y),
-            )
-        },
-    );
-    (max_x - min_x) * (max_y - min_y)
-}
-
-/// Renders a label at the centroid of a polygon.
-fn render_polygon_label(
+/// Labels pass: project cached anchors and paint cached galleys. Rebuilds
+/// the cache when the camera has settled and the cache token has changed.
+fn render_labels_pass(
     painter: &Painter,
-    coords: &[Coord<f64>],
+    layer: &GeoLayer,
     projection: &MapProjection,
+    show_labels: bool,
+    zoom: f32,
+    dark: bool,
+    camera_settled: bool,
+) {
+    if !show_labels {
+        return;
+    }
+
+    let token = LabelCacheToken {
+        zoom_bucket: (zoom * 4.0).round().clamp(0.0, u16::MAX as f32) as u16,
+        dark,
+        show_labels,
+    };
+
+    {
+        let mut cache = layer.label_cache_mut();
+        let needs_rebuild = match cache.token {
+            None => true,
+            Some(t) if t != token && camera_settled => true,
+            _ => false,
+        };
+        if needs_rebuild {
+            rebuild_label_cache(painter, layer, projection, zoom, dark, &mut cache);
+            cache.token = Some(token);
+        }
+    }
+
+    let cache = layer.label_cache();
+    paint_label_cache(painter, projection, &cache);
+}
+
+/// Build the per-layer label cache: one [`LabelEntry`] per visible
+/// labelable feature, with text laid out into an `Arc<Galley>`. Skips
+/// features whose `min_label_zoom` threshold isn't met or whose anchor
+/// isn't within the visible bounds at build time.
+fn rebuild_label_cache(
+    painter: &Painter,
+    layer: &GeoLayer,
+    projection: &MapProjection,
+    zoom: f32,
+    dark: bool,
+    cache: &mut LayerLabelCache,
+) {
+    cache.entries.clear();
+
+    if zoom < layer.layer_type.min_label_zoom() {
+        return;
+    }
+
+    let layer_type = layer.layer_type;
+
+    for feature in &layer.features {
+        let Some(text) = feature.label_text() else {
+            continue;
+        };
+        let Some(anchor) = feature.label_anchor() else {
+            continue;
+        };
+        // Visibility check at build time uses generous margin so labels
+        // near the edge stay cached and stay positioned correctly during
+        // small pans before the next settle.
+        if !projection.is_visible(anchor, 0.5) {
+            continue;
+        }
+
+        let entry = match feature {
+            GeoFeature::Polygon { .. } | GeoFeature::MultiPolygon { .. } => {
+                build_polygon_label_entry(painter, anchor, text, zoom, layer_type, dark)
+            }
+            GeoFeature::Point(_, _) => build_point_label_entry(painter, anchor, text, zoom, dark),
+            _ => None,
+        };
+        if let Some(entry) = entry {
+            cache.entries.push(entry);
+        }
+    }
+}
+
+fn build_polygon_label_entry(
+    painter: &Painter,
+    anchor: Coord<f64>,
     text: &str,
     zoom: f32,
-    layer_type: super::GeoLayerType,
-) {
-    use super::GeoLayerType;
+    layer_type: GeoLayerType,
+    _dark: bool,
+) -> Option<LabelEntry> {
+    let (base_size, color) = polygon_label_style(layer_type);
+    let font_size = (base_size * zoom).clamp(base_size * 0.7, base_size * 1.5);
+    let galley = painter.layout_no_wrap(text.to_string(), FontId::proportional(font_size), color);
+    Some(LabelEntry {
+        anchor,
+        align: Align2::CENTER_CENTER,
+        pixel_offset: Vec2::ZERO,
+        galley,
+        color,
+    })
+}
 
-    if coords.is_empty() {
-        return;
-    }
+fn build_point_label_entry(
+    painter: &Painter,
+    anchor: Coord<f64>,
+    text: &str,
+    zoom: f32,
+    _dark: bool,
+) -> Option<LabelEntry> {
+    let radius = (2.5 * zoom.sqrt()).clamp(2.0, 5.0);
+    let font_size = (9.0 * zoom.sqrt()).clamp(8.0, 13.0);
+    let color = Color32::from_rgb(180, 180, 200);
+    let galley = painter.layout_no_wrap(text.to_string(), FontId::proportional(font_size), color);
+    Some(LabelEntry {
+        anchor,
+        align: Align2::LEFT_CENTER,
+        pixel_offset: Vec2::new(radius + 2.0, -2.0),
+        galley,
+        color,
+    })
+}
 
-    // Check if zoom level is sufficient for labels on this layer type
-    if zoom < layer_type.min_label_zoom() {
-        return;
-    }
-
-    // Compute centroid using proper polygon centroid formula
-    let centroid = compute_polygon_centroid(coords);
-
-    // Skip if centroid is outside visible bounds
-    if !projection.is_visible(centroid, 0.5) {
-        return;
-    }
-
-    let pos = projection.geo_to_screen(centroid);
-
-    // Style based on layer type
-    let (base_size, color) = match layer_type {
+fn polygon_label_style(layer_type: GeoLayerType) -> (f32, Color32) {
+    match layer_type {
         GeoLayerType::States => (12.0, Color32::from_rgb(220, 220, 240)),
         GeoLayerType::Counties => (8.0, Color32::from_rgb(210, 210, 225)),
         GeoLayerType::Cities => (10.0, Color32::from_rgb(200, 200, 220)),
         GeoLayerType::Highways => (8.0, Color32::from_rgb(130, 110, 90)),
         GeoLayerType::Lakes => (9.0, Color32::from_rgb(100, 130, 180)),
-    };
-
-    // Scale font size with zoom, clamped to reasonable range
-    let font_size = (base_size * zoom).clamp(base_size * 0.7, base_size * 1.5);
-
-    text_with_halo(
-        painter,
-        pos,
-        Align2::CENTER_CENTER,
-        text,
-        FontId::proportional(font_size),
-        color,
-    );
+    }
 }
 
-/// Renders a point feature (city marker, etc.). The marker circle is drawn in
-/// the `Lines` pass and its label in the `Labels` pass so text can sit over
-/// the radar while markers stay underneath.
-fn render_point(
+/// Per-frame label paint: project each cached anchor through the current
+/// projection and emit one halo'd galley per entry. No text layout runs
+/// here — galleys are reused via `Arc::clone`.
+fn paint_label_cache(painter: &Painter, projection: &MapProjection, cache: &LayerLabelCache) {
+    for entry in &cache.entries {
+        let anchor_screen = projection.geo_to_screen(entry.anchor);
+        let anchor_with_offset = anchor_screen + entry.pixel_offset;
+        let pos = aligned_galley_pos(anchor_with_offset, entry.galley.size(), entry.align);
+        paint_galley_with_halo(painter, pos, &entry.galley, entry.color, Color32::BLACK);
+    }
+}
+
+/// Renders a point feature's marker dot. Labels for points are emitted via
+/// the layer label cache during the Labels pass.
+fn render_point_marker(
     painter: &Painter,
     coord: &Coord<f64>,
     projection: &MapProjection,
     color: Color32,
-    label: Option<&str>,
     zoom: f32,
-    pass: GeoPass,
 ) {
-    // Skip if outside visible bounds
     if !projection.is_visible(*coord, 0.5) {
         return;
     }
-
     let pos = projection.geo_to_screen(*coord);
     let radius = (2.5 * zoom.sqrt()).clamp(2.0, 5.0);
-
-    match pass {
-        GeoPass::Lines => {
-            painter.circle_filled(pos, radius, color);
-        }
-        GeoPass::Labels => {
-            if let Some(text) = label {
-                let font_size = (9.0 * zoom.sqrt()).clamp(8.0, 13.0);
-                let label_pos = Pos2::new(pos.x + radius + 2.0, pos.y - 2.0);
-                text_with_halo(
-                    painter,
-                    label_pos,
-                    Align2::LEFT_CENTER,
-                    text,
-                    FontId::proportional(font_size),
-                    color,
-                );
-            }
-        }
-    }
+    painter.circle_filled(pos, radius, color);
 }
 
 /// Renders a line string (boundary, river, etc.) using already-projected

--- a/src/geo/renderer.rs
+++ b/src/geo/renderer.rs
@@ -5,8 +5,50 @@
 use super::layer::FeatureProjection;
 use super::{GeoFeature, GeoLayer, GeoLayerSet, MapProjection};
 use crate::state::GeoLayerVisibility;
-use eframe::egui::{Color32, FontId, Painter, Pos2, Stroke};
+use eframe::egui::{Align2, Color32, FontId, Painter, Pos2, Stroke, Vec2};
 use geo_types::Coord;
+
+/// Which geo rendering pass to execute. Split so lines/markers can draw
+/// below the radar texture while labels draw on top of it for legibility.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum GeoPass {
+    Lines,
+    Labels,
+}
+
+/// Draws `text` with a 1px black outline by repeating the draw call at eight
+/// surrounding offsets before drawing the colored text on top. Cheap enough
+/// for the label counts we render and keeps labels legible against any
+/// underlying radar color.
+pub fn text_with_halo(
+    painter: &Painter,
+    pos: Pos2,
+    align: Align2,
+    text: &str,
+    font: FontId,
+    color: Color32,
+) {
+    const OFFSETS: [(f32, f32); 8] = [
+        (-1.0, -1.0),
+        (0.0, -1.0),
+        (1.0, -1.0),
+        (-1.0, 0.0),
+        (1.0, 0.0),
+        (-1.0, 1.0),
+        (0.0, 1.0),
+        (1.0, 1.0),
+    ];
+    for (dx, dy) in OFFSETS {
+        painter.text(
+            pos + Vec2::new(dx, dy),
+            align,
+            text,
+            font.clone(),
+            Color32::BLACK,
+        );
+    }
+    painter.text(pos, align, text, font, color);
+}
 
 /// Renders all visible geographic layers to the canvas.
 ///
@@ -21,11 +63,12 @@ pub fn render_geo_layers(
     projection: &MapProjection,
     zoom: f32,
     show_labels: bool,
+    pass: GeoPass,
 ) {
     // Render layers in order (back to front)
     for (layer, visible) in layers_with_visibility(layers, visibility) {
         if visible && layer.visible && zoom >= layer.layer_type.min_zoom() {
-            render_layer(painter, layer, projection, show_labels, zoom);
+            render_layer(painter, layer, projection, show_labels, zoom, pass);
         }
     }
 }
@@ -52,6 +95,7 @@ fn render_layer(
     projection: &MapProjection,
     show_labels: bool,
     zoom: f32,
+    pass: GeoPass,
 ) {
     let color = layer.effective_color();
     let line_width = layer.effective_line_width();
@@ -71,6 +115,7 @@ fn render_layer(
             show_labels,
             zoom,
             layer.layer_type,
+            pass,
         );
     }
 }
@@ -87,23 +132,29 @@ fn render_feature(
     show_labels: bool,
     zoom: f32,
     layer_type: super::GeoLayerType,
+    pass: GeoPass,
 ) {
+    let draw_lines = pass == GeoPass::Lines;
+    let draw_labels = pass == GeoPass::Labels && show_labels;
     match (feature, entry) {
         (GeoFeature::Point(coord, label), _) => {
+            // Pass the label through only when labels are enabled so the
+            // marker still draws even with the user's label toggle off.
+            let effective_label = if show_labels { label.as_deref() } else { None };
             render_point(
                 painter,
                 coord,
                 projection,
                 color,
-                label.as_deref(),
-                show_labels,
+                effective_label,
                 zoom,
+                pass,
             );
         }
-        (GeoFeature::LineString(coords), FeatureProjection::Single(points)) => {
+        (GeoFeature::LineString(coords), FeatureProjection::Single(points)) if draw_lines => {
             render_projected_line(painter, coords, points, projection, stroke);
         }
-        (GeoFeature::MultiLineString(lines), FeatureProjection::Multi(parts)) => {
+        (GeoFeature::MultiLineString(lines), FeatureProjection::Multi(parts)) if draw_lines => {
             for (coords, points) in lines.iter().zip(parts.iter()) {
                 render_projected_line(painter, coords, points, projection, stroke);
             }
@@ -116,18 +167,22 @@ fn render_feature(
             },
             FeatureProjection::Single(points),
         ) => {
-            render_projected_line(painter, exterior, points, projection, stroke);
-            if show_labels {
+            if draw_lines {
+                render_projected_line(painter, exterior, points, projection, stroke);
+            }
+            if draw_labels {
                 if let Some(text) = label {
                     render_polygon_label(painter, exterior, projection, text, zoom, layer_type);
                 }
             }
         }
         (GeoFeature::MultiPolygon { polygons, label }, FeatureProjection::Multi(parts)) => {
-            for ((exterior, _holes), points) in polygons.iter().zip(parts.iter()) {
-                render_projected_line(painter, exterior, points, projection, stroke);
+            if draw_lines {
+                for ((exterior, _holes), points) in polygons.iter().zip(parts.iter()) {
+                    render_projected_line(painter, exterior, points, projection, stroke);
+                }
             }
-            if show_labels {
+            if draw_labels {
                 if let Some(text) = label {
                     if let Some((largest_exterior, _)) = polygons.iter().max_by(|(a, _), (b, _)| {
                         let area_a = polygon_bbox_area(a);
@@ -254,7 +309,7 @@ fn render_polygon_label(
     // Style based on layer type
     let (base_size, color) = match layer_type {
         GeoLayerType::States => (12.0, Color32::from_rgb(220, 220, 240)),
-        GeoLayerType::Counties => (8.0, Color32::from_rgb(100, 100, 115)),
+        GeoLayerType::Counties => (8.0, Color32::from_rgb(210, 210, 225)),
         GeoLayerType::Cities => (10.0, Color32::from_rgb(200, 200, 220)),
         GeoLayerType::Highways => (8.0, Color32::from_rgb(130, 110, 90)),
         GeoLayerType::Lakes => (9.0, Color32::from_rgb(100, 130, 180)),
@@ -263,24 +318,27 @@ fn render_polygon_label(
     // Scale font size with zoom, clamped to reasonable range
     let font_size = (base_size * zoom).clamp(base_size * 0.7, base_size * 1.5);
 
-    painter.text(
+    text_with_halo(
+        painter,
         pos,
-        eframe::egui::Align2::CENTER_CENTER,
+        Align2::CENTER_CENTER,
         text,
         FontId::proportional(font_size),
         color,
     );
 }
 
-/// Renders a point feature (city marker, etc.).
+/// Renders a point feature (city marker, etc.). The marker circle is drawn in
+/// the `Lines` pass and its label in the `Labels` pass so text can sit over
+/// the radar while markers stay underneath.
 fn render_point(
     painter: &Painter,
     coord: &Coord<f64>,
     projection: &MapProjection,
     color: Color32,
     label: Option<&str>,
-    show_labels: bool,
     zoom: f32,
+    pass: GeoPass,
 ) {
     // Skip if outside visible bounds
     if !projection.is_visible(*coord, 0.5) {
@@ -288,23 +346,25 @@ fn render_point(
     }
 
     let pos = projection.geo_to_screen(*coord);
-
-    // Draw a small circle for the point
     let radius = (2.5 * zoom.sqrt()).clamp(2.0, 5.0);
-    painter.circle_filled(pos, radius, color);
 
-    // Draw label if present and labels are enabled
-    if show_labels {
-        if let Some(text) = label {
-            let font_size = (9.0 * zoom.sqrt()).clamp(8.0, 13.0);
-            let label_pos = Pos2::new(pos.x + radius + 2.0, pos.y - 2.0);
-            painter.text(
-                label_pos,
-                eframe::egui::Align2::LEFT_CENTER,
-                text,
-                FontId::proportional(font_size),
-                color,
-            );
+    match pass {
+        GeoPass::Lines => {
+            painter.circle_filled(pos, radius, color);
+        }
+        GeoPass::Labels => {
+            if let Some(text) = label {
+                let font_size = (9.0 * zoom.sqrt()).clamp(8.0, 13.0);
+                let label_pos = Pos2::new(pos.x + radius + 2.0, pos.y - 2.0);
+                text_with_halo(
+                    painter,
+                    label_pos,
+                    Align2::LEFT_CENTER,
+                    text,
+                    FontId::proportional(font_size),
+                    color,
+                );
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1674,6 +1674,25 @@ impl WorkbenchApp {
                 // up regardless of which side arrives first.
                 self.state.live_mode_state.try_capture_forecast();
             }
+
+            // Record the empirical availability lag (S3 upload − ACTUAL
+            // chunk collection time) into the projector's stats bucket.
+            // Uses the chunk's latest-radial time (when the radar finished
+            // this chunk) paired with the most recent arrival stat's
+            // Last-Modified header.
+            if let (Some(chunk_max_secs), Some(s3_at)) = (
+                result.chunk_max_time_secs,
+                self.state
+                    .live_mode_state
+                    .chunk_arrivals
+                    .last()
+                    .and_then(|a| a.s3_last_modified_at),
+            ) {
+                let lag_secs = s3_at - chunk_max_secs;
+                if lag_secs.is_finite() {
+                    self.streaming.record_availability_lag_secs(lag_secs);
+                }
+            }
             if !result.elevations_completed.is_empty() {
                 let vol_start_ts = self
                     .state

--- a/src/main.rs
+++ b/src/main.rs
@@ -1068,7 +1068,7 @@ impl WorkbenchApp {
                 time_until_next,
                 is_volume_end,
                 fetch_latency_ms,
-                projected_volume_end_secs,
+                projected_volume_end_available_at_secs,
                 chunk_projections,
                 arrival_stat,
             } => {
@@ -1081,14 +1081,14 @@ impl WorkbenchApp {
                     is_volume_end,
                     fetch_latency_ms,
                     time_until_next,
-                    projected_volume_end_secs,
+                    projected_volume_end_available_at_secs,
                 );
                 self.state.live_mode_state.handle_realtime_chunk(
                     chunks_in_volume,
                     time_until_next,
                     is_volume_end,
                     now,
-                    projected_volume_end_secs,
+                    projected_volume_end_available_at_secs,
                     chunk_projections,
                 );
 
@@ -2465,7 +2465,7 @@ impl WorkbenchApp {
         if self.state.live_mode_state.is_active() {
             if let Some(duration) = self.streaming.time_until_next() {
                 let now = js_sys::Date::now() / 1000.0;
-                self.state.live_mode_state.next_chunk_expected_at =
+                self.state.live_mode_state.next_chunk_available_at_secs =
                     Some(now + duration.as_secs_f64());
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -244,6 +244,7 @@ impl WorkbenchApp {
 
         // Apply URL parameters (site, time, lat/lon)
         let url_params = state::url_state::parse_from_url();
+        state.dev_mode = url_params.dev;
         if let Some(ref site) = url_params.site {
             state.viz_state.site_id = site.to_uppercase();
             if let Some(site_info) = data::sites::get_site(site) {
@@ -465,7 +466,9 @@ impl WorkbenchApp {
                 sms
             },
             event_modal_state: ui::EventModalState::default(),
-            network_monitor: nexrad::NetworkMonitor::new(),
+            // Lazily initialized when dev mode is enabled (at startup if the
+            // URL has `dev=true`, or when the user toggles it on later).
+            network_monitor: None,
             playback_manager: PlaybackManager::new(),
             alerts_manager: alerts::AlertsManager::new(),
             scrub_cache: ScrubCache::default(),
@@ -476,6 +479,12 @@ impl WorkbenchApp {
         app.state.cross_origin_isolated = nexrad::is_cross_origin_isolated();
         if !app.state.cross_origin_isolated {
             log::warn!("Not cross-origin isolated: SharedArrayBuffer unavailable");
+        }
+
+        // Attach the service-worker network monitor only in dev mode. When
+        // toggled on later, `update_network_stats` will lazily attach it.
+        if app.state.dev_mode {
+            app.network_monitor = nexrad::NetworkMonitor::new();
         }
 
         app
@@ -1074,9 +1083,11 @@ impl WorkbenchApp {
                 chunk_projections,
                 arrival_stat,
             } => {
-                self.state
-                    .session_stats
-                    .record_fetch_latency(fetch_latency_ms);
+                if self.state.dev_mode {
+                    self.state
+                        .session_stats
+                        .record_fetch_latency(fetch_latency_ms);
+                }
                 log::debug!(
                     "Realtime status: chunks_in_volume={} is_end={} latency={:.0}ms next_in={:?} proj_end={:?}",
                     chunks_in_volume,
@@ -1211,9 +1222,11 @@ impl WorkbenchApp {
     /// Per-frame bookkeeping: record stats, apply theme, recompute staleness,
     /// update storm cells, and detect site changes.
     fn apply_frame_setup(&mut self, ctx: &egui::Context) {
-        // Record frame time for FPS meter
-        let dt = ctx.input(|i| i.stable_dt);
-        self.state.session_stats.record_frame_time(dt);
+        // Record frame time for FPS meter (dev mode only)
+        if self.state.dev_mode {
+            let dt = ctx.input(|i| i.stable_dt);
+            self.state.session_stats.record_frame_time(dt);
+        }
 
         // Resolve theme and apply egui visuals
         self.state.is_dark = self.state.theme_mode.is_dark();
@@ -1540,22 +1553,24 @@ impl WorkbenchApp {
             result.context.fetch_latency_ms,
         );
 
-        self.state
-            .session_stats
-            .record_fetch_latency(result.context.fetch_latency_ms);
-        self.state
-            .session_stats
-            .record_processing_time(result.total_ms);
+        if self.state.dev_mode {
+            self.state
+                .session_stats
+                .record_fetch_latency(result.context.fetch_latency_ms);
+            self.state
+                .session_stats
+                .record_processing_time(result.total_ms);
 
-        // Store detailed ingest timing for the detail modal.
-        self.state.session_stats.last_ingest_detail = Some(crate::state::IngestTimingDetail {
-            split_ms: result.split_ms,
-            decompress_ms: result.decompress_ms,
-            decode_ms: result.decode_ms,
-            extract_ms: result.extract_ms,
-            store_ms: result.store_ms,
-            index_ms: result.index_ms,
-        });
+            // Store detailed ingest timing for the detail modal.
+            self.state.session_stats.last_ingest_detail = Some(crate::state::IngestTimingDetail {
+                split_ms: result.split_ms,
+                decompress_ms: result.decompress_ms,
+                decode_ms: result.decode_ms,
+                extract_ms: result.extract_ms,
+                store_ms: result.store_ms,
+                index_ms: result.index_ms,
+            });
+        }
 
         // Track the scan for render requests
         self.render
@@ -1931,7 +1946,9 @@ impl WorkbenchApp {
             result.total_ms,
         );
 
-        self.state.session_stats.record_render_time(result.total_ms);
+        if self.state.dev_mode {
+            self.state.session_stats.record_render_time(result.total_ms);
+        }
 
         // Cache decoded data for stateless sweep animation
         let result_sweep_id = sweep_cache_key(
@@ -2022,13 +2039,15 @@ impl WorkbenchApp {
         }
         let gpu_upload_ms = t_gpu.elapsed().as_secs_f64() * 1000.0;
 
-        // Store detailed render timing for the detail modal.
-        self.state.session_stats.last_render_detail = Some(crate::state::RenderTimingDetail {
-            fetch_ms: result.fetch_ms,
-            deser_ms: result.deser_ms,
-            marshal_ms: result.marshal_ms,
-            gpu_upload_ms,
-        });
+        // Store detailed render timing for the detail modal (dev mode only).
+        if self.state.dev_mode {
+            self.state.session_stats.last_render_detail = Some(crate::state::RenderTimingDetail {
+                fetch_ms: result.fetch_ms,
+                deser_ms: result.deser_ms,
+                marshal_ms: result.marshal_ms,
+                gpu_upload_ms,
+            });
+        }
 
         // GPU upload complete.
         self.state.session_stats.pipeline.mark_render_done();
@@ -2277,12 +2296,14 @@ impl WorkbenchApp {
                 fetch_latency_ms,
                 decode_latency_ms,
             } => {
-                self.state
-                    .session_stats
-                    .record_fetch_latency(*fetch_latency_ms);
-                self.state
-                    .session_stats
-                    .record_processing_time(*decode_latency_ms);
+                if self.state.dev_mode {
+                    self.state
+                        .session_stats
+                        .record_fetch_latency(*fetch_latency_ms);
+                    self.state
+                        .session_stats
+                        .record_processing_time(*decode_latency_ms);
+                }
                 (Some(scan), false)
             }
             nexrad::DownloadResult::CacheHit(scan) => (Some(scan), true),
@@ -2998,6 +3019,15 @@ impl WorkbenchApp {
         self.state
             .session_stats
             .update_from_network_stats(&network_stats);
+
+        // Service worker metrics are only collected in dev mode. Lazily
+        // attach the listener the first time dev mode becomes active.
+        if !self.state.dev_mode {
+            return;
+        }
+        if self.network_monitor.is_none() {
+            self.network_monitor = nexrad::NetworkMonitor::new();
+        }
 
         // Drain service worker network metrics into app state
         if let Some(ref monitor) = self.network_monitor {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1700,6 +1700,12 @@ impl WorkbenchApp {
                 let lag_secs = s3_at - chunk_max_secs;
                 if lag_secs.is_finite() {
                     self.streaming.record_availability_lag_secs(lag_secs);
+                    // Back-fill the per-chunk availability lag onto the most
+                    // recent arrival record so the diagnostics modal can
+                    // surface per-chunk lag (not just the global median).
+                    self.state
+                        .live_mode_state
+                        .attach_availability_lag_to_last_arrival((lag_secs * 1000.0) as i64);
                 }
             }
             if !result.elevations_completed.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@
 mod alerts;
 mod data;
 mod geo;
+mod net;
 mod nexrad;
 mod state;
 mod ui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1867,7 +1867,6 @@ impl WorkbenchApp {
             } else {
                 let now = js_sys::Date::now() / 1000.0;
                 self.state.playback_state.set_playback_position(now);
-                self.state.playback_state.center_view_on(now);
             }
 
             log::debug!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1069,6 +1069,7 @@ impl WorkbenchApp {
                 is_volume_end,
                 fetch_latency_ms,
                 projected_volume_end_available_at_secs,
+                projected_volume_end_collection_secs,
                 chunk_projections,
                 arrival_stat,
             } => {
@@ -1089,6 +1090,7 @@ impl WorkbenchApp {
                     is_volume_end,
                     now,
                     projected_volume_end_available_at_secs,
+                    projected_volume_end_collection_secs,
                     chunk_projections,
                 );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1228,16 +1228,22 @@ impl WorkbenchApp {
             self.state.session_stats.record_frame_time(dt);
         }
 
-        // Resolve theme and apply egui visuals
+        // Resolve theme and apply egui visuals. The `Visuals` struct is
+        // cloned into the egui context on each `set_visuals` call, so guard
+        // against the per-frame allocation+copy when the resolved theme
+        // hasn't changed.
         self.state.is_dark = self.state.theme_mode.is_dark();
-        if self.state.is_dark {
-            let mut visuals = egui::Visuals::dark();
-            visuals.panel_fill = egui::Color32::BLACK;
-            visuals.window_fill = egui::Color32::BLACK;
-            visuals.extreme_bg_color = egui::Color32::BLACK;
-            ctx.set_visuals(visuals);
-        } else {
-            ctx.set_visuals(egui::Visuals::light());
+        if self.state.render_cache.last_dark != Some(self.state.is_dark) {
+            if self.state.is_dark {
+                let mut visuals = egui::Visuals::dark();
+                visuals.panel_fill = egui::Color32::BLACK;
+                visuals.window_fill = egui::Color32::BLACK;
+                visuals.extreme_bg_color = egui::Color32::BLACK;
+                ctx.set_visuals(visuals);
+            } else {
+                ctx.set_visuals(egui::Visuals::light());
+            }
+            self.state.render_cache.last_dark = Some(self.state.is_dark);
         }
 
         // Recompute data staleness every frame against wall-clock time.
@@ -2840,14 +2846,30 @@ impl WorkbenchApp {
 
         let is_auto = self.state.viz_state.elevation_selection.is_auto();
 
-        // Determine which sweep should be the previous-sweep under-layer.
-        let prev_info = PlaybackManager::find_prev_sweep(
-            &self.state.radar_timeline,
-            playback_ts,
+        // Cache the previous-sweep search by its inputs. When the user is
+        // paused on the same sweep frame after frame, the timeline walk in
+        // `find_prev_sweep` becomes a no-op cache hit.
+        let cache_key = state::PrevSweepCacheKey {
+            playback_ts_bits: playback_ts.to_bits(),
             displayed_elev,
             is_auto,
-            MAX_SCAN_AGE_SECS,
-        );
+            scan_count: self.state.radar_timeline.scans.len(),
+        };
+        let prev_info = if self.state.render_cache.prev_sweep_cache_key.as_ref() == Some(&cache_key)
+        {
+            self.state.render_cache.prev_sweep_cache_value
+        } else {
+            let computed = PlaybackManager::find_prev_sweep(
+                &self.state.radar_timeline,
+                playback_ts,
+                displayed_elev,
+                is_auto,
+                MAX_SCAN_AGE_SECS,
+            );
+            self.state.render_cache.prev_sweep_cache_key = Some(cache_key);
+            self.state.render_cache.prev_sweep_cache_value = computed;
+            computed
+        };
 
         let (prev_scan_key_ts, prev_elev_num, prev_elev_deg, prev_start, prev_end) = match prev_info
         {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1689,24 +1689,31 @@ impl WorkbenchApp {
             // Uses the chunk's latest-radial time (when the radar finished
             // this chunk) paired with the most recent arrival stat's
             // Last-Modified header.
-            if let (Some(chunk_max_secs), Some(s3_at)) = (
-                result.chunk_max_time_secs,
-                self.state
+            if let Some(chunk_max_secs) = result.chunk_max_time_secs {
+                // Lag requires both a parsed collection time AND the chunk's
+                // S3 Last-Modified header. Stamp collection time unconditionally
+                // and lag only when both are finite.
+                let s3_at = self
+                    .state
                     .live_mode_state
                     .chunk_arrivals
                     .last()
-                    .and_then(|a| a.s3_last_modified_at),
-            ) {
-                let lag_secs = s3_at - chunk_max_secs;
-                if lag_secs.is_finite() {
-                    self.streaming.record_availability_lag_secs(lag_secs);
-                    // Back-fill the per-chunk availability lag onto the most
-                    // recent arrival record so the diagnostics modal can
-                    // surface per-chunk lag (not just the global median).
-                    self.state
-                        .live_mode_state
-                        .attach_availability_lag_to_last_arrival((lag_secs * 1000.0) as i64);
+                    .and_then(|a| a.s3_last_modified_at);
+                let lag_secs = s3_at
+                    .map(|s3| s3 - chunk_max_secs)
+                    .filter(|v| v.is_finite());
+                if let Some(lag) = lag_secs {
+                    self.streaming.record_availability_lag_secs(lag);
                 }
+                // Back-fill onto the most recent arrival so the diagnostics
+                // modal can compute per-chunk collection-space intervals
+                // and (when available) per-chunk availability lag.
+                self.state
+                    .live_mode_state
+                    .attach_collection_data_to_last_arrival(
+                        chunk_max_secs,
+                        lag_secs.map(|lag| (lag * 1000.0) as i64),
+                    );
             }
             if !result.elevations_completed.is_empty() {
                 let vol_start_ts = self

--- a/src/main.rs
+++ b/src/main.rs
@@ -1664,6 +1664,10 @@ impl WorkbenchApp {
             // header (the first radial of the volume scan).
             if let Some(header_time) = result.volume_header_time_secs {
                 self.state.live_mode_state.current_volume_start = Some(header_time);
+                // Push the parsed collection time down into the streaming
+                // loop so it can anchor future-chunk projections on ACTUAL
+                // collection time rather than S3 upload time.
+                self.streaming.record_volume_header_time_secs(header_time);
                 // Retry the forecast snapshot in case the VCP pattern was
                 // already recorded before the volume-start timestamp arrived.
                 // `record_vcp` below also calls this, so the usual flow picks

--- a/src/main.rs
+++ b/src/main.rs
@@ -1666,15 +1666,22 @@ impl WorkbenchApp {
             // header (the first radial of the volume scan).
             if let Some(header_time) = result.volume_header_time_secs {
                 self.state.live_mode_state.current_volume_start = Some(header_time);
-                // Push the parsed collection time down into the streaming
-                // loop so it can anchor future-chunk projections on ACTUAL
-                // collection time rather than S3 upload time.
-                self.streaming.record_volume_header_time_secs(header_time);
                 // Retry the forecast snapshot in case the VCP pattern was
                 // already recorded before the volume-start timestamp arrived.
                 // `record_vcp` below also calls this, so the usual flow picks
                 // up regardless of which side arrives first.
                 self.state.live_mode_state.try_capture_forecast();
+            }
+
+            // Push the most recent chunk's collection-end time down to the
+            // streaming loop so the next projection anchors on the current
+            // chunk's actual collection time (not the volume's start time).
+            // Without this, forward-chunk projections come out as
+            // volume_start + small_offset, landing in the past once the
+            // volume is past its first chunk.
+            if let Some(chunk_max_secs) = result.chunk_max_time_secs {
+                self.streaming
+                    .record_chunk_collection_end_secs(chunk_max_secs);
             }
 
             // Record the empirical availability lag (S3 upload − ACTUAL

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,0 +1,7 @@
+//! Networking primitives shared across data sources.
+//!
+//! Today this is just the [`retry`] module — a single retry policy applied
+//! consistently to every outbound HTTP request the app makes (S3 archive,
+//! S3 real-time chunks, NWS alerts, zip-code geocoding, NOAA mosaic).
+
+pub mod retry;

--- a/src/net/retry.rs
+++ b/src/net/retry.rs
@@ -1,0 +1,207 @@
+//! Exponential-backoff retry with full jitter, applied uniformly across all
+//! outbound HTTP calls.
+//!
+//! Each call site supplies a closure that performs one attempt and classifies
+//! the outcome as [`Verdict::Ok`], [`Verdict::Retry`], or [`Verdict::Terminal`].
+//! The helper handles per-attempt timeouts, between-attempt sleeps, the
+//! `Retry-After` hint, and the overall attempt/wall-clock budget.
+//!
+//! Two presets cover the call sites we have today:
+//! - [`DEFAULT_POLICY`] — transient-error recovery for one-shot user-driven
+//!   fetches (archive list/download, alerts, geocoding).
+//! - [`REALTIME_CHUNK_POLICY`] — recovery after a timing-prediction-driven
+//!   first attempt misses on a real-time chunk that hasn't been published yet.
+
+use std::future::Future;
+use std::time::Duration;
+use wasm_bindgen::prelude::*;
+
+/// Outcome of a single attempt.
+pub enum Verdict<T> {
+    /// Attempt succeeded — return this value.
+    Ok(T),
+    /// Attempt failed transiently — back off and try again.
+    /// `after` carries an optional `Retry-After` hint from the server.
+    Retry { after: Option<Duration> },
+    /// Attempt failed in a way that further retries cannot fix.
+    Terminal(String),
+}
+
+/// Backoff parameters. See module docs for preset rationale.
+#[derive(Clone, Debug)]
+pub struct RetryPolicy {
+    /// Base delay for exponential backoff. Delay before retry N is drawn from
+    /// `random_uniform(0, min(cap, base * 2^(N-1)))` (full jitter).
+    pub base: Duration,
+    /// Upper bound on the per-retry delay window.
+    pub cap: Duration,
+    /// Total attempts including the first. `max_attempts = 1` disables retry.
+    pub max_attempts: u32,
+    /// Wall-clock budget across all attempts. Whichever fires first
+    /// (`max_attempts` or `total_budget`) ends the loop.
+    pub total_budget: Duration,
+    /// Timeout applied to each individual attempt.
+    pub per_attempt_timeout: Duration,
+}
+
+/// Default policy for one-shot user-driven fetches: archive list/download,
+/// NWS alerts, zip-code lookup, mosaic refresh.
+pub const DEFAULT_POLICY: RetryPolicy = RetryPolicy {
+    base: Duration::from_millis(250),
+    cap: Duration::from_secs(4),
+    max_attempts: 4,
+    total_budget: Duration::from_secs(30),
+    per_attempt_timeout: Duration::from_secs(15),
+};
+
+/// Recovery policy for real-time chunk fetch when the timing-prediction-driven
+/// first attempt returns 404. Larger base delay (chunks land seconds late, not
+/// milliseconds), shorter per-attempt timeout (a 404 round-trip is fast),
+/// total budget sized to roughly match the prior 25×500ms+2.5s polling window.
+pub const REALTIME_CHUNK_POLICY: RetryPolicy = RetryPolicy {
+    base: Duration::from_millis(500),
+    cap: Duration::from_secs(4),
+    max_attempts: 6,
+    total_budget: Duration::from_secs(15),
+    per_attempt_timeout: Duration::from_secs(5),
+};
+
+/// Run `op` under `policy`. Returns the first `Ok` value, or the first
+/// `Terminal`, or a budget-exceeded error.
+///
+/// The closure receives the 1-based attempt number for diagnostics. Note: the
+/// returned future must not borrow from the closure's environment — capture
+/// state by clone or via shared ownership. Call sites that need to mutate
+/// captured state across attempts (e.g. an `&mut Iterator`) should use the
+/// per-attempt primitives ([`attempt_with_timeout`], [`compute_delay`],
+/// [`sleep_duration`]) directly in an inline loop.
+pub async fn with_retry<F, Fut, T>(
+    policy: &RetryPolicy,
+    label: &str,
+    mut op: F,
+) -> Result<T, String>
+where
+    F: FnMut(u32) -> Fut,
+    Fut: Future<Output = Verdict<T>>,
+{
+    let started = web_time::Instant::now();
+    let mut last_msg: Option<String> = None;
+
+    for attempt in 1..=policy.max_attempts {
+        let verdict = attempt_with_timeout(op(attempt), policy.per_attempt_timeout).await;
+        match verdict {
+            Verdict::Ok(v) => return Ok(v),
+            Verdict::Terminal(msg) => return Err(msg),
+            Verdict::Retry { after } => {
+                last_msg = Some(format!("attempt {} failed", attempt));
+                if attempt >= policy.max_attempts {
+                    break;
+                }
+                let elapsed = started.elapsed();
+                if elapsed >= policy.total_budget {
+                    return Err(format!(
+                        "{}: budget {}s exhausted after {} attempts",
+                        label,
+                        policy.total_budget.as_secs(),
+                        attempt
+                    ));
+                }
+                let mut delay = compute_delay(policy, attempt, after);
+                let remaining = policy.total_budget.saturating_sub(elapsed);
+                if delay > remaining {
+                    delay = remaining;
+                }
+                sleep_duration(delay).await;
+            }
+        }
+    }
+
+    Err(format!(
+        "{}: gave up after {} attempts ({})",
+        label,
+        policy.max_attempts,
+        last_msg.as_deref().unwrap_or("retry exhausted")
+    ))
+}
+
+/// Compute the backoff delay between attempt `n` and attempt `n+1`. Honors a
+/// server-supplied `Retry-After`, otherwise full-jitter exponential.
+pub fn compute_delay(
+    policy: &RetryPolicy,
+    failure_count: u32,
+    retry_after: Option<Duration>,
+) -> Duration {
+    if let Some(after) = retry_after {
+        // Honor server hint, but bound it so a misbehaving server cannot
+        // pin us indefinitely. 2× the configured cap is the ceiling.
+        let ceiling = policy.cap.saturating_mul(2);
+        return after.min(ceiling);
+    }
+
+    // Exponential window: base * 2^(failure_count - 1), saturating at cap.
+    // failure_count is 1-based (1 means we just had our first failure, so
+    // this is the wait before attempt 2).
+    let shift = failure_count.saturating_sub(1).min(20);
+    let exp_ms = (policy.base.as_millis() as u64).saturating_mul(1u64 << shift);
+    let cap_ms = policy.cap.as_millis() as u64;
+    let window_ms = exp_ms.min(cap_ms);
+
+    // Full jitter: uniform random in [0, window_ms).
+    let jitter = js_sys::Math::random() * window_ms as f64;
+    Duration::from_millis(jitter as u64)
+}
+
+/// Run `fut` to completion or treat it as a transient failure if it doesn't
+/// finish within `timeout`.
+pub async fn attempt_with_timeout<Fut, T>(fut: Fut, timeout: Duration) -> Verdict<T>
+where
+    Fut: Future<Output = Verdict<T>>,
+{
+    let timer = sleep_duration(timeout);
+    futures_util::pin_mut!(fut);
+    futures_util::pin_mut!(timer);
+    match futures_util::future::select(fut, timer).await {
+        futures_util::future::Either::Left((verdict, _)) => verdict,
+        futures_util::future::Either::Right(((), _)) => Verdict::Retry { after: None },
+    }
+}
+
+/// Wait approximately `dur` using browser `setTimeout`. The browser clamps
+/// the minimum delay (~4ms in modern browsers); below that `setTimeout(0)`
+/// just yields.
+pub async fn sleep_duration(dur: Duration) {
+    let ms = dur.as_millis().min(u32::MAX as u128) as u32;
+    sleep_ms(ms).await;
+}
+
+/// Wait `ms` milliseconds via browser `setTimeout`.
+pub async fn sleep_ms(ms: u32) {
+    #[wasm_bindgen]
+    extern "C" {
+        #[wasm_bindgen(js_name = setTimeout)]
+        fn set_timeout(closure: &Closure<dyn FnMut()>, millis: u32) -> i32;
+    }
+
+    let (tx, rx) = futures_channel::oneshot::channel::<()>();
+    let closure = Closure::once(move || {
+        let _ = tx.send(());
+    });
+    set_timeout(&closure, ms);
+    let _ = rx.await;
+}
+
+/// Parse an HTTP `Retry-After` header value.
+///
+/// Accepts either delta-seconds (e.g., `"120"`) or HTTP-date. Returns `None`
+/// for malformed values; HTTP-date parsing is best-effort via chrono.
+#[allow(dead_code)] // wired in by the alerts endpoint in a follow-up commit
+pub fn parse_retry_after(header: &str) -> Option<Duration> {
+    let trimmed = header.trim();
+    if let Ok(secs) = trimmed.parse::<u64>() {
+        return Some(Duration::from_secs(secs));
+    }
+    let parsed = chrono::DateTime::parse_from_rfc2822(trimmed).ok()?;
+    let now = chrono::Utc::now();
+    let delta = parsed.with_timezone(&chrono::Utc) - now;
+    delta.to_std().ok()
+}

--- a/src/nexrad/decode_worker/receive.rs
+++ b/src/nexrad/decode_worker/receive.rs
@@ -283,6 +283,8 @@ fn handle_chunk_ingested_message(
             last_radial_azimuth: r.last_radial_azimuth,
             last_radial_time_secs: r.last_radial_time_secs,
             volume_header_time_secs: r.volume_header_time_secs,
+            chunk_min_time_secs: r.chunk_min_time_secs,
+            chunk_max_time_secs: r.chunk_max_time_secs,
             chunk_elev_spans: r.chunk_elev_spans,
             chunk_elev_az_ranges: r.chunk_elev_az_ranges,
         }));

--- a/src/nexrad/decode_worker/types.rs
+++ b/src/nexrad/decode_worker/types.rs
@@ -68,6 +68,10 @@ pub(super) struct ChunkIngestResultMsg {
     #[serde(default)]
     pub volume_header_time_secs: Option<f64>,
     #[serde(default)]
+    pub chunk_min_time_secs: Option<f64>,
+    #[serde(default)]
+    pub chunk_max_time_secs: Option<f64>,
+    #[serde(default)]
     pub chunk_elev_spans: Vec<(u8, f64, f64, u32)>,
     #[serde(default)]
     pub chunk_elev_az_ranges: Vec<(u8, f32, f32)>,
@@ -333,6 +337,13 @@ pub struct ChunkIngestResult {
     pub last_radial_time_secs: Option<f64>,
     /// Volume header date/time in Unix seconds (authoritative scan start time).
     pub volume_header_time_secs: Option<f64>,
+    /// Earliest radial collection time (Unix seconds) observed in this chunk.
+    #[allow(dead_code)] // Consumed by debug UI in a later commit.
+    pub chunk_min_time_secs: Option<f64>,
+    /// Latest radial collection time (Unix seconds) observed in this chunk.
+    /// Paired with the chunk's S3 upload time yields the per-chunk
+    /// availability lag (AVAILABILITY − ACTUAL collection).
+    pub chunk_max_time_secs: Option<f64>,
     /// Per-elevation time spans within this chunk:
     /// (elevation_number, start_secs, end_secs, radial_count).
     pub chunk_elev_spans: Vec<(u8, f64, f64, u32)>,

--- a/src/nexrad/download.rs
+++ b/src/nexrad/download.rs
@@ -6,6 +6,7 @@
 use super::archive_index::{current_timestamp_secs, ArchiveFileMeta, ArchiveListing};
 use super::types::{CachedScan, DownloadResult};
 use crate::data::{DataFacade, ScanCompleteness, ScanKey};
+use crate::net::retry::{with_retry, Verdict, DEFAULT_POLICY};
 use chrono::NaiveDate;
 use eframe::egui;
 use std::cell::RefCell;
@@ -229,19 +230,16 @@ async fn fetch_archive_listing(site_id: &str, date: NaiveDate) -> ListingResult 
 
     log::debug!("Fetching archive listing for {}/{}", site_id, date);
 
-    let files = match with_timeout(
-        archive::list_files(site_id, &date),
-        REQUEST_TIMEOUT_MS,
-        "Archive listing",
-    )
+    let site_owned = site_id.to_string();
+    let files = match with_retry(&DEFAULT_POLICY, "archive_list", |_attempt| {
+        let s = site_owned.clone();
+        async move { classify_nexrad_result(archive::list_files(&s, &date).await) }
+    })
     .await
     {
-        Ok(Ok(files)) => files,
-        Ok(Err(e)) => {
-            return ListingResult::Error(format!("Failed to list files: {}", e));
-        }
-        Err(timeout_msg) => {
-            return ListingResult::Error(timeout_msg);
+        Ok(files) => files,
+        Err(msg) => {
+            return ListingResult::Error(format!("Failed to list files: {}", msg));
         }
     };
 
@@ -277,46 +275,26 @@ async fn fetch_archive_listing(site_id: &str, date: NaiveDate) -> ListingResult 
     }
 }
 
-/// Timeout duration for individual network requests (listing + download).
-const REQUEST_TIMEOUT_MS: u32 = 30_000; // 30 seconds
-
-/// Run a future with a timeout. Returns `Err(msg)` if the timeout fires first.
-async fn with_timeout<T>(
-    future: impl std::future::Future<Output = T>,
-    timeout_ms: u32,
-    label: &str,
-) -> Result<T, String> {
-    let label = label.to_string();
-    let timeout = async {
-        sleep_ms(timeout_ms).await;
-    };
-
-    futures_util::pin_mut!(future);
-    futures_util::pin_mut!(timeout);
-
-    match futures_util::future::select(future, timeout).await {
-        futures_util::future::Either::Left((val, _)) => Ok(val),
-        futures_util::future::Either::Right(_) => {
-            Err(format!("{} timed out after {}s", label, timeout_ms / 1000))
-        }
+/// Map a `nexrad-data` archive result to a retry [`Verdict`].
+///
+/// Transport-layer S3 errors (network failures, 5xx, mid-stream errors,
+/// truncated lists) are retryable. Everything else — including `S3ObjectNotFound`
+/// (404), which means the file genuinely does not exist in the archive — is
+/// terminal.
+fn classify_nexrad_result<T>(result: nexrad_data::result::Result<T>) -> Verdict<T> {
+    use nexrad_data::result::aws::AWSError;
+    use nexrad_data::result::Error;
+    match result {
+        Ok(v) => Verdict::Ok(v),
+        Err(Error::AWS(
+            AWSError::S3GetObjectRequest(_)
+            | AWSError::S3GetObject(_)
+            | AWSError::S3Streaming(_)
+            | AWSError::S3ListObjects(_)
+            | AWSError::TruncatedListObjectsResponse,
+        )) => Verdict::Retry { after: None },
+        Err(e) => Verdict::Terminal(format!("{}", e)),
     }
-}
-
-async fn sleep_ms(ms: u32) {
-    use wasm_bindgen::prelude::*;
-
-    #[wasm_bindgen]
-    extern "C" {
-        #[wasm_bindgen(js_name = setTimeout)]
-        fn set_timeout(closure: &Closure<dyn FnMut()>, millis: u32) -> i32;
-    }
-
-    let (tx, rx) = futures_channel::oneshot::channel::<()>();
-    let closure = Closure::once(move || {
-        let _ = tx.send(());
-    });
-    set_timeout(&closure, ms);
-    let _ = rx.await;
 }
 
 /// Downloads a specific file from the archive.
@@ -344,28 +322,21 @@ async fn download_specific_file(
 
     // Request 1: List files to find the one we want
     stats.request_started();
-    let files = match with_timeout(
-        archive::list_files(site_id, &date),
-        REQUEST_TIMEOUT_MS,
-        "Archive listing",
-    )
+    let site_owned = site_id.to_string();
+    let files = match with_retry(&DEFAULT_POLICY, "archive_list", |_attempt| {
+        let s = site_owned.clone();
+        async move { classify_nexrad_result(archive::list_files(&s, &date).await) }
+    })
     .await
     {
-        Ok(Ok(files)) => {
+        Ok(files) => {
             stats.request_completed(0);
             files
         }
-        Ok(Err(e)) => {
+        Err(msg) => {
             stats.request_completed(0);
             return DownloadResult::Error {
-                message: format!("Failed to list files: {}", e),
-                scan_start: timestamp,
-            };
-        }
-        Err(timeout_msg) => {
-            stats.request_completed(0);
-            return DownloadResult::Error {
-                message: timeout_msg,
+                message: format!("Failed to list files: {}", msg),
                 scan_start: timestamp,
             };
         }
@@ -385,25 +356,17 @@ async fn download_specific_file(
     // Request 2: Download the file
     stats.request_started();
     let fetch_start = web_time::Instant::now();
-    let file = match with_timeout(
-        archive::download_file(file_meta),
-        REQUEST_TIMEOUT_MS,
-        "File download",
-    )
+    let file = match with_retry(&DEFAULT_POLICY, "archive_download", |_attempt| {
+        let id = file_meta.clone();
+        async move { classify_nexrad_result(archive::download_file(id).await) }
+    })
     .await
     {
-        Ok(Ok(file)) => file,
-        Ok(Err(e)) => {
+        Ok(file) => file,
+        Err(msg) => {
             stats.request_completed(0);
             return DownloadResult::Error {
-                message: format!("Download failed: {}", e),
-                scan_start: timestamp,
-            };
-        }
-        Err(timeout_msg) => {
-            stats.request_completed(0);
-            return DownloadResult::Error {
-                message: timeout_msg,
+                message: format!("Download failed: {}", msg),
                 scan_start: timestamp,
             };
         }

--- a/src/nexrad/mod.rs
+++ b/src/nexrad/mod.rs
@@ -29,6 +29,7 @@ pub(crate) mod render_coordinator;
 pub(crate) mod render_request;
 pub(crate) mod streaming_manager;
 mod streaming_state;
+pub(crate) mod timing;
 mod types;
 mod volume_discovery;
 pub(crate) mod volume_ray_renderer;

--- a/src/nexrad/national_mosaic.rs
+++ b/src/nexrad/national_mosaic.rs
@@ -3,9 +3,12 @@
 //! Fetches a CONUS base-reflectivity composite PNG (NOAA NCEP MRMS via
 //! GeoServer WMS) and makes it available as a GPU texture for painting
 //! under per-site radar data. Polls only while the layer is enabled;
-//! dropping the layer releases the texture and stops polling. Failed
-//! fetches back off so a broken endpoint does not retry every frame.
+//! dropping the layer releases the texture and stops polling. Each refresh
+//! routes through `crate::net::retry::with_retry`, so transient failures get
+//! a short burst of exponential-backoff retries instead of waiting for the
+//! full refresh interval to roll around.
 
+use crate::net::retry::{with_retry, Verdict, DEFAULT_POLICY};
 use eframe::egui;
 use futures_channel::oneshot;
 use std::cell::RefCell;
@@ -34,11 +37,10 @@ const MOSAIC_URL: &str = concat!(
 const MOSAIC_BOUNDS: (f64, f64, f64, f64) = (-126.0, 24.0, -66.0, 50.0);
 
 /// How often to refetch while enabled (seconds). Matches source cadence.
+/// Applied for both successful and failed attempts — transient failures are
+/// already absorbed by `with_retry`'s in-burst backoff, so a persistent
+/// failure just means the next 120 s tick will retry.
 const REFRESH_INTERVAL_SECS: f64 = 120.0;
-
-/// Backoff after a failed fetch (seconds). Stops the per-frame retry storm
-/// that would otherwise hammer the endpoint when it returns errors.
-const FAILURE_BACKOFF_SECS: f64 = 300.0;
 
 enum FetchOutcome {
     Loaded {
@@ -54,10 +56,8 @@ enum FetchOutcome {
 pub struct NationalMosaic {
     texture: Option<egui::TextureHandle>,
     /// Timestamp (seconds) of the last attempt — successful or not. Used to
-    /// gate the next attempt against the success or failure interval.
+    /// gate the next attempt against `REFRESH_INTERVAL_SECS`.
     last_attempt_ts: Option<f64>,
-    /// True if the most recent attempt failed; controls which interval applies.
-    last_attempt_failed: bool,
     in_flight: Rc<RefCell<bool>>,
     sender: Sender<FetchOutcome>,
     receiver: Receiver<FetchOutcome>,
@@ -69,7 +69,6 @@ impl Default for NationalMosaic {
         Self {
             texture: None,
             last_attempt_ts: None,
-            last_attempt_failed: false,
             in_flight: Rc::new(RefCell::new(false)),
             sender,
             receiver,
@@ -86,7 +85,6 @@ impl NationalMosaic {
             if self.texture.is_some() || self.last_attempt_ts.is_some() {
                 self.texture = None;
                 self.last_attempt_ts = None;
-                self.last_attempt_failed = false;
             }
             while self.receiver.try_recv().is_ok() {}
             return;
@@ -99,11 +97,9 @@ impl NationalMosaic {
                         ctx.load_texture("national_mosaic", image, egui::TextureOptions::LINEAR);
                     self.texture = Some(handle);
                     self.last_attempt_ts = Some(fetched_at);
-                    self.last_attempt_failed = false;
                 }
                 FetchOutcome::Failed { attempted_at } => {
                     self.last_attempt_ts = Some(attempted_at);
-                    self.last_attempt_failed = true;
                 }
             }
         }
@@ -113,14 +109,9 @@ impl NationalMosaic {
         }
 
         let now = js_sys::Date::now() / 1000.0;
-        let interval = if self.last_attempt_failed {
-            FAILURE_BACKOFF_SECS
-        } else {
-            REFRESH_INTERVAL_SECS
-        };
         let due = match self.last_attempt_ts {
             None => true,
-            Some(ts) => now - ts >= interval,
+            Some(ts) => now - ts >= REFRESH_INTERVAL_SECS,
         };
         if !due {
             return;
@@ -131,13 +122,27 @@ impl NationalMosaic {
         let in_flight = self.in_flight.clone();
         let ctx_clone = ctx.clone();
         wasm_bindgen_futures::spawn_local(async move {
-            let outcome = match fetch_and_decode(MOSAIC_URL).await {
+            let outcome = match with_retry(&DEFAULT_POLICY, "national_mosaic", |_attempt| async {
+                match fetch_and_decode(MOSAIC_URL).await {
+                    Ok(image) => Verdict::Ok(image),
+                    Err(e) => {
+                        // The HtmlImageElement load API doesn't surface HTTP
+                        // status codes, so we can't distinguish 4xx from 5xx
+                        // from network failure. Treat all errors as transient
+                        // and let the policy's attempt budget bound it.
+                        log::debug!("National mosaic fetch attempt failed: {}", e);
+                        Verdict::Retry { after: None }
+                    }
+                }
+            })
+            .await
+            {
                 Ok(image) => FetchOutcome::Loaded {
                     image,
                     fetched_at: js_sys::Date::now() / 1000.0,
                 },
-                Err(e) => {
-                    log::warn!("National mosaic fetch failed: {}", e);
+                Err(msg) => {
+                    log::warn!("National mosaic fetch failed: {}", msg);
                     FetchOutcome::Failed {
                         attempted_at: js_sys::Date::now() / 1000.0,
                     }

--- a/src/nexrad/persistence_manager.rs
+++ b/src/nexrad/persistence_manager.rs
@@ -81,6 +81,7 @@ impl PersistenceManager {
             state.viz_state.center_lat,
             state.viz_state.center_lon,
             &view,
+            state.dev_mode,
         );
 
         // Save user preferences if changed (piggyback on URL throttle)

--- a/src/nexrad/realtime.rs
+++ b/src/nexrad/realtime.rs
@@ -765,18 +765,24 @@ async fn streaming_loop(
                 // chunk is "current".
                 let anchor_source = Some(iter.current_anchor_source());
 
-                let (bucket_key, stats_n_at_prediction, scheduler_path, physics_breakdown) =
-                    match cur_diagnostics.as_ref() {
-                        Some(d) => (
-                            d.bucket
-                                .as_ref()
-                                .map(crate::state::BucketKey::from_characteristics),
-                            d.stats_n_at_prediction,
-                            Some(d.path),
-                            d.physics_breakdown,
-                        ),
-                        None => (None, 0, None, None),
-                    };
+                let (
+                    bucket_key,
+                    stats_n_at_prediction,
+                    scheduler_path,
+                    physics_breakdown,
+                    predicted_wait_secs,
+                ) = match cur_diagnostics.as_ref() {
+                    Some(d) => (
+                        d.bucket
+                            .as_ref()
+                            .map(crate::state::BucketKey::from_characteristics),
+                        d.stats_n_at_prediction,
+                        Some(d.path),
+                        d.physics_breakdown,
+                        Some(d.duration.num_milliseconds() as f64 / 1000.0),
+                    ),
+                    None => (None, 0, None, None, None),
+                };
 
                 let arrival_stat = crate::state::ChunkArrivalStat {
                     sequence: chunks_in_volume,
@@ -795,6 +801,8 @@ async fn streaming_loop(
                     physics_breakdown,
                     anchor_source,
                     availability_lag_ms: None,
+                    collection_time_secs: None,
+                    predicted_wait_secs,
                 };
 
                 // Reset tracking state for the next chunk

--- a/src/nexrad/realtime.rs
+++ b/src/nexrad/realtime.rs
@@ -91,6 +91,12 @@ struct RealtimeState {
     active: bool,
     time_until_next: Option<Duration>,
     stop_requested: bool,
+    /// ACTUAL category: most recently observed volume header time (Unix
+    /// seconds), parsed by the worker from the first Message 31 radial of
+    /// the current volume. Pushed in from `main.rs` after each ingest
+    /// response; consumed by the streaming loop to populate the projection
+    /// anchor in a later commit.
+    pending_volume_header_time_secs: Option<f64>,
 }
 
 /// Channel for real-time NEXRAD streaming.
@@ -159,6 +165,13 @@ impl RealtimeChannel {
             Some(state.results.remove(0))
         }
     }
+
+    /// Push the ACTUAL volume header time parsed by the worker after an
+    /// ingest response. The streaming loop picks this up and stamps it onto
+    /// the `StreamingState` before the next projection.
+    pub fn record_volume_header_time_secs(&self, secs: f64) {
+        self.state.borrow_mut().pending_volume_header_time_secs = Some(secs);
+    }
 }
 
 /// Build projection info from the streaming state's current position.
@@ -204,6 +217,31 @@ fn get_projected_volume_end_available_at_secs(state: &StreamingState) -> Option<
     state
         .projected_volume_end_available_at()
         .map(|dt| dt.timestamp() as f64)
+}
+
+/// Drain any pending volume-header time pushed in from `main.rs` after a
+/// worker ingest and stamp it onto the `StreamingState`. Logs a debug line
+/// with the lag between the S3 upload time of the current anchor chunk and
+/// the parsed collection time, which is the empirical "NEXRAD ingest lag".
+fn drain_pending_volume_header_time(
+    state_cell: &Rc<RefCell<RealtimeState>>,
+    iter: &mut StreamingState,
+) {
+    let pending = state_cell
+        .borrow_mut()
+        .pending_volume_header_time_secs
+        .take();
+    if let Some(secs) = pending {
+        let prior = iter.latest_volume_header_time_secs();
+        iter.record_volume_header_time_secs(secs);
+        if prior != Some(secs) {
+            log::debug!(
+                "volume_header_time: updated to {:.3}s (prior={:?})",
+                secs,
+                prior
+            );
+        }
+    }
 }
 
 async fn streaming_loop(
@@ -539,6 +577,10 @@ async fn streaming_loop(
             break;
         }
 
+        // Ingest any volume header time the worker parsed from the most
+        // recent chunk's radials so projections in this iteration can see it.
+        drain_pending_volume_header_time(&state, &mut iter);
+
         // Wait for expected chunk time. Only capture the prediction on the
         // first iteration for a given chunk — subsequent retry iterations
         // re-enter here with a near-zero wait, which would overwrite the
@@ -603,6 +645,23 @@ async fn streaming_loop(
                     .identifier
                     .upload_date_time()
                     .map(|dt| dt.timestamp_millis() as f64 / 1000.0);
+
+                // Empirical NEXRAD ingest lag: difference between the chunk's
+                // S3 upload time (AVAILABILITY) and the parsed volume header
+                // time (ACTUAL collection). Feeds the collection/availability
+                // model introduced in a follow-up commit.
+                if let (Some(upload_secs), Some(header_secs)) =
+                    (s3_last_modified_at, iter.latest_volume_header_time_secs())
+                {
+                    log::debug!(
+                        "ingest lag: upload={:.3}s header={:.3}s Δ={:+.3}s (seq={} type={})",
+                        upload_secs,
+                        header_secs,
+                        upload_secs - header_secs,
+                        chunks_in_volume,
+                        type_label,
+                    );
+                }
 
                 // Look up this chunk's entry in the library's projection list
                 // so we can attach elevation_number and chunk-within-sweep

--- a/src/nexrad/realtime.rs
+++ b/src/nexrad/realtime.rs
@@ -262,6 +262,10 @@ async fn streaming_loop(
     };
 
     let mut iter = init_result.state;
+    if let Some(cached) = load_cached_timing_stats(&site_id) {
+        iter.preload_timing_stats(cached);
+        log::debug!("Loaded cached timing stats for {}", site_id);
+    }
     let mut stats_tracker = StatsTracker::new(&iter);
     stats_tracker.update(&stats, &iter);
 
@@ -647,6 +651,8 @@ async fn streaming_loop(
                     });
                 }
 
+                save_timing_stats(&site_id, iter.timing_stats());
+
                 ctx.request_repaint();
             }
             Ok(None) => {
@@ -834,6 +840,35 @@ fn get_cached_volume(site_id: &str) -> Option<nexrad_data::aws::realtime::Volume
     } else {
         None
     }
+}
+
+// ── Timing stats persistence ──────────────────────────────────────────────
+
+fn timing_stats_key(site_id: &str) -> String {
+    format!("nexrad_timing_stats_{}", site_id)
+}
+
+/// Persist the site's rolling chunk-timing statistics to localStorage so the
+/// next session starts warm instead of cold-starting from pure physics.
+fn save_timing_stats(site_id: &str, stats: &super::timing::ChunkTimingStats) {
+    let Some(json) = stats.to_json() else {
+        return;
+    };
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let Ok(Some(storage)) = window.local_storage() else {
+        return;
+    };
+    let _ = storage.set_item(&timing_stats_key(site_id), &json);
+}
+
+/// Read a previously-persisted timing stats snapshot for the site, if any.
+fn load_cached_timing_stats(site_id: &str) -> Option<super::timing::ChunkTimingStats> {
+    let window = web_sys::window()?;
+    let storage = window.local_storage().ok()??;
+    let raw = storage.get_item(&timing_stats_key(site_id)).ok()??;
+    super::timing::ChunkTimingStats::from_json(&raw)
 }
 
 /// Run [`find_latest_volume`] then initialize a [`StreamingState`] at that volume.

--- a/src/nexrad/realtime.rs
+++ b/src/nexrad/realtime.rs
@@ -52,7 +52,13 @@ pub struct ChunkProjectionInfo {
 }
 
 /// Result type for realtime streaming events.
+///
+/// `ChunkReceived` is significantly larger than the other variants because it
+/// carries the per-chunk diagnostic bundle (`arrival_stat`) used by the VCP
+/// forecast modal. Boxing it would add an allocation per chunk for no gain —
+/// these values are produced and consumed within the same frame.
 #[derive(Clone, Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum RealtimeResult {
     /// Iterator initialized, streaming started
     Started { site_id: String },
@@ -639,9 +645,8 @@ async fn streaming_loop(
     // chunk and reset on success (or on final-retry recovery).
     let mut none_retries: u32 = 0;
     let mut cur_predicted_at: Option<f64> = None; // absolute Unix seconds
-    let mut cur_scheduled_at: Option<f64> = None; // first poll time
-    let mut cur_first_empty_at: Option<f64> = None;
     let mut cur_last_empty_at: Option<f64> = None;
+    let mut cur_diagnostics: Option<super::timing::EstimatedChunkProcessing> = None;
     loop {
         // Check stop signal
         if state.borrow().stop_requested {
@@ -664,6 +669,10 @@ async fn streaming_loop(
             if let Some(d) = time_until_next_opt {
                 cur_predicted_at = Some(current_timestamp_f64() + d.as_secs_f64());
             }
+            // Capture the rich estimator diagnostics (which path, sample
+            // count, physics breakdown) at the first poll for this chunk
+            // so we can attribute prediction error component-by-component.
+            cur_diagnostics = iter.next_chunk_processing_diagnostics();
         }
         if let Some(wait_duration) = time_until_next_opt {
             let mut wait_ms = wait_duration.as_millis() as u32;
@@ -679,10 +688,6 @@ async fn streaming_loop(
                 log::debug!("Realtime streaming stopped");
                 break;
             }
-        }
-
-        if cur_scheduled_at.is_none() {
-            cur_scheduled_at = Some(current_timestamp_f64());
         }
 
         // Fetch next chunk (with timing)
@@ -752,6 +757,27 @@ async fn streaming_loop(
                         None => (None, None, None),
                     };
 
+                // Anchor source the projector was using for the *previous*
+                // chunk — i.e. the one whose arrival we're recording.
+                // Captured AFTER `try_next` advances `iter.current` is fine
+                // because `current_anchor_source` reads collection-end +
+                // median-lag state, both of which are independent of which
+                // chunk is "current".
+                let anchor_source = Some(iter.current_anchor_source());
+
+                let (bucket_key, stats_n_at_prediction, scheduler_path, physics_breakdown) =
+                    match cur_diagnostics.as_ref() {
+                        Some(d) => (
+                            d.bucket
+                                .as_ref()
+                                .map(crate::state::BucketKey::from_characteristics),
+                            d.stats_n_at_prediction,
+                            Some(d.path),
+                            d.physics_breakdown,
+                        ),
+                        None => (None, 0, None, None),
+                    };
+
                 let arrival_stat = crate::state::ChunkArrivalStat {
                     sequence: chunks_in_volume,
                     chunk_type: type_label,
@@ -759,21 +785,23 @@ async fn streaming_loop(
                     chunk_index_in_sweep,
                     chunks_in_sweep,
                     predicted_available_at: cur_predicted_at,
-                    scheduled_at: cur_scheduled_at.unwrap_or(success_at),
                     empty_polls: none_retries,
-                    first_empty_poll_at: cur_first_empty_at,
                     last_empty_poll_at: cur_last_empty_at,
                     s3_last_modified_at,
                     success_at,
-                    fetch_latency_ms: chunk_fetch_ms,
+                    bucket_key,
+                    stats_n_at_prediction,
+                    scheduler_path,
+                    physics_breakdown,
+                    anchor_source,
+                    availability_lag_ms: None,
                 };
 
                 // Reset tracking state for the next chunk
                 none_retries = 0;
                 cur_predicted_at = None;
-                cur_scheduled_at = None;
-                cur_first_empty_at = None;
                 cur_last_empty_at = None;
+                cur_diagnostics = None;
 
                 let time_until_next = iter.time_until_next().and_then(|td| td.to_std().ok());
 
@@ -810,11 +838,7 @@ async fn streaming_loop(
             Ok(None) => {
                 // Chunk not ready yet, brief retry
                 none_retries += 1;
-                let now = current_timestamp_f64();
-                if cur_first_empty_at.is_none() {
-                    cur_first_empty_at = Some(now);
-                }
-                cur_last_empty_at = Some(now);
+                cur_last_empty_at = Some(current_timestamp_f64());
                 if none_retries >= CHUNK_POLL_MAX_RETRIES {
                     let elapsed_secs =
                         (none_retries * CHUNK_POLL_INTERVAL_MS + CHUNK_POLL_GRACE_MS) / 1000;
@@ -835,9 +859,8 @@ async fn streaming_loop(
                             // is an existing quirk of the recovery path).
                             none_retries = 0;
                             cur_predicted_at = None;
-                            cur_scheduled_at = None;
-                            cur_first_empty_at = None;
                             cur_last_empty_at = None;
+                            cur_diagnostics = None;
                             continue;
                         }
                         Ok(None) => {

--- a/src/nexrad/realtime.rs
+++ b/src/nexrad/realtime.rs
@@ -223,7 +223,13 @@ async fn streaming_loop(
     // Pad added to the first poll wait per chunk; collapses the "fire a hair
     // early → empty poll → sleep 500ms → fire" path on chunks whose
     // predictions are tight. Retry waits are unaffected.
-    const POLL_DELAY_AFTER_PREDICTED_MS: u32 = 300;
+    //
+    // Sized to hedge the observed +0.96s mean chunk_pred_err (chunks arrive ~1s
+    // later than predicted on average, largely because S3 Last-Modified is
+    // second-quantized — ~0.5s of that 0.96s is quantization alone). 600ms plus
+    // the ~300ms of WASM/setTimeout slop lands scheduled fetches close to actual
+    // arrival for most intra-sweep chunks.
+    const POLL_DELAY_AFTER_PREDICTED_MS: u32 = 600;
 
     let hint = get_cached_volume(&site_id);
     let init_future = acquire_streaming_state(&site_id, hint);

--- a/src/nexrad/realtime.rs
+++ b/src/nexrad/realtime.rs
@@ -17,6 +17,9 @@ use std::time::Duration;
 use eframe::egui;
 
 use crate::data::facade::DataFacade;
+use crate::net::retry::{
+    attempt_with_timeout, compute_delay, sleep_duration, Verdict, REALTIME_CHUNK_POLICY,
+};
 
 /// Projected timing and structural info for a single chunk in the volume.
 ///
@@ -332,13 +335,10 @@ async fn streaming_loop(
     // the timeout wins the select, the init future is dropped, which drops any
     // in-flight HTTP request futures and cancels them.
     const ACQUIRE_TIMEOUT_SECS: u32 = 10;
-    const CHUNK_POLL_INTERVAL_MS: u32 = 500;
-    const CHUNK_POLL_MAX_RETRIES: u32 = 25; // 25 × 500ms = 12.5s
-    const CHUNK_POLL_GRACE_MS: u32 = 2500; // 2.5s final grace → 15s total
 
     // Pad added to the first poll wait per chunk; collapses the "fire a hair
-    // early → empty poll → sleep 500ms → fire" path on chunks whose
-    // predictions are tight. Retry waits are unaffected.
+    // early → empty poll → backoff → fire" path on chunks whose predictions
+    // are tight. Retry waits are governed by `REALTIME_CHUNK_POLICY`.
     //
     // Sized from observed availability-space prediction error: across all
     // buckets in a representative VCP 212 volume, scheduler predictions ran
@@ -710,9 +710,8 @@ async fn streaming_loop(
             let mut wait_ms = wait_duration.as_millis() as u32;
             // Pad the first (prediction-driven) wait per chunk so we fire
             // slightly after `predicted_available_at`. Retry waits after an
-            // empty poll come through `sleep_ms(CHUNK_POLL_INTERVAL_MS)` in
-            // the `Ok(None)` arm, not here, so the pad applies exactly once
-            // per chunk.
+            // empty poll come through the `REALTIME_CHUNK_POLICY` backoff
+            // loop below, not here, so the pad applies exactly once per chunk.
             if is_first_iter_for_chunk && wait_ms > 0 {
                 wait_ms = wait_ms.saturating_add(POLL_DELAY_AFTER_PREDICTED_MS);
             }
@@ -722,10 +721,64 @@ async fn streaming_loop(
             }
         }
 
-        // Fetch next chunk (with timing)
+        // Fetch next chunk. The first attempt fires at the timing-prediction
+        // sleep above; if it returns 404 (chunk not yet published) or a
+        // transient transport error, the loop below applies the standard
+        // exponential-backoff-with-jitter policy from `REALTIME_CHUNK_POLICY`.
+        // The retry loop is inlined (rather than going through `with_retry`)
+        // because each attempt borrows `iter` mutably and the resulting Future
+        // can't escape an `FnMut` closure body.
         let chunk_fetch_start = web_time::Instant::now();
-        match iter.try_next().await {
-            Ok(Some(chunk)) => {
+        let policy = &REALTIME_CHUNK_POLICY;
+        let mut last_msg: Option<String> = None;
+        let fetch_outcome: Result<nexrad_data::aws::realtime::DownloadedChunk, String> = 'retry: {
+            for attempt in 1..=policy.max_attempts {
+                if state.borrow().stop_requested {
+                    break 'retry Err("stopped".into());
+                }
+                if attempt > 1 {
+                    none_retries = attempt - 1;
+                    cur_last_empty_at = Some(current_timestamp_f64());
+                }
+                let verdict = attempt_with_timeout(
+                    async { classify_chunk_result(iter.try_next().await) },
+                    policy.per_attempt_timeout,
+                )
+                .await;
+                match verdict {
+                    Verdict::Ok(c) => break 'retry Ok(c),
+                    Verdict::Terminal(m) => break 'retry Err(m),
+                    Verdict::Retry { after } => {
+                        last_msg = Some(format!("attempt {} empty/transient", attempt));
+                        if attempt >= policy.max_attempts {
+                            break;
+                        }
+                        let elapsed = chunk_fetch_start.elapsed();
+                        if elapsed >= policy.total_budget {
+                            break 'retry Err(format!(
+                                "chunk_fetch: budget {}s exhausted after {} attempts",
+                                policy.total_budget.as_secs(),
+                                attempt
+                            ));
+                        }
+                        let mut delay = compute_delay(policy, attempt, after);
+                        let remaining = policy.total_budget.saturating_sub(elapsed);
+                        if delay > remaining {
+                            delay = remaining;
+                        }
+                        sleep_duration(delay).await;
+                    }
+                }
+            }
+            Err(format!(
+                "chunk_fetch: gave up after {} attempts ({})",
+                policy.max_attempts,
+                last_msg.as_deref().unwrap_or("retry exhausted")
+            ))
+        };
+
+        match fetch_outcome {
+            Ok(chunk) => {
                 let chunk_fetch_ms = chunk_fetch_start.elapsed().as_secs_f64() * 1000.0;
                 let success_at = current_timestamp_f64();
                 stats_tracker.update(&stats, &iter);
@@ -875,64 +928,10 @@ async fn streaming_loop(
 
                 ctx.request_repaint();
             }
-            Ok(None) => {
-                // Chunk not ready yet, brief retry
-                none_retries += 1;
-                cur_last_empty_at = Some(current_timestamp_f64());
-                if none_retries >= CHUNK_POLL_MAX_RETRIES {
-                    let elapsed_secs =
-                        (none_retries * CHUNK_POLL_INTERVAL_MS + CHUNK_POLL_GRACE_MS) / 1000;
-                    log::warn!(
-                        "Streaming: {} consecutive empty polls, attempting final fetch after {}ms delay",
-                        none_retries,
-                        CHUNK_POLL_GRACE_MS,
-                    );
-                    sleep_ms(CHUNK_POLL_GRACE_MS).await;
-                    if state.borrow().stop_requested {
-                        break;
-                    }
-                    match iter.try_next().await {
-                        Ok(Some(_chunk)) => {
-                            // Recovered — let the next loop iteration handle it normally.
-                            // Reset the per-chunk tracking so the next successful fetch
-                            // emits a fresh ChunkArrivalStat (the discarded chunk here
-                            // is an existing quirk of the recovery path).
-                            none_retries = 0;
-                            cur_predicted_at = None;
-                            cur_last_empty_at = None;
-                            cur_diagnostics = None;
-                            continue;
-                        }
-                        Ok(None) => {
-                            log::error!(
-                                "Streaming: final retry still empty after ~{}s, giving up",
-                                elapsed_secs
-                            );
-                            let mut s = state.borrow_mut();
-                            s.results.push(RealtimeResult::Error(format!(
-                                "Chunk polling timed out — no data received for ~{} seconds",
-                                elapsed_secs
-                            )));
-                            s.active = false;
-                            ctx.request_repaint();
-                            break;
-                        }
-                        Err(e) => {
-                            log::error!("Streaming error on final retry: {}", e);
-                            let mut s = state.borrow_mut();
-                            s.results.push(RealtimeResult::Error(format!("{}", e)));
-                            s.active = false;
-                            ctx.request_repaint();
-                            break;
-                        }
-                    }
-                }
-                sleep_ms(CHUNK_POLL_INTERVAL_MS).await;
-            }
-            Err(e) => {
-                log::error!("Streaming error: {}", e);
+            Err(msg) => {
+                log::error!("Streaming error: {}", msg);
                 let mut s = state.borrow_mut();
-                s.results.push(RealtimeResult::Error(format!("{}", e)));
+                s.results.push(RealtimeResult::Error(msg));
                 s.active = false;
                 ctx.request_repaint();
                 break;
@@ -941,6 +940,31 @@ async fn streaming_loop(
     }
 
     state.borrow_mut().active = false;
+}
+
+/// Map a `nexrad-data` chunk-fetch result to a retry [`Verdict`].
+///
+/// `Ok(None)` (S3 returned 404 — chunk not yet published) is treated as a
+/// retryable miss in this call site, since real-time chunks land seconds late
+/// by design. Transport-layer errors are also retryable; data-decoding and
+/// identifier errors are terminal.
+fn classify_chunk_result(
+    result: nexrad_data::result::Result<Option<nexrad_data::aws::realtime::DownloadedChunk>>,
+) -> Verdict<nexrad_data::aws::realtime::DownloadedChunk> {
+    use nexrad_data::result::aws::AWSError;
+    use nexrad_data::result::Error;
+    match result {
+        Ok(Some(chunk)) => Verdict::Ok(chunk),
+        Ok(None) => Verdict::Retry { after: None },
+        Err(Error::AWS(
+            AWSError::S3GetObjectRequest(_)
+            | AWSError::S3GetObject(_)
+            | AWSError::S3Streaming(_)
+            | AWSError::S3ListObjects(_)
+            | AWSError::TruncatedListObjectsResponse,
+        )) => Verdict::Retry { after: None },
+        Err(e) => Verdict::Terminal(format!("{}", e)),
+    }
 }
 
 /// Sleep in increments, updating countdown UI and checking stop flag.

--- a/src/nexrad/realtime.rs
+++ b/src/nexrad/realtime.rs
@@ -435,6 +435,23 @@ async fn streaming_loop(
                 // sweep, not replacing the full volume.
                 skip_overlap_delete: true,
             });
+            // Why: chunk_projections is consumed by the worker fast-path to
+            // detect last-chunk-in-sweep. ChunkReceived is the only event
+            // that updates it on the main thread, so without this push the
+            // resumed sweep's chunks reach the worker with stale/None
+            // projections and finalize only on the next sweep's first chunk.
+            s.results.push(RealtimeResult::ChunkReceived {
+                chunks_in_volume: 1,
+                time_until_next: None,
+                is_volume_end: false,
+                fetch_latency_ms: 0.0,
+                projected_volume_end_available_at_secs: get_projected_volume_end_available_at_secs(
+                    &iter,
+                ),
+                projected_volume_end_collection_secs: iter.projected_volume_end_collection_secs(),
+                chunk_projections: build_chunk_projections(&iter),
+                arrival_stat: None,
+            });
         }
         ctx.request_repaint();
 
@@ -538,6 +555,18 @@ async fn streaming_loop(
                                 is_end: false,
                                 timestamp: current_scan_start_secs,
                                 skip_overlap_delete: false,
+                            });
+                            s.results.push(RealtimeResult::ChunkReceived {
+                                chunks_in_volume,
+                                time_until_next: None,
+                                is_volume_end: false,
+                                fetch_latency_ms: 0.0,
+                                projected_volume_end_available_at_secs:
+                                    get_projected_volume_end_available_at_secs(&iter),
+                                projected_volume_end_collection_secs: iter
+                                    .projected_volume_end_collection_secs(),
+                                chunk_projections: build_chunk_projections(&iter),
+                                arrival_stat: None,
                             });
                         }
                         ctx.request_repaint();

--- a/src/nexrad/realtime.rs
+++ b/src/nexrad/realtime.rs
@@ -34,6 +34,11 @@ pub struct ChunkProjectionInfo {
     pub elevation_angle_deg: f64,
     /// Azimuth rotation rate in degrees/second from the VCP.
     pub azimuth_rate_dps: f64,
+    /// COLLECTION category: projected Unix-seconds time the radar physically
+    /// emits/receives for this chunk. `Some` for future chunks (from
+    /// ScanTimingProjection), `None` for past chunks. Drives timeline
+    /// placeholders for future sweeps.
+    pub projected_collection_time_secs: Option<f64>,
     /// AVAILABILITY category: projected Unix-seconds time this chunk becomes
     /// available in S3. `Some` for future chunks (from ScanTimingProjection),
     /// `None` for past chunks.
@@ -181,14 +186,20 @@ fn build_chunk_projections(state: &StreamingState) -> Option<Vec<ChunkProjection
     let all_meta = state.all_chunk_metadata()?;
     let projection = state.project_remaining_scan();
 
-    // Build a lookup from sequence → projected-availability-time for future chunks
-    let projected_available_at_by_seq: std::collections::HashMap<usize, f64> = projection
+    // Build lookups from sequence → {collection, availability} times.
+    let (projected_collection_by_seq, projected_available_at_by_seq): (
+        std::collections::HashMap<usize, f64>,
+        std::collections::HashMap<usize, f64>,
+    ) = projection
         .as_ref()
         .map(|p| {
-            p.chunks()
-                .iter()
-                .map(|c| (c.sequence(), c.projected_available_at().timestamp() as f64))
-                .collect()
+            let mut collection = std::collections::HashMap::new();
+            let mut available = std::collections::HashMap::new();
+            for c in p.chunks() {
+                collection.insert(c.sequence(), c.projected_collection_time_secs());
+                available.insert(c.sequence(), c.projected_available_at().timestamp() as f64);
+            }
+            (collection, available)
         })
         .unwrap_or_default();
 
@@ -200,6 +211,9 @@ fn build_chunk_projections(state: &StreamingState) -> Option<Vec<ChunkProjection
                 elevation_number: meta.elevation_number(),
                 elevation_angle_deg: meta.elevation_angle_deg(),
                 azimuth_rate_dps: meta.azimuth_rate_dps(),
+                projected_collection_time_secs: projected_collection_by_seq
+                    .get(&meta.sequence())
+                    .copied(),
                 projected_available_at_secs: projected_available_at_by_seq
                     .get(&meta.sequence())
                     .copied(),

--- a/src/nexrad/realtime.rs
+++ b/src/nexrad/realtime.rs
@@ -66,6 +66,10 @@ pub enum RealtimeResult {
         /// of the current volume becomes available in S3, from the library's
         /// physics model.
         projected_volume_end_available_at_secs: Option<f64>,
+        /// COLLECTION category: projected Unix-seconds time the radar finishes
+        /// physically scanning the final chunk of the current volume. Drives
+        /// the timeline's projected end-of-volume marker.
+        projected_volume_end_collection_secs: Option<f64>,
         /// Per-chunk projection info for the entire volume.
         /// Structural metadata is present for all chunks; projected times only for future chunks.
         chunk_projections: Option<Vec<ChunkProjectionInfo>>,
@@ -580,6 +584,7 @@ async fn streaming_loop(
                 projected_volume_end_available_at_secs: get_projected_volume_end_available_at_secs(
                     &iter,
                 ),
+                projected_volume_end_collection_secs: iter.projected_volume_end_collection_secs(),
                 chunk_projections: build_chunk_projections(&iter),
                 arrival_stat: None,
             });
@@ -620,6 +625,7 @@ async fn streaming_loop(
                 projected_volume_end_available_at_secs: get_projected_volume_end_available_at_secs(
                     &iter,
                 ),
+                projected_volume_end_collection_secs: iter.projected_volume_end_collection_secs(),
                 chunk_projections: build_chunk_projections(&iter),
                 arrival_stat: None,
             });
@@ -790,6 +796,8 @@ async fn streaming_loop(
                         fetch_latency_ms: chunk_fetch_ms,
                         projected_volume_end_available_at_secs:
                             get_projected_volume_end_available_at_secs(&iter),
+                        projected_volume_end_collection_secs: iter
+                            .projected_volume_end_collection_secs(),
                         chunk_projections,
                         arrival_stat: Some(arrival_stat),
                     });

--- a/src/nexrad/realtime.rs
+++ b/src/nexrad/realtime.rs
@@ -100,12 +100,12 @@ struct RealtimeState {
     active: bool,
     time_until_next: Option<Duration>,
     stop_requested: bool,
-    /// ACTUAL category: most recently observed volume header time (Unix
-    /// seconds), parsed by the worker from the first Message 31 radial of
-    /// the current volume. Pushed in from `main.rs` after each ingest
-    /// response; consumed by the streaming loop to populate the projection
-    /// anchor in a later commit.
-    pending_volume_header_time_secs: Option<f64>,
+    /// ACTUAL category: latest radial collection time (Unix seconds) of
+    /// the most recently ingested chunk. Pushed in from `main.rs` after
+    /// each ingest response and drained by the streaming loop into
+    /// `StreamingState` so projections anchor on the current chunk's true
+    /// collection time rather than the volume's start.
+    pending_chunk_collection_end_secs: Option<f64>,
     /// Empirical availability lag (seconds) for the most recently ingested
     /// chunk, computed in `main.rs` as `s3_last_modified - chunk_max_time`.
     /// Drained by the streaming loop and attached to the latest
@@ -180,11 +180,12 @@ impl RealtimeChannel {
         }
     }
 
-    /// Push the ACTUAL volume header time parsed by the worker after an
-    /// ingest response. The streaming loop picks this up and stamps it onto
-    /// the `StreamingState` before the next projection.
-    pub fn record_volume_header_time_secs(&self, secs: f64) {
-        self.state.borrow_mut().pending_volume_header_time_secs = Some(secs);
+    /// Push the latest radial collection time (Unix seconds) parsed from
+    /// the chunk that was just ingested. The streaming loop drains this
+    /// and stamps it onto `StreamingState` so the next projection anchors
+    /// on the current chunk's actual collection time.
+    pub fn record_chunk_collection_end_secs(&self, secs: f64) {
+        self.state.borrow_mut().pending_chunk_collection_end_secs = Some(secs);
     }
 
     /// Push an empirical availability lag (S3 upload − ACTUAL chunk
@@ -286,19 +287,19 @@ fn drain_pending_ingest_observations(
     state_cell: &Rc<RefCell<RealtimeState>>,
     iter: &mut StreamingState,
 ) {
-    let (pending_header, pending_lag) = {
+    let (pending_collection_end, pending_lag) = {
         let mut s = state_cell.borrow_mut();
         (
-            s.pending_volume_header_time_secs.take(),
+            s.pending_chunk_collection_end_secs.take(),
             s.pending_availability_lag_secs.take(),
         )
     };
-    if let Some(secs) = pending_header {
-        let prior = iter.latest_volume_header_time_secs();
-        iter.record_volume_header_time_secs(secs);
+    if let Some(secs) = pending_collection_end {
+        let prior = iter.latest_chunk_collection_end_secs();
+        iter.record_chunk_collection_end_secs(secs);
         if prior != Some(secs) {
             log::debug!(
-                "volume_header_time: updated to {:.3}s (prior={:?})",
+                "chunk_collection_end: updated to {:.3}s (prior={:?})",
                 secs,
                 prior
             );
@@ -720,17 +721,16 @@ async fn streaming_loop(
                     .map(|dt| dt.timestamp_millis() as f64 / 1000.0);
 
                 // Empirical NEXRAD ingest lag: difference between the chunk's
-                // S3 upload time (AVAILABILITY) and the parsed volume header
-                // time (ACTUAL collection). Feeds the collection/availability
-                // model introduced in a follow-up commit.
-                if let (Some(upload_secs), Some(header_secs)) =
-                    (s3_last_modified_at, iter.latest_volume_header_time_secs())
+                // S3 upload time (AVAILABILITY) and its latest radial
+                // collection time (ACTUAL).
+                if let (Some(upload_secs), Some(collection_end_secs)) =
+                    (s3_last_modified_at, iter.latest_chunk_collection_end_secs())
                 {
                     log::debug!(
-                        "ingest lag: upload={:.3}s header={:.3}s Δ={:+.3}s (seq={} type={})",
+                        "ingest lag: upload={:.3}s collection_end={:.3}s Δ={:+.3}s (seq={} type={})",
                         upload_secs,
-                        header_secs,
-                        upload_secs - header_secs,
+                        collection_end_secs,
+                        upload_secs - collection_end_secs,
                         chunks_in_volume,
                         type_label,
                     );

--- a/src/nexrad/realtime.rs
+++ b/src/nexrad/realtime.rs
@@ -340,13 +340,16 @@ async fn streaming_loop(
     // early → empty poll → sleep 500ms → fire" path on chunks whose
     // predictions are tight. Retry waits are unaffected.
     //
-    // Sized to cover the ~300 ms of WASM/setTimeout slop plus a small margin
-    // for prediction bias. Previously bumped to 600 ms as a blunt hedge for
-    // sweep-transition mispredictions; the proper fix for those lives in the
-    // timing model + historical-stats lookup, so this can stay modest and
-    // avoid adding latency to the ~90% of chunks that are intra-sweep and
-    // predicted accurately.
-    const POLL_DELAY_AFTER_PREDICTED_MS: u32 = 400;
+    // Sized from observed availability-space prediction error: across all
+    // buckets in a representative VCP 212 volume, scheduler predictions ran
+    // ~900 ms early in availability-space (collection-space prediction is
+    // accurate; the residual is S3-availability lag the projector under-
+    // estimates). `wait_after_last_empty_ms` clusters tightly at ~670 ms,
+    // confirming that when we fire early we miss by roughly one poll cycle.
+    // 750 ms covers the typical case while leaving outliers (one-chunk lag
+    // spikes) to the existing retry path. The deeper fix is per-bucket lag
+    // in the projector and an EWMA on lag history.
+    const POLL_DELAY_AFTER_PREDICTED_MS: u32 = 750;
 
     let hint = get_cached_volume(&site_id);
     let init_future = acquire_streaming_state(&site_id, hint);

--- a/src/nexrad/realtime.rs
+++ b/src/nexrad/realtime.rs
@@ -102,6 +102,11 @@ struct RealtimeState {
     /// response; consumed by the streaming loop to populate the projection
     /// anchor in a later commit.
     pending_volume_header_time_secs: Option<f64>,
+    /// Empirical availability lag (seconds) for the most recently ingested
+    /// chunk, computed in `main.rs` as `s3_last_modified - chunk_max_time`.
+    /// Drained by the streaming loop and attached to the latest
+    /// `ChunkTimingStats` sample.
+    pending_availability_lag_secs: Option<f64>,
 }
 
 /// Channel for real-time NEXRAD streaming.
@@ -177,6 +182,14 @@ impl RealtimeChannel {
     pub fn record_volume_header_time_secs(&self, secs: f64) {
         self.state.borrow_mut().pending_volume_header_time_secs = Some(secs);
     }
+
+    /// Push an empirical availability lag (S3 upload − ACTUAL chunk
+    /// collection time, seconds) for the chunk just ingested. The streaming
+    /// loop attaches it to the most recent `ChunkTimingStats` sample so
+    /// future projections can use a median lag rather than a hard default.
+    pub fn record_availability_lag_secs(&self, lag_secs: f64) {
+        self.state.borrow_mut().pending_availability_lag_secs = Some(lag_secs);
+    }
 }
 
 /// Build projection info from the streaming state's current position.
@@ -233,19 +246,22 @@ fn get_projected_volume_end_available_at_secs(state: &StreamingState) -> Option<
         .map(|dt| dt.timestamp() as f64)
 }
 
-/// Drain any pending volume-header time pushed in from `main.rs` after a
-/// worker ingest and stamp it onto the `StreamingState`. Logs a debug line
-/// with the lag between the S3 upload time of the current anchor chunk and
-/// the parsed collection time, which is the empirical "NEXRAD ingest lag".
-fn drain_pending_volume_header_time(
+/// Drain anything pushed in from `main.rs` after a worker ingest and stamp
+/// it onto the `StreamingState`: the ACTUAL volume header time (anchors
+/// collection-time projections) and the empirical per-chunk availability
+/// lag (feeds `ChunkTimingStats`).
+fn drain_pending_ingest_observations(
     state_cell: &Rc<RefCell<RealtimeState>>,
     iter: &mut StreamingState,
 ) {
-    let pending = state_cell
-        .borrow_mut()
-        .pending_volume_header_time_secs
-        .take();
-    if let Some(secs) = pending {
+    let (pending_header, pending_lag) = {
+        let mut s = state_cell.borrow_mut();
+        (
+            s.pending_volume_header_time_secs.take(),
+            s.pending_availability_lag_secs.take(),
+        )
+    };
+    if let Some(secs) = pending_header {
         let prior = iter.latest_volume_header_time_secs();
         iter.record_volume_header_time_secs(secs);
         if prior != Some(secs) {
@@ -255,6 +271,9 @@ fn drain_pending_volume_header_time(
                 prior
             );
         }
+    }
+    if let Some(lag_secs) = pending_lag {
+        iter.record_availability_lag_for_current(lag_secs);
     }
 }
 
@@ -591,9 +610,10 @@ async fn streaming_loop(
             break;
         }
 
-        // Ingest any volume header time the worker parsed from the most
-        // recent chunk's radials so projections in this iteration can see it.
-        drain_pending_volume_header_time(&state, &mut iter);
+        // Ingest any volume header time + availability lag the worker
+        // produced from the most recent chunk's radials so projections and
+        // stats in this iteration see them.
+        drain_pending_ingest_observations(&state, &mut iter);
 
         // Wait for expected chunk time. Only capture the prediction on the
         // first iteration for a given chunk — subsequent retry iterations

--- a/src/nexrad/realtime.rs
+++ b/src/nexrad/realtime.rs
@@ -246,6 +246,34 @@ fn get_projected_volume_end_available_at_secs(state: &StreamingState) -> Option<
         .map(|dt| dt.timestamp() as f64)
 }
 
+/// Default provisional lag applied when we have no observed median lag
+/// yet. Matches the default in the projector so a cold stream's first
+/// ScanKey lands near the eventual real value.
+const DEFAULT_PROVISIONAL_LAG_SECS: f64 = 5.0;
+
+/// Provisional scan-start timestamp (Unix seconds) for a new volume.
+///
+/// Uses the Start chunk's S3 upload time minus the current median
+/// availability lag from `ChunkTimingStats` (falling back to
+/// `DEFAULT_PROVISIONAL_LAG_SECS`). That lands close to the real volume
+/// header collection time — closer than the wall-clock receipt time it
+/// replaces — without needing to wait for the first M chunk's radial
+/// parse. If there is no upload time, fall back to wall clock.
+fn provisional_scan_start_secs(
+    start_upload: Option<chrono::DateTime<chrono::Utc>>,
+    iter: &StreamingState,
+) -> i64 {
+    let median_lag_secs = iter
+        .timing_stats()
+        .median_availability_lag_secs()
+        .unwrap_or(DEFAULT_PROVISIONAL_LAG_SECS);
+    if let Some(upload) = start_upload {
+        let upload_secs = upload.timestamp_millis() as f64 / 1000.0;
+        return (upload_secs - median_lag_secs).round() as i64;
+    }
+    current_timestamp()
+}
+
 /// Drain anything pushed in from `main.rs` after a worker ingest and stamp
 /// it onto the `StreamingState`: the ACTUAL volume header time (anchors
 /// collection-time projections) and the empirical per-chunk availability
@@ -377,7 +405,8 @@ async fn streaming_loop(
     if let Some(start_chunk) = init_result.start_chunk {
         // Joined mid-volume: emit the start chunk + current sweep's chunks only.
         let start_data = start_chunk.chunk.data().to_vec();
-        current_scan_start_secs = current_timestamp();
+        current_scan_start_secs =
+            provisional_scan_start_secs(start_chunk.identifier.upload_date_time(), &iter);
 
         log::debug!(
             "Init: emitting start_chunk ({} bytes) for mid-volume join",
@@ -562,7 +591,10 @@ async fn streaming_loop(
         let latest_type = init_result.latest_chunk.identifier.chunk_type();
         let latest_is_start = latest_type == ChunkType::Start;
         let latest_is_end = latest_type == ChunkType::End;
-        current_scan_start_secs = current_timestamp();
+        current_scan_start_secs = provisional_scan_start_secs(
+            init_result.latest_chunk.identifier.upload_date_time(),
+            &iter,
+        );
         chunks_in_volume = 1;
         cache_volume_number(&site_id, *init_result.latest_chunk.identifier.volume());
 
@@ -662,7 +694,8 @@ async fn streaming_loop(
                 // Reset counters on new volume
                 if is_start {
                     chunks_in_volume = 0;
-                    current_scan_start_secs = current_timestamp();
+                    current_scan_start_secs =
+                        provisional_scan_start_secs(chunk.identifier.upload_date_time(), &iter);
                     cache_volume_number(&site_id, *chunk.identifier.volume());
                 }
 

--- a/src/nexrad/realtime.rs
+++ b/src/nexrad/realtime.rs
@@ -34,9 +34,10 @@ pub struct ChunkProjectionInfo {
     pub elevation_angle_deg: f64,
     /// Azimuth rotation rate in degrees/second from the VCP.
     pub azimuth_rate_dps: f64,
-    /// Projected time this chunk becomes available (Unix seconds).
-    /// `Some` for future chunks (from ScanTimingProjection), `None` for past chunks.
-    pub projected_time_secs: Option<f64>,
+    /// AVAILABILITY category: projected Unix-seconds time this chunk becomes
+    /// available in S3. `Some` for future chunks (from ScanTimingProjection),
+    /// `None` for past chunks.
+    pub projected_available_at_secs: Option<f64>,
     /// Whether this chunk starts a new sweep.
     pub starts_new_sweep: bool,
     /// 0-based index of this chunk within its sweep.
@@ -56,8 +57,10 @@ pub enum RealtimeResult {
         time_until_next: Option<Duration>,
         is_volume_end: bool,
         fetch_latency_ms: f64,
-        /// Projected volume end time (Unix seconds), from the library's physics model.
-        projected_volume_end_secs: Option<f64>,
+        /// AVAILABILITY category: projected Unix-seconds time the final chunk
+        /// of the current volume becomes available in S3, from the library's
+        /// physics model.
+        projected_volume_end_available_at_secs: Option<f64>,
         /// Per-chunk projection info for the entire volume.
         /// Structural metadata is present for all chunks; projected times only for future chunks.
         chunk_projections: Option<Vec<ChunkProjectionInfo>>,
@@ -165,13 +168,13 @@ fn build_chunk_projections(state: &StreamingState) -> Option<Vec<ChunkProjection
     let all_meta = state.all_chunk_metadata()?;
     let projection = state.project_remaining_scan();
 
-    // Build a lookup from sequence → projected_time for future chunks
-    let projected_times: std::collections::HashMap<usize, f64> = projection
+    // Build a lookup from sequence → projected-availability-time for future chunks
+    let projected_available_at_by_seq: std::collections::HashMap<usize, f64> = projection
         .as_ref()
         .map(|p| {
             p.chunks()
                 .iter()
-                .map(|c| (c.sequence(), c.projected_time().timestamp() as f64))
+                .map(|c| (c.sequence(), c.projected_available_at().timestamp() as f64))
                 .collect()
         })
         .unwrap_or_default();
@@ -184,7 +187,9 @@ fn build_chunk_projections(state: &StreamingState) -> Option<Vec<ChunkProjection
                 elevation_number: meta.elevation_number(),
                 elevation_angle_deg: meta.elevation_angle_deg(),
                 azimuth_rate_dps: meta.azimuth_rate_dps(),
-                projected_time_secs: projected_times.get(&meta.sequence()).copied(),
+                projected_available_at_secs: projected_available_at_by_seq
+                    .get(&meta.sequence())
+                    .copied(),
                 starts_new_sweep: meta.is_first_in_sweep(),
                 chunk_index_in_sweep: meta.chunk_index_in_sweep(),
                 chunks_in_sweep: meta.chunks_in_sweep(),
@@ -193,10 +198,11 @@ fn build_chunk_projections(state: &StreamingState) -> Option<Vec<ChunkProjection
     )
 }
 
-/// Get the projected volume end time from the streaming state.
-fn get_projected_volume_end_secs(state: &StreamingState) -> Option<f64> {
+/// Get the projected S3-availability time of the current volume's final
+/// chunk (Unix seconds).
+fn get_projected_volume_end_available_at_secs(state: &StreamingState) -> Option<f64> {
     state
-        .projected_volume_end_time()
+        .projected_volume_end_available_at()
         .map(|dt| dt.timestamp() as f64)
 }
 
@@ -471,7 +477,9 @@ async fn streaming_loop(
                 time_until_next: iter.time_until_next().and_then(|td| td.to_std().ok()),
                 is_volume_end: latest_is_end,
                 fetch_latency_ms: 0.0,
-                projected_volume_end_secs: get_projected_volume_end_secs(&iter),
+                projected_volume_end_available_at_secs: get_projected_volume_end_available_at_secs(
+                    &iter,
+                ),
                 chunk_projections: build_chunk_projections(&iter),
                 arrival_stat: None,
             });
@@ -506,7 +514,9 @@ async fn streaming_loop(
                 time_until_next: iter.time_until_next().and_then(|td| td.to_std().ok()),
                 is_volume_end: latest_is_end,
                 fetch_latency_ms: 0.0,
-                projected_volume_end_secs: get_projected_volume_end_secs(&iter),
+                projected_volume_end_available_at_secs: get_projected_volume_end_available_at_secs(
+                    &iter,
+                ),
                 chunk_projections: build_chunk_projections(&iter),
                 arrival_stat: None,
             });
@@ -652,7 +662,8 @@ async fn streaming_loop(
                         time_until_next,
                         is_volume_end: is_end,
                         fetch_latency_ms: chunk_fetch_ms,
-                        projected_volume_end_secs: get_projected_volume_end_secs(&iter),
+                        projected_volume_end_available_at_secs:
+                            get_projected_volume_end_available_at_secs(&iter),
                         chunk_projections,
                         arrival_stat: Some(arrival_stat),
                     });

--- a/src/nexrad/realtime.rs
+++ b/src/nexrad/realtime.rs
@@ -224,12 +224,13 @@ async fn streaming_loop(
     // early → empty poll → sleep 500ms → fire" path on chunks whose
     // predictions are tight. Retry waits are unaffected.
     //
-    // Sized to hedge the observed +0.96s mean chunk_pred_err (chunks arrive ~1s
-    // later than predicted on average, largely because S3 Last-Modified is
-    // second-quantized — ~0.5s of that 0.96s is quantization alone). 600ms plus
-    // the ~300ms of WASM/setTimeout slop lands scheduled fetches close to actual
-    // arrival for most intra-sweep chunks.
-    const POLL_DELAY_AFTER_PREDICTED_MS: u32 = 600;
+    // Sized to cover the ~300 ms of WASM/setTimeout slop plus a small margin
+    // for prediction bias. Previously bumped to 600 ms as a blunt hedge for
+    // sweep-transition mispredictions; the proper fix for those lives in the
+    // timing model + historical-stats lookup, so this can stay modest and
+    // avoid adding latency to the ~90% of chunks that are intra-sweep and
+    // predicted accurately.
+    const POLL_DELAY_AFTER_PREDICTED_MS: u32 = 400;
 
     let hint = get_cached_volume(&site_id);
     let init_future = acquire_streaming_state(&site_id, hint);

--- a/src/nexrad/streaming_manager.rs
+++ b/src/nexrad/streaming_manager.rs
@@ -41,6 +41,14 @@ impl StreamingManager {
         self.realtime_channel.time_until_next()
     }
 
+    /// Push the ACTUAL volume header time (Unix seconds) parsed by the worker
+    /// from the first Message 31 radial of the current volume down into the
+    /// streaming loop. The loop stamps it onto the `StreamingState` before
+    /// the next projection.
+    pub fn record_volume_header_time_secs(&self, secs: f64) {
+        self.realtime_channel.record_volume_header_time_secs(secs);
+    }
+
     /// Drain all pending results from the realtime channel into events.
     pub fn poll(&mut self) -> Vec<StreamingEvent> {
         let mut events = Vec::new();

--- a/src/nexrad/streaming_manager.rs
+++ b/src/nexrad/streaming_manager.rs
@@ -49,6 +49,13 @@ impl StreamingManager {
         self.realtime_channel.record_volume_header_time_secs(secs);
     }
 
+    /// Push the empirical per-chunk availability lag (S3 upload − chunk
+    /// collection time, seconds) from the most recent worker ingest down
+    /// into the streaming loop.
+    pub fn record_availability_lag_secs(&self, lag_secs: f64) {
+        self.realtime_channel.record_availability_lag_secs(lag_secs);
+    }
+
     /// Drain all pending results from the realtime channel into events.
     pub fn poll(&mut self) -> Vec<StreamingEvent> {
         let mut events = Vec::new();

--- a/src/nexrad/streaming_manager.rs
+++ b/src/nexrad/streaming_manager.rs
@@ -41,12 +41,11 @@ impl StreamingManager {
         self.realtime_channel.time_until_next()
     }
 
-    /// Push the ACTUAL volume header time (Unix seconds) parsed by the worker
-    /// from the first Message 31 radial of the current volume down into the
-    /// streaming loop. The loop stamps it onto the `StreamingState` before
-    /// the next projection.
-    pub fn record_volume_header_time_secs(&self, secs: f64) {
-        self.realtime_channel.record_volume_header_time_secs(secs);
+    /// Push the latest radial collection time (Unix seconds) of the chunk
+    /// just ingested into the streaming loop, so the next projection
+    /// anchors on the current chunk's true collection time.
+    pub fn record_chunk_collection_end_secs(&self, secs: f64) {
+        self.realtime_channel.record_chunk_collection_end_secs(secs);
     }
 
     /// Push the empirical per-chunk availability lag (S3 upload − chunk

--- a/src/nexrad/streaming_state.rs
+++ b/src/nexrad/streaming_state.rs
@@ -256,10 +256,14 @@ impl StreamingState {
                 .get_sequence_elevation_number(chunk_id.sequence())
                 .and_then(|n| vcp.elevations().get(n - 1))
             {
+                let is_first_in_sweep = mapper
+                    .get_chunk_metadata(chunk_id.sequence())
+                    .is_some_and(|m| m.is_first_in_sweep());
                 let characteristics = ChunkCharacteristics {
                     chunk_type: chunk_id.chunk_type(),
                     waveform_type: elevation.waveform_type(),
                     channel_configuration: elevation.channel_configuration(),
+                    is_first_in_sweep,
                 };
                 self.timing_stats
                     .add_timing(characteristics, duration, attempts);

--- a/src/nexrad/streaming_state.rs
+++ b/src/nexrad/streaming_state.rs
@@ -259,24 +259,44 @@ impl StreamingState {
         duration: ChronoDuration,
         attempts: usize,
     ) {
-        if let (Some(vcp), Some(mapper)) = (&self.vcp, &self.elevation_mapper) {
-            if let Some(elevation) = mapper
-                .get_sequence_elevation_number(chunk_id.sequence())
-                .and_then(|n| vcp.elevations().get(n - 1))
-            {
-                let is_first_in_sweep = mapper
-                    .get_chunk_metadata(chunk_id.sequence())
-                    .is_some_and(|m| m.is_first_in_sweep());
-                let characteristics = ChunkCharacteristics {
-                    chunk_type: chunk_id.chunk_type(),
-                    waveform_type: elevation.waveform_type(),
-                    channel_configuration: elevation.channel_configuration(),
-                    is_first_in_sweep,
-                };
-                self.timing_stats
-                    .add_timing(characteristics, duration, attempts);
-            }
+        if let Some(characteristics) = self.characteristics_for_sequence(chunk_id) {
+            self.timing_stats
+                .add_timing(characteristics, duration, None, attempts);
         }
+    }
+
+    fn characteristics_for_sequence(
+        &self,
+        chunk_id: &ChunkIdentifier,
+    ) -> Option<ChunkCharacteristics> {
+        let vcp = self.vcp.as_ref()?;
+        let mapper = self.elevation_mapper.as_ref()?;
+        let elevation = mapper
+            .get_sequence_elevation_number(chunk_id.sequence())
+            .and_then(|n| vcp.elevations().get(n - 1))?;
+        let is_first_in_sweep = mapper
+            .get_chunk_metadata(chunk_id.sequence())
+            .is_some_and(|m| m.is_first_in_sweep());
+        Some(ChunkCharacteristics {
+            chunk_type: chunk_id.chunk_type(),
+            waveform_type: elevation.waveform_type(),
+            channel_configuration: elevation.channel_configuration(),
+            is_first_in_sweep,
+        })
+    }
+
+    /// Attach an observed availability-lag (S3 upload − ACTUAL collection
+    /// time) sample to the most recent timing stat recorded for the current
+    /// chunk. Called from the streaming loop after a worker ingest produces
+    /// the parsed chunk collection time.
+    pub fn record_availability_lag_for_current(&mut self, lag_secs: f64) {
+        let Some(characteristics) = self.characteristics_for_sequence(&self.current.clone()) else {
+            return;
+        };
+        self.timing_stats.attach_availability_lag(
+            &characteristics,
+            ChronoDuration::milliseconds((lag_secs * 1000.0) as i64),
+        );
     }
 
     /// Expose the rolling timing statistics for persistence by the streaming loop.

--- a/src/nexrad/streaming_state.rs
+++ b/src/nexrad/streaming_state.rs
@@ -334,7 +334,13 @@ impl StreamingState {
     pub fn project_remaining_scan(&self) -> Option<ScanTimingProjection> {
         let vcp = self.vcp.as_ref()?;
         let mapper = self.elevation_mapper.as_ref()?;
-        project_scan_timing(&self.current, vcp, mapper, Some(&self.timing_stats))
+        project_scan_timing(
+            &self.current,
+            self.latest_volume_header_time_secs,
+            vcp,
+            mapper,
+            Some(&self.timing_stats),
+        )
     }
 
     /// AVAILABILITY category: projected S3-availability time of the final

--- a/src/nexrad/streaming_state.rs
+++ b/src/nexrad/streaming_state.rs
@@ -316,8 +316,11 @@ impl StreamingState {
         project_scan_timing(&self.current, vcp, mapper, Some(&self.timing_stats))
     }
 
-    pub fn projected_volume_end_time(&self) -> Option<DateTime<Utc>> {
-        self.project_remaining_scan().map(|p| p.volume_end_time())
+    /// AVAILABILITY category: projected S3-availability time of the final
+    /// chunk of the current volume.
+    pub fn projected_volume_end_available_at(&self) -> Option<DateTime<Utc>> {
+        self.project_remaining_scan()
+            .map(|p| p.volume_end_available_at())
     }
 
     pub fn requests_made(&self) -> usize {

--- a/src/nexrad/streaming_state.rs
+++ b/src/nexrad/streaming_state.rs
@@ -271,6 +271,17 @@ impl StreamingState {
         }
     }
 
+    /// Expose the rolling timing statistics for persistence by the streaming loop.
+    pub fn timing_stats(&self) -> &ChunkTimingStats {
+        &self.timing_stats
+    }
+
+    /// Replace the rolling timing statistics with a previously-persisted snapshot.
+    /// Called once on stream start when a localStorage cache is available for the site.
+    pub fn preload_timing_stats(&mut self, stats: ChunkTimingStats) {
+        self.timing_stats = stats;
+    }
+
     pub fn next_expected_time(&self) -> Option<DateTime<Utc>> {
         let vcp = self.vcp.as_ref()?;
         let mapper = self.elevation_mapper.as_ref()?;

--- a/src/nexrad/streaming_state.rs
+++ b/src/nexrad/streaming_state.rs
@@ -7,8 +7,9 @@
 //! `try_next`, and timing/metadata accessors.
 
 use super::timing::{
-    estimate_chunk_availability_time, project_scan_timing, ChunkCharacteristics, ChunkMetadata,
-    ChunkTimingStats, ElevationChunkMapper, ScanTimingProjection,
+    estimate_chunk_availability_time, estimate_chunk_processing_diagnostics, project_scan_timing,
+    ChunkCharacteristics, ChunkMetadata, ChunkTimingStats, ElevationChunkMapper,
+    EstimatedChunkProcessing, ScanTimingProjection,
 };
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use log::debug;
@@ -335,6 +336,32 @@ impl StreamingState {
             None
         } else {
             Some(expected - now)
+        }
+    }
+
+    /// Diagnostic counterpart to [`time_until_next`] — returns the path the
+    /// scheduler took, the bucket sample count at prediction time, and the
+    /// physics decomposition (when applicable) so callers can attach them
+    /// to per-chunk arrival records.
+    pub fn next_chunk_processing_diagnostics(&self) -> Option<EstimatedChunkProcessing> {
+        let vcp = self.vcp.as_ref()?;
+        let mapper = self.elevation_mapper.as_ref()?;
+        estimate_chunk_processing_diagnostics(&self.current, vcp, mapper, Some(&self.timing_stats))
+    }
+
+    /// Anchor source the projector would use right now — `ObservedCollection`
+    /// when an ACTUAL collection-end time is available for the current chunk,
+    /// `UploadMinusMedian` when only `ChunkTimingStats` median lag is, or
+    /// `UploadMinusDefault` otherwise. Captured per-chunk so we can spot
+    /// degraded projections in the diagnostics modal.
+    pub fn current_anchor_source(&self) -> super::timing::AnchorSource {
+        use super::timing::AnchorSource;
+        if self.latest_chunk_collection_end_secs.is_some() {
+            AnchorSource::ObservedCollection
+        } else if self.timing_stats.median_availability_lag_secs().is_some() {
+            AnchorSource::UploadMinusMedian
+        } else {
+            AnchorSource::UploadMinusDefault
         }
     }
 

--- a/src/nexrad/streaming_state.rs
+++ b/src/nexrad/streaming_state.rs
@@ -37,11 +37,14 @@ pub struct StreamingState {
     vcp: Option<volume_coverage_pattern::Message<'static>>,
     timing_stats: ChunkTimingStats,
     last_chunk_time: Option<DateTime<Utc>>,
-    /// ACTUAL category: most recently observed volume header time (Unix seconds),
-    /// parsed by the worker from the first Message 31 radial of the current volume.
-    /// Pushed in from `main.rs` after each ingest response. Reset on volume boundary.
-    /// Used in a later commit as the anchor for projected COLLECTION times.
-    latest_volume_header_time_secs: Option<f64>,
+    /// ACTUAL category: collection-end time (Unix seconds) of the most
+    /// recently ingested chunk, parsed by the worker as the latest radial
+    /// timestamp in the chunk. Pushed in from `main.rs` after each ingest
+    /// response and reset on volume boundary. Used as the anchor for
+    /// projected COLLECTION times — the projector adds cumulative
+    /// inter-chunk physics intervals to this to place future chunks on
+    /// the timeline.
+    latest_chunk_collection_end_secs: Option<f64>,
     requests_made: usize,
     bytes_downloaded: u64,
 }
@@ -108,7 +111,7 @@ impl StreamingState {
             vcp,
             timing_stats: ChunkTimingStats::new(),
             last_chunk_time,
-            latest_volume_header_time_secs: None,
+            latest_chunk_collection_end_secs: None,
             requests_made,
             bytes_downloaded,
         };
@@ -173,7 +176,7 @@ impl StreamingState {
                         self.elevation_mapper = Some(ElevationChunkMapper::new(&v));
                         self.vcp = Some(v);
                     }
-                    self.latest_volume_header_time_secs = None;
+                    self.latest_chunk_collection_end_secs = None;
                 }
 
                 if let (Some(upload), Some(prev)) =
@@ -218,7 +221,7 @@ impl StreamingState {
                 self.elevation_mapper = Some(ElevationChunkMapper::new(&v));
                 self.vcp = Some(v);
             }
-            self.latest_volume_header_time_secs = None;
+            self.latest_chunk_collection_end_secs = None;
         } else if self.elevation_mapper.is_none() {
             // Joined mid-volume without a mapper — fetch the Start chunk too.
             let start_id = ChunkIdentifier::new(
@@ -304,17 +307,19 @@ impl StreamingState {
         &self.timing_stats
     }
 
-    /// Record the ACTUAL volume header time parsed by the worker from the
-    /// first Message 31 radial of the current volume. Pushed in from the
-    /// streaming loop after each ingest response.
-    pub fn record_volume_header_time_secs(&mut self, secs: f64) {
-        self.latest_volume_header_time_secs = Some(secs);
+    /// Record the latest radial collection time (Unix seconds) of the
+    /// most recently ingested chunk. Pushed in from the streaming loop
+    /// after each ingest response and used as the anchor for projected
+    /// COLLECTION times — the projector adds cumulative inter-chunk
+    /// physics intervals to this value.
+    pub fn record_chunk_collection_end_secs(&mut self, secs: f64) {
+        self.latest_chunk_collection_end_secs = Some(secs);
     }
 
-    /// Most recently recorded volume header time (Unix seconds), if any.
-    #[allow(dead_code)] // Consumed in a later commit to anchor collection-time projections.
-    pub fn latest_volume_header_time_secs(&self) -> Option<f64> {
-        self.latest_volume_header_time_secs
+    /// Most recently recorded chunk collection-end time (Unix seconds),
+    /// if any. None until the first M chunk of a volume has been ingested.
+    pub fn latest_chunk_collection_end_secs(&self) -> Option<f64> {
+        self.latest_chunk_collection_end_secs
     }
 
     /// Replace the rolling timing statistics with a previously-persisted snapshot.
@@ -356,7 +361,7 @@ impl StreamingState {
         let mapper = self.elevation_mapper.as_ref()?;
         project_scan_timing(
             &self.current,
-            self.latest_volume_header_time_secs,
+            self.latest_chunk_collection_end_secs,
             vcp,
             mapper,
             Some(&self.timing_stats),

--- a/src/nexrad/streaming_state.rs
+++ b/src/nexrad/streaming_state.rs
@@ -370,6 +370,17 @@ impl StreamingState {
             .map(|p| p.volume_end_available_at())
     }
 
+    /// COLLECTION category: projected Unix-seconds time the radar finishes
+    /// physically scanning the final chunk of the current volume. Drives
+    /// the timeline's right-edge marker for the in-progress volume.
+    pub fn projected_volume_end_collection_secs(&self) -> Option<f64> {
+        let projection = self.project_remaining_scan()?;
+        projection
+            .chunks()
+            .last()
+            .map(|c| c.projected_collection_time_secs())
+    }
+
     pub fn requests_made(&self) -> usize {
         self.requests_made
     }

--- a/src/nexrad/streaming_state.rs
+++ b/src/nexrad/streaming_state.rs
@@ -208,39 +208,33 @@ impl StreamingState {
     ) -> Result<Option<DownloadedChunk>> {
         let chunks = list_chunks_in_volume(&self.site, volume, 100).await?;
         self.requests_made += 1;
-        let latest = match chunks.last() {
+
+        // Always emit the Start chunk first when transitioning to a new
+        // volume — the worker accumulator is cleared on the previous
+        // volume's End and only re-initializes when an `is_start: true`
+        // chunk arrives. If we instead emitted the latest chunk in the
+        // new volume (potentially Intermediate, when polling lands after
+        // the inter-volume gap and several chunks are already published),
+        // every subsequent ingest would error with
+        // "No accumulator — missing Start chunk?".
+        //
+        // Subsequent `try_next` iterations fetch chunks 2, 3, … in
+        // sequence order via the normal `try_fetch_chunk` path.
+        let target = match chunks.iter().find(|c| c.chunk_type() == ChunkType::Start) {
             Some(id) => id,
-            None => return Ok(None), // Volume hasn't started yet
+            None => return Ok(None), // Start chunk hasn't been published yet
         };
-        let (identifier, chunk) = download_chunk(&self.site, latest).await?;
+        let (identifier, chunk) = download_chunk(&self.site, target).await?;
         self.requests_made += 1;
         self.bytes_downloaded += chunk.data().len() as u64;
 
-        if identifier.chunk_type() == ChunkType::Start {
-            if let Ok(v) = extract_vcp(&chunk) {
-                self.elevation_mapper = Some(ElevationChunkMapper::new(&v));
-                self.vcp = Some(v);
-            }
-            self.latest_chunk_collection_end_secs = None;
-        } else if self.elevation_mapper.is_none() {
-            // Joined mid-volume without a mapper — fetch the Start chunk too.
-            let start_id = ChunkIdentifier::new(
-                self.site.clone(),
-                volume,
-                *identifier.date_time_prefix(),
-                1,
-                ChunkType::Start,
-                None,
-            );
-            if let Ok((_, start_chunk)) = download_chunk(&self.site, &start_id).await {
-                self.requests_made += 1;
-                self.bytes_downloaded += start_chunk.data().len() as u64;
-                if let Ok(v) = extract_vcp(&start_chunk) {
-                    self.elevation_mapper = Some(ElevationChunkMapper::new(&v));
-                    self.vcp = Some(v);
-                }
-            }
+        // Identifier must be Start by construction above; extract VCP and
+        // reset the per-volume collection-end anchor.
+        if let Ok(v) = extract_vcp(&chunk) {
+            self.elevation_mapper = Some(ElevationChunkMapper::new(&v));
+            self.vcp = Some(v);
         }
+        self.latest_chunk_collection_end_secs = None;
 
         if let (Some(upload), Some(prev)) = (identifier.upload_date_time(), self.last_chunk_time) {
             self.update_timing_stats(&identifier, upload - prev, 1);

--- a/src/nexrad/streaming_state.rs
+++ b/src/nexrad/streaming_state.rs
@@ -37,6 +37,11 @@ pub struct StreamingState {
     vcp: Option<volume_coverage_pattern::Message<'static>>,
     timing_stats: ChunkTimingStats,
     last_chunk_time: Option<DateTime<Utc>>,
+    /// ACTUAL category: most recently observed volume header time (Unix seconds),
+    /// parsed by the worker from the first Message 31 radial of the current volume.
+    /// Pushed in from `main.rs` after each ingest response. Reset on volume boundary.
+    /// Used in a later commit as the anchor for projected COLLECTION times.
+    latest_volume_header_time_secs: Option<f64>,
     requests_made: usize,
     bytes_downloaded: u64,
 }
@@ -103,6 +108,7 @@ impl StreamingState {
             vcp,
             timing_stats: ChunkTimingStats::new(),
             last_chunk_time,
+            latest_volume_header_time_secs: None,
             requests_made,
             bytes_downloaded,
         };
@@ -167,6 +173,7 @@ impl StreamingState {
                         self.elevation_mapper = Some(ElevationChunkMapper::new(&v));
                         self.vcp = Some(v);
                     }
+                    self.latest_volume_header_time_secs = None;
                 }
 
                 if let (Some(upload), Some(prev)) =
@@ -211,6 +218,7 @@ impl StreamingState {
                 self.elevation_mapper = Some(ElevationChunkMapper::new(&v));
                 self.vcp = Some(v);
             }
+            self.latest_volume_header_time_secs = None;
         } else if self.elevation_mapper.is_none() {
             // Joined mid-volume without a mapper — fetch the Start chunk too.
             let start_id = ChunkIdentifier::new(
@@ -274,6 +282,19 @@ impl StreamingState {
     /// Expose the rolling timing statistics for persistence by the streaming loop.
     pub fn timing_stats(&self) -> &ChunkTimingStats {
         &self.timing_stats
+    }
+
+    /// Record the ACTUAL volume header time parsed by the worker from the
+    /// first Message 31 radial of the current volume. Pushed in from the
+    /// streaming loop after each ingest response.
+    pub fn record_volume_header_time_secs(&mut self, secs: f64) {
+        self.latest_volume_header_time_secs = Some(secs);
+    }
+
+    /// Most recently recorded volume header time (Unix seconds), if any.
+    #[allow(dead_code)] // Consumed in a later commit to anchor collection-time projections.
+    pub fn latest_volume_header_time_secs(&self) -> Option<f64> {
+        self.latest_volume_header_time_secs
     }
 
     /// Replace the rolling timing statistics with a previously-persisted snapshot.

--- a/src/nexrad/streaming_state.rs
+++ b/src/nexrad/streaming_state.rs
@@ -6,12 +6,15 @@
 //! init (fetch latest + optional start chunk, extract VCP), pull-based
 //! `try_next`, and timing/metadata accessors.
 
+use super::timing::{
+    estimate_chunk_availability_time, project_scan_timing, ChunkCharacteristics, ChunkMetadata,
+    ChunkTimingStats, ElevationChunkMapper, ScanTimingProjection,
+};
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use log::debug;
 use nexrad_data::aws::realtime::{
-    download_chunk, estimate_chunk_availability_time, list_chunks_in_volume, project_scan_timing,
-    Chunk, ChunkCharacteristics, ChunkIdentifier, ChunkMetadata, ChunkTimingStats, ChunkType,
-    DownloadedChunk, ElevationChunkMapper, NextChunk, ScanTimingProjection, VolumeIndex,
+    download_chunk, list_chunks_in_volume, Chunk, ChunkIdentifier, ChunkType, DownloadedChunk,
+    VolumeIndex,
 };
 use nexrad_data::result::{aws::AWSError, Error, Result};
 use nexrad_decode::messages::volume_coverage_pattern;
@@ -124,15 +127,30 @@ impl StreamingState {
             .elevation_mapper
             .as_ref()
             .ok_or(AWSError::FailedToDetermineNextChunk)?;
-        let next = self
-            .current
-            .next_chunk(mapper)
-            .ok_or(AWSError::FailedToDetermineNextChunk)?;
+        let final_sequence = mapper.final_sequence();
+        let current_sequence = self.current.sequence();
 
-        match next {
-            NextChunk::Sequence(next_id) => self.try_fetch_chunk(next_id).await,
-            NextChunk::Volume(next_volume) => self.try_fetch_volume_start(next_volume).await,
+        if current_sequence == final_sequence {
+            return self
+                .try_fetch_volume_start(self.current.volume().next())
+                .await;
         }
+
+        let next_sequence = current_sequence + 1;
+        let next_type = if next_sequence == final_sequence {
+            ChunkType::End
+        } else {
+            ChunkType::Intermediate
+        };
+        let next_id = ChunkIdentifier::new(
+            self.current.site().to_string(),
+            *self.current.volume(),
+            *self.current.date_time_prefix(),
+            next_sequence,
+            next_type,
+            None,
+        );
+        self.try_fetch_chunk(next_id).await
     }
 
     async fn try_fetch_chunk(

--- a/src/nexrad/timing/chunk_timing_model.rs
+++ b/src/nexrad/timing/chunk_timing_model.rs
@@ -1,4 +1,5 @@
 use super::ChunkMetadata;
+use nexrad_decode::messages::volume_coverage_pattern::WaveformType;
 
 /// Sweep duration bias correction in seconds.
 ///
@@ -58,15 +59,25 @@ impl ChunkTimingModel {
         Self::sweep_duration_secs(azimuth_rate_dps).map(|d| d / chunks_in_sweep as f64)
     }
 
-    /// Predicted inter-sweep gap in seconds based on elevation angle change.
+    /// Predicted inter-sweep gap in seconds based on elevation angle change and
+    /// waveform transition.
     ///
-    /// Formula: `0.7 + (|from_elevation - to_elevation| * 0.08)`
+    /// Formula: `0.7 + (|from_elevation - to_elevation| * 0.08) + waveform_penalty`
     ///
     /// The base 0.7s represents mode switching overhead. The 0.08s per degree represents
     /// antenna slew rate during transitions (much faster than the survey rotation rate).
-    pub fn inter_sweep_gap_secs(from_elevation_deg: f64, to_elevation_deg: f64) -> f64 {
+    /// The waveform penalty accounts for additional mode-switch overhead when the
+    /// waveform type changes between sweeps (see [`waveform_transition_penalty_secs`]).
+    pub fn inter_sweep_gap_secs(
+        from_elevation_deg: f64,
+        to_elevation_deg: f64,
+        from_waveform: Option<WaveformType>,
+        to_waveform: Option<WaveformType>,
+    ) -> f64 {
         let elevation_change = (to_elevation_deg - from_elevation_deg).abs();
-        INTER_SWEEP_BASE_GAP_SECS + (elevation_change * INTER_SWEEP_ELEVATION_RATE_SECS_PER_DEG)
+        INTER_SWEEP_BASE_GAP_SECS
+            + (elevation_change * INTER_SWEEP_ELEVATION_RATE_SECS_PER_DEG)
+            + waveform_transition_penalty_secs(from_waveform, to_waveform)
     }
 
     /// Predicted inter-volume gap in seconds (constant 8.5s).
@@ -97,6 +108,8 @@ impl ChunkTimingModel {
             let gap = Self::inter_sweep_gap_secs(
                 previous.elevation_angle_deg(),
                 next.elevation_angle_deg(),
+                previous.waveform_type(),
+                next.waveform_type(),
             );
 
             return match chunk_duration {
@@ -114,5 +127,44 @@ impl ChunkTimingModel {
     /// Uses the midpoint of observed chunk durations (~4s) as a conservative default.
     fn fallback_chunk_duration_secs() -> f64 {
         4.0
+    }
+}
+
+/// Extra inter-sweep gap in seconds attributable to a waveform-type transition.
+///
+/// The base `inter_sweep_gap_secs` already covers antenna slew and a small mode-switch
+/// overhead. This function adds a further penalty when the waveform type itself changes,
+/// which empirically dominates the physics-only prediction error on sweep boundaries.
+///
+/// Calibration is from one VCP 212 volume (2026-04-24, 24 elevations) where the base
+/// formula predicted first-chunk-of-sweep arrivals 2–4s too early on waveform changes.
+/// Specific pairs are matched first; asymmetric catch-alls apply when only one side is
+/// known.
+fn waveform_transition_penalty_secs(from: Option<WaveformType>, to: Option<WaveformType>) -> f64 {
+    let (from, to) = match (from, to) {
+        (Some(f), Some(t)) => (f, t),
+        // Start chunk or otherwise unknown: no additional penalty — the caller
+        // (inter_volume_gap branch, or base inter-sweep gap) already covers it.
+        _ => return 0.0,
+    };
+
+    if std::mem::discriminant(&from) == std::mem::discriminant(&to) {
+        return 0.0;
+    }
+
+    match (from, to) {
+        // CS → CDW: same-angle SAILS/MRLE transition, observed 5–6 empty polls
+        // per chunk with pred_err +3.4 to +4.0s against a 0.7s base.
+        (WaveformType::CS, WaveformType::CDW) => 2.8,
+        // CDW → CS: reverse direction, observed ~+1s drift.
+        (WaveformType::CDW, WaveformType::CS) => 1.0,
+        // B → CDWO: high-elevation transition, observed pred_err ~+3s.
+        (WaveformType::B, WaveformType::CDWO) => 3.0,
+        // CDWO leaving to any other waveform: small penalty, ~+1s.
+        (WaveformType::CDWO, _) => 1.0,
+        // Anything arriving at B: small penalty, ~+1s.
+        (_, WaveformType::B) => 1.0,
+        // Catch-all for untabulated waveform changes: conservative middle ground.
+        _ => 2.0,
     }
 }

--- a/src/nexrad/timing/chunk_timing_model.rs
+++ b/src/nexrad/timing/chunk_timing_model.rs
@@ -156,8 +156,12 @@ impl ChunkTimingModel {
 /// overhead. This function adds a further penalty when the waveform type itself changes,
 /// which empirically dominates the physics-only prediction error on sweep boundaries.
 ///
-/// Calibration is from one VCP 212 volume (2026-04-24, 24 elevations) where the base
-/// formula predicted first-chunk-of-sweep arrivals 2–4s too early on waveform changes.
+/// Calibration is from two VCP 212 volumes (2026-04-24). The initial values were
+/// tuned from the first volume; after deploying them, a second volume showed residual
+/// pred_err of +1.8 to +3.1s on CS→CDW (penalty was diluted ~30% by the physics/historical
+/// blend in `scan_timing_projection`) and +1.95s on B→CDWO. These values are sized to
+/// land predictions within ~0.5s of observed after blend dilution.
+///
 /// Specific pairs are matched first; asymmetric catch-alls apply when only one side is
 /// known.
 fn waveform_transition_penalty_secs(from: Option<WaveformType>, to: Option<WaveformType>) -> f64 {
@@ -173,13 +177,14 @@ fn waveform_transition_penalty_secs(from: Option<WaveformType>, to: Option<Wavef
     }
 
     match (from, to) {
-        // CS → CDW: same-angle SAILS/MRLE transition, observed 5–6 empty polls
-        // per chunk with pred_err +3.4 to +4.0s against a 0.7s base.
-        (WaveformType::CS, WaveformType::CDW) => 2.8,
-        // CDW → CS: reverse direction, observed ~+1s drift.
+        // CS → CDW: same-angle SAILS/MRLE transition. The dominant source of
+        // remaining empty polls. Effective shift after 70/30 blend dilution is ~2.8s.
+        (WaveformType::CS, WaveformType::CDW) => 4.0,
+        // CDW → CS: reverse direction, observed ~+1s drift (held on Δstart across both volumes).
         (WaveformType::CDW, WaveformType::CS) => 1.0,
-        // B → CDWO: high-elevation transition, observed pred_err ~+3s.
-        (WaveformType::B, WaveformType::CDWO) => 3.0,
+        // B → CDWO: high-elevation transition between B sweeps and CDWO. Bumped after
+        // a second volume showed +1.95s residual pred_err at this transition.
+        (WaveformType::B, WaveformType::CDWO) => 3.5,
         // CDWO leaving to any other waveform: small penalty, ~+1s.
         (WaveformType::CDWO, _) => 1.0,
         // Anything arriving at B: small penalty, ~+1s.

--- a/src/nexrad/timing/chunk_timing_model.rs
+++ b/src/nexrad/timing/chunk_timing_model.rs
@@ -1,6 +1,52 @@
 use super::ChunkMetadata;
 use nexrad_decode::messages::volume_coverage_pattern::WaveformType;
 
+/// Which case [`ChunkTimingModel::estimate_chunk_interval_secs`] selected.
+///
+/// Recorded on the per-chunk diagnostic so we can tell whether a prediction
+/// error came from intra-sweep rotation rate, inter-sweep transition, or the
+/// fixed inter-volume gap — three completely different fixes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IntervalCase {
+    /// Pure rotation rate: same elevation, no transition.
+    IntraSweep,
+    /// First chunk of a new sweep within the same volume — base gap +
+    /// elevation slew + waveform penalty + chunk duration.
+    InterSweep,
+    /// First chunk of a new volume — fixed `INTER_VOLUME_GAP_SECS`.
+    InterVolume,
+}
+
+impl IntervalCase {
+    pub fn short(&self) -> &'static str {
+        match self {
+            IntervalCase::IntraSweep => "intra",
+            IntervalCase::InterSweep => "inter_sweep",
+            IntervalCase::InterVolume => "inter_volume",
+        }
+    }
+}
+
+/// Decomposition of a single physics-model interval prediction.
+///
+/// `total_secs` is what the legacy `estimate_chunk_interval_secs` returns;
+/// the other fields expose the components that fed it so prediction error
+/// can be attributed to a specific knob.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PhysicsBreakdown {
+    pub case: IntervalCase,
+    pub total_secs: f64,
+    /// Per-chunk rotation duration (sweep_duration / chunks_in_sweep).
+    /// `None` for InterVolume (no chunk-duration term applies) or when the
+    /// azimuth rate wasn't available and a fallback was used.
+    pub chunk_duration_secs: Option<f64>,
+    /// Inter-sweep gap base (0.7s) + elevation slew. `None` outside InterSweep.
+    pub inter_sweep_gap_secs: Option<f64>,
+    /// Waveform-transition penalty applied within an inter-sweep gap. `None`
+    /// outside InterSweep (or when no penalty applies).
+    pub waveform_penalty_secs: Option<f64>,
+}
+
 /// Sweep duration bias correction in seconds.
 ///
 /// Sweeps consistently finish ~0.67s before a full 360-degree rotation would predict,
@@ -107,39 +153,79 @@ impl ChunkTimingModel {
 
     /// Estimate the time interval in seconds between two consecutive chunks.
     ///
-    /// Three cases:
-    /// 1. **Start chunk** (inter-volume): Returns the inter-volume gap (~8.5s).
-    /// 2. **First chunk in a new sweep** (inter-sweep): Chunk duration + inter-sweep gap.
-    /// 3. **Intra-sweep chunk**: Pure chunk duration (sweep_duration / chunks_in_sweep).
-    ///
-    /// Falls back to static defaults if the azimuth rate is zero or unavailable.
+    /// Thin wrapper around [`Self::estimate_chunk_interval_breakdown`] for callers
+    /// that only need the total. Diagnostic paths should call the breakdown form
+    /// directly so the component split is observable.
     pub fn estimate_chunk_interval_secs(previous: &ChunkMetadata, next: &ChunkMetadata) -> f64 {
+        Self::estimate_chunk_interval_breakdown(previous, next).total_secs
+    }
+
+    /// Estimate the time interval between two consecutive chunks, with the
+    /// physics decomposition exposed for diagnostics.
+    ///
+    /// Three cases:
+    /// 1. **Start chunk** (inter-volume): fixed inter-volume gap (~8.5s).
+    /// 2. **First chunk in a new sweep** (inter-sweep): chunk duration +
+    ///    inter-sweep gap (base + elevation slew + waveform penalty).
+    /// 3. **Intra-sweep chunk**: pure chunk duration (sweep_duration /
+    ///    chunks_in_sweep).
+    ///
+    /// Falls back to a static chunk-duration default if the azimuth rate is
+    /// zero or unavailable; in that case `chunk_duration_secs` in the
+    /// returned breakdown is `None` to signal the fallback was used.
+    pub fn estimate_chunk_interval_breakdown(
+        previous: &ChunkMetadata,
+        next: &ChunkMetadata,
+    ) -> PhysicsBreakdown {
         // Case 1: Start chunk (beginning of new volume)
         if next.is_start_chunk() {
-            return Self::inter_volume_gap_secs();
+            return PhysicsBreakdown {
+                case: IntervalCase::InterVolume,
+                total_secs: Self::inter_volume_gap_secs(),
+                chunk_duration_secs: None,
+                inter_sweep_gap_secs: None,
+                waveform_penalty_secs: None,
+            };
         }
 
-        // Get the chunk duration for the next chunk's sweep
         let chunk_duration =
             Self::chunk_duration_secs(next.azimuth_rate_dps(), next.chunks_in_sweep());
 
         // Case 2: First chunk in a new sweep (inter-sweep transition)
         if next.is_first_in_sweep() {
-            let gap = Self::inter_sweep_gap_secs(
-                previous.elevation_angle_deg(),
-                next.elevation_angle_deg(),
-                previous.waveform_type(),
-                next.waveform_type(),
-            );
-
-            return match chunk_duration {
+            let waveform_penalty =
+                waveform_transition_penalty_secs(previous.waveform_type(), next.waveform_type());
+            let elevation_change =
+                (next.elevation_angle_deg() - previous.elevation_angle_deg()).abs();
+            let gap = INTER_SWEEP_BASE_GAP_SECS
+                + elevation_change * INTER_SWEEP_ELEVATION_RATE_SECS_PER_DEG
+                + waveform_penalty;
+            let total = match chunk_duration {
                 Some(d) => d + gap,
                 None => gap + Self::fallback_chunk_duration_secs(),
             };
+            return PhysicsBreakdown {
+                case: IntervalCase::InterSweep,
+                total_secs: total,
+                chunk_duration_secs: chunk_duration,
+                inter_sweep_gap_secs: Some(gap),
+                waveform_penalty_secs: if waveform_penalty > 0.0 {
+                    Some(waveform_penalty)
+                } else {
+                    None
+                },
+            };
         }
 
-        // Case 3: Intra-sweep chunk (same elevation, continuous rotation)
-        chunk_duration.unwrap_or(Self::fallback_chunk_duration_secs())
+        // Case 3: Intra-sweep chunk
+        let total = chunk_duration.unwrap_or(Self::fallback_chunk_duration_secs());
+        PhysicsBreakdown {
+            case: IntervalCase::IntraSweep,
+            total_secs: total,
+            chunk_duration_secs: chunk_duration,
+            inter_sweep_gap_secs: None,
+            waveform_penalty_secs: None,
+        }
     }
 
     /// Fallback chunk duration when azimuth rate is unavailable.

--- a/src/nexrad/timing/chunk_timing_model.rs
+++ b/src/nexrad/timing/chunk_timing_model.rs
@@ -1,0 +1,118 @@
+use super::ChunkMetadata;
+
+/// Sweep duration bias correction in seconds.
+///
+/// Sweeps consistently finish ~0.67s before a full 360-degree rotation would predict,
+/// because the last radial at ~359.5 degrees means the sweep is slightly short of a
+/// full circle. Derived from analysis of 801 sweep observations across 59 volumes.
+const SWEEP_DURATION_BIAS_SECS: f64 = 0.67;
+
+/// Base overhead for inter-sweep transitions in seconds.
+///
+/// This represents the minimum time for mode switching between sweeps when the
+/// antenna doesn't need to change elevation (e.g., CS to CDW at same angle).
+const INTER_SWEEP_BASE_GAP_SECS: f64 = 0.7;
+
+/// Seconds per degree of elevation change during inter-sweep transitions.
+///
+/// Represents the antenna slew rate during transitions between sweeps at different
+/// elevation angles. Combined with the base gap: gap = 0.7 + (|delta_elev| * 0.08).
+const INTER_SWEEP_ELEVATION_RATE_SECS_PER_DEG: f64 = 0.08;
+
+/// Inter-volume gap in seconds.
+///
+/// Time between the last radial of one volume and the first radial of the next.
+/// Includes antenna return to starting elevation plus initialization overhead.
+/// Derived from analysis: mean ~8.5s, range 7-10s.
+const INTER_VOLUME_GAP_SECS: f64 = 8.5;
+
+/// Physics-based timing model for predicting chunk and sweep timing from VCP parameters.
+///
+/// All predictions are derived from analysis of 59 archive volumes across 12 NEXRAD sites,
+/// 8 VCP types, and diverse meteorological scenarios. The azimuth rate from the VCP is the
+/// dominant predictor, achieving a mean absolute error of 0.33s for sweep duration prediction.
+pub struct ChunkTimingModel;
+
+impl ChunkTimingModel {
+    /// Predicted sweep duration in seconds based on azimuth rotation rate.
+    ///
+    /// Formula: `(360 / azimuth_rate_dps) - 0.67`
+    ///
+    /// Returns `None` if `azimuth_rate_dps` is zero or negative.
+    pub fn sweep_duration_secs(azimuth_rate_dps: f64) -> Option<f64> {
+        if azimuth_rate_dps <= 0.0 {
+            return None;
+        }
+        Some((360.0 / azimuth_rate_dps) - SWEEP_DURATION_BIAS_SECS)
+    }
+
+    /// Predicted duration for a single chunk within a sweep.
+    ///
+    /// Chunks divide a sweep evenly: `sweep_duration / chunks_in_sweep`.
+    ///
+    /// Returns `None` if `azimuth_rate_dps` is zero or negative, or `chunks_in_sweep` is zero.
+    pub fn chunk_duration_secs(azimuth_rate_dps: f64, chunks_in_sweep: usize) -> Option<f64> {
+        if chunks_in_sweep == 0 {
+            return None;
+        }
+        Self::sweep_duration_secs(azimuth_rate_dps).map(|d| d / chunks_in_sweep as f64)
+    }
+
+    /// Predicted inter-sweep gap in seconds based on elevation angle change.
+    ///
+    /// Formula: `0.7 + (|from_elevation - to_elevation| * 0.08)`
+    ///
+    /// The base 0.7s represents mode switching overhead. The 0.08s per degree represents
+    /// antenna slew rate during transitions (much faster than the survey rotation rate).
+    pub fn inter_sweep_gap_secs(from_elevation_deg: f64, to_elevation_deg: f64) -> f64 {
+        let elevation_change = (to_elevation_deg - from_elevation_deg).abs();
+        INTER_SWEEP_BASE_GAP_SECS + (elevation_change * INTER_SWEEP_ELEVATION_RATE_SECS_PER_DEG)
+    }
+
+    /// Predicted inter-volume gap in seconds (constant 8.5s).
+    pub fn inter_volume_gap_secs() -> f64 {
+        INTER_VOLUME_GAP_SECS
+    }
+
+    /// Estimate the time interval in seconds between two consecutive chunks.
+    ///
+    /// Three cases:
+    /// 1. **Start chunk** (inter-volume): Returns the inter-volume gap (~8.5s).
+    /// 2. **First chunk in a new sweep** (inter-sweep): Chunk duration + inter-sweep gap.
+    /// 3. **Intra-sweep chunk**: Pure chunk duration (sweep_duration / chunks_in_sweep).
+    ///
+    /// Falls back to static defaults if the azimuth rate is zero or unavailable.
+    pub fn estimate_chunk_interval_secs(previous: &ChunkMetadata, next: &ChunkMetadata) -> f64 {
+        // Case 1: Start chunk (beginning of new volume)
+        if next.is_start_chunk() {
+            return Self::inter_volume_gap_secs();
+        }
+
+        // Get the chunk duration for the next chunk's sweep
+        let chunk_duration =
+            Self::chunk_duration_secs(next.azimuth_rate_dps(), next.chunks_in_sweep());
+
+        // Case 2: First chunk in a new sweep (inter-sweep transition)
+        if next.is_first_in_sweep() {
+            let gap = Self::inter_sweep_gap_secs(
+                previous.elevation_angle_deg(),
+                next.elevation_angle_deg(),
+            );
+
+            return match chunk_duration {
+                Some(d) => d + gap,
+                None => gap + Self::fallback_chunk_duration_secs(),
+            };
+        }
+
+        // Case 3: Intra-sweep chunk (same elevation, continuous rotation)
+        chunk_duration.unwrap_or(Self::fallback_chunk_duration_secs())
+    }
+
+    /// Fallback chunk duration when azimuth rate is unavailable.
+    ///
+    /// Uses the midpoint of observed chunk durations (~4s) as a conservative default.
+    fn fallback_chunk_duration_secs() -> f64 {
+        4.0
+    }
+}

--- a/src/nexrad/timing/chunk_timing_model.rs
+++ b/src/nexrad/timing/chunk_timing_model.rs
@@ -31,10 +31,10 @@ const INTER_VOLUME_GAP_SECS: f64 = 8.5;
 /// chunk's upload, within the same volume.
 ///
 /// The Start chunk is metadata-only and is published almost immediately; the first
-/// intermediate chunk lags by only a few seconds (observed ~2s in one VCP 212 volume).
-/// This is distinct from `INTER_VOLUME_GAP_SECS`, which measures the gap between
-/// the *End* of one volume and the *Start* of the next.
-const START_TO_FIRST_INTERMEDIATE_GAP_SECS: f64 = 3.0;
+/// intermediate chunk lags by ~1–2s in practice (observed across three VCP 212
+/// volumes). This is distinct from `INTER_VOLUME_GAP_SECS`, which measures the gap
+/// between the *End* of one volume and the *Start* of the next.
+const START_TO_FIRST_INTERMEDIATE_GAP_SECS: f64 = 1.5;
 
 /// Physics-based timing model for predicting chunk and sweep timing from VCP parameters.
 ///

--- a/src/nexrad/timing/chunk_timing_model.rs
+++ b/src/nexrad/timing/chunk_timing_model.rs
@@ -27,6 +27,15 @@ const INTER_SWEEP_ELEVATION_RATE_SECS_PER_DEG: f64 = 0.08;
 /// Derived from analysis: mean ~8.5s, range 7-10s.
 const INTER_VOLUME_GAP_SECS: f64 = 8.5;
 
+/// Gap in seconds between the Start chunk's upload and the first intermediate
+/// chunk's upload, within the same volume.
+///
+/// The Start chunk is metadata-only and is published almost immediately; the first
+/// intermediate chunk lags by only a few seconds (observed ~2s in one VCP 212 volume).
+/// This is distinct from `INTER_VOLUME_GAP_SECS`, which measures the gap between
+/// the *End* of one volume and the *Start* of the next.
+const START_TO_FIRST_INTERMEDIATE_GAP_SECS: f64 = 3.0;
+
 /// Physics-based timing model for predicting chunk and sweep timing from VCP parameters.
 ///
 /// All predictions are derived from analysis of 59 archive volumes across 12 NEXRAD sites,
@@ -81,8 +90,19 @@ impl ChunkTimingModel {
     }
 
     /// Predicted inter-volume gap in seconds (constant 8.5s).
+    ///
+    /// Measures the gap from the End chunk of one volume to the Start chunk of the next.
     pub fn inter_volume_gap_secs() -> f64 {
         INTER_VOLUME_GAP_SECS
+    }
+
+    /// Predicted gap in seconds from the Start chunk to the first intermediate chunk
+    /// within the same volume (constant 3.0s).
+    ///
+    /// Distinct from [`inter_volume_gap_secs`]: that measures End → Start across volumes,
+    /// whereas this measures Start → first intermediate within a single volume.
+    pub fn start_to_first_intermediate_gap_secs() -> f64 {
+        START_TO_FIRST_INTERMEDIATE_GAP_SECS
     }
 
     /// Estimate the time interval in seconds between two consecutive chunks.

--- a/src/nexrad/timing/chunk_timing_stats.rs
+++ b/src/nexrad/timing/chunk_timing_stats.rs
@@ -11,7 +11,10 @@ const MAX_TIMING_SAMPLES: usize = 10;
 /// Schema version for the serialized `ChunkTimingStats` payload in localStorage.
 /// Bump when the on-disk shape changes so old caches are ignored rather than
 /// silently misinterpreted.
-const PERSIST_SCHEMA_VERSION: u32 = 1;
+///
+/// v2 added `availability_lag_ms` to every sample; v1 payloads are discarded
+/// because the field can't be backfilled from S3 deltas alone.
+const PERSIST_SCHEMA_VERSION: u32 = 2;
 
 /// Characteristics of a chunk that affect timing.
 ///
@@ -41,12 +44,18 @@ impl Hash for ChunkCharacteristics {
     }
 }
 
-/// Statistics for a single timing sample
+/// Statistics for a single timing sample.
+///
+/// `duration` is the legacy S3-upload→S3-upload delta (AVAILABILITY-to-
+/// AVAILABILITY), used by the scheduler via `get_average_timing`.
+/// `availability_lag` is the empirical (upload − ACTUAL collection) delay
+/// for this chunk when the collection time could be recorded; used by the
+/// projector to estimate the availability-lag tail per characteristics.
+/// `None` indicates the sample predates collection-time plumbing.
 #[derive(Debug, Clone, Copy)]
 pub(super) struct TimingStat {
-    /// Duration of the timing sample
     duration: Duration,
-    /// Number of attempts to download the chunk
+    availability_lag: Option<Duration>,
     attempts: usize,
 }
 
@@ -65,21 +74,69 @@ impl ChunkTimingStats {
         }
     }
 
-    /// Add a timing sample for the given chunk characteristics
+    /// Add an S3-upload-delta timing sample for the given chunk characteristics.
+    /// `availability_lag` is optional; pass `Some` when the per-chunk lag
+    /// (S3 upload − ACTUAL collection time) can be computed from a successful
+    /// worker ingest, `None` when only the S3 delta is known.
     pub fn add_timing(
         &mut self,
         characteristics: ChunkCharacteristics,
         duration: Duration,
+        availability_lag: Option<Duration>,
         attempts: usize,
     ) {
         let entry = self.timings.entry(characteristics).or_default();
 
-        entry.push_back(TimingStat { duration, attempts });
+        entry.push_back(TimingStat {
+            duration,
+            availability_lag,
+            attempts,
+        });
 
         // Maintain the rolling window by removing oldest if we exceed the max
         if entry.len() > MAX_TIMING_SAMPLES {
             entry.pop_front();
         }
+    }
+
+    /// Update the most recent sample for the given characteristics to attach
+    /// an availability lag observation. Used when the S3 delta is recorded in
+    /// the streaming loop but the ACTUAL collection time only becomes known
+    /// later once the worker decodes the chunk.
+    pub fn attach_availability_lag(
+        &mut self,
+        characteristics: &ChunkCharacteristics,
+        availability_lag: Duration,
+    ) {
+        if let Some(entry) = self.timings.get_mut(characteristics) {
+            if let Some(latest) = entry.back_mut() {
+                latest.availability_lag = Some(availability_lag);
+            }
+        }
+    }
+
+    /// Median availability lag (S3 upload − ACTUAL collection) across all
+    /// characteristics, as Unix seconds. Returns `None` until at least one
+    /// sample with a lag observation has been recorded. Median (not mean)
+    /// so clock outliers don't skew the projection fallback.
+    pub fn median_availability_lag_secs(&self) -> Option<f64> {
+        let mut lags_ms: Vec<i64> = self
+            .timings
+            .values()
+            .flat_map(|queue| queue.iter())
+            .filter_map(|stat| stat.availability_lag.map(|d| d.num_milliseconds()))
+            .collect();
+        if lags_ms.is_empty() {
+            return None;
+        }
+        lags_ms.sort_unstable();
+        let mid = lags_ms.len() / 2;
+        let median_ms = if lags_ms.len().is_multiple_of(2) {
+            (lags_ms[mid - 1] + lags_ms[mid]) / 2
+        } else {
+            lags_ms[mid]
+        };
+        Some(median_ms as f64 / 1000.0)
     }
 
     /// Get the average timing for the given chunk characteristics
@@ -147,6 +204,7 @@ impl ChunkTimingStats {
                         .iter()
                         .map(|t| TimingStatDto {
                             duration_ms: t.duration.num_milliseconds(),
+                            availability_lag_ms: t.availability_lag.map(|d| d.num_milliseconds()),
                             attempts: t.attempts,
                         })
                         .collect();
@@ -177,6 +235,7 @@ impl ChunkTimingStats {
             for sample in samples.into_iter().rev().take(MAX_TIMING_SAMPLES).rev() {
                 queue.push_back(TimingStat {
                     duration: Duration::milliseconds(sample.duration_ms),
+                    availability_lag: sample.availability_lag_ms.map(Duration::milliseconds),
                     attempts: sample.attempts,
                 });
             }
@@ -207,6 +266,8 @@ struct ChunkCharacteristicsDto {
 #[derive(Serialize, Deserialize)]
 struct TimingStatDto {
     duration_ms: i64,
+    #[serde(default)]
+    availability_lag_ms: Option<i64>,
     attempts: usize,
 }
 

--- a/src/nexrad/timing/chunk_timing_stats.rs
+++ b/src/nexrad/timing/chunk_timing_stats.rs
@@ -1,0 +1,118 @@
+use chrono::Duration;
+use nexrad_data::aws::realtime::ChunkType;
+use nexrad_decode::messages::volume_coverage_pattern::{ChannelConfiguration, WaveformType};
+use std::collections::{HashMap, VecDeque};
+use std::hash::{Hash, Hasher};
+
+/// Maximum number of timing samples to keep per chunk characteristics
+const MAX_TIMING_SAMPLES: usize = 10;
+
+/// Characteristics of a chunk that affect timing
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct ChunkCharacteristics {
+    /// Type of the chunk
+    pub chunk_type: ChunkType,
+    /// Waveform type of the elevation
+    pub waveform_type: WaveformType,
+    /// Channel configuration of the elevation
+    pub channel_configuration: ChannelConfiguration,
+}
+
+impl Hash for ChunkCharacteristics {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(&self.chunk_type).hash(state);
+        std::mem::discriminant(&self.waveform_type).hash(state);
+        std::mem::discriminant(&self.channel_configuration).hash(state);
+    }
+}
+
+/// Statistics for a single timing sample
+#[derive(Debug, Clone, Copy)]
+pub(super) struct TimingStat {
+    /// Duration of the timing sample
+    duration: Duration,
+    /// Number of attempts to download the chunk
+    attempts: usize,
+}
+
+/// Statistics for timing between chunks
+#[derive(Debug, Clone, Default)]
+pub struct ChunkTimingStats {
+    /// Timing statistics for each chunk characteristics
+    timings: HashMap<ChunkCharacteristics, VecDeque<TimingStat>>,
+}
+
+impl ChunkTimingStats {
+    /// Create a new empty timing statistics
+    pub fn new() -> Self {
+        Self {
+            timings: HashMap::new(),
+        }
+    }
+
+    /// Add a timing sample for the given chunk characteristics
+    pub fn add_timing(
+        &mut self,
+        characteristics: ChunkCharacteristics,
+        duration: Duration,
+        attempts: usize,
+    ) {
+        let entry = self.timings.entry(characteristics).or_default();
+
+        entry.push_back(TimingStat { duration, attempts });
+
+        // Maintain the rolling window by removing oldest if we exceed the max
+        if entry.len() > MAX_TIMING_SAMPLES {
+            entry.pop_front();
+        }
+    }
+
+    /// Get the average timing for the given chunk characteristics
+    pub(super) fn get_average_timing(
+        &self,
+        characteristics: &ChunkCharacteristics,
+    ) -> Option<Duration> {
+        self.timings.get(characteristics).and_then(|timings| {
+            if timings.is_empty() {
+                return None;
+            }
+
+            let total_millis: i64 = timings
+                .iter()
+                .map(|timing| timing.duration.num_milliseconds())
+                .sum();
+
+            let avg_millis = total_millis / timings.len() as i64;
+            Some(Duration::milliseconds(avg_millis))
+        })
+    }
+
+    /// Get the average number of attempts for the given chunk characteristics
+    pub(super) fn get_average_attempts(
+        &self,
+        characteristics: &ChunkCharacteristics,
+    ) -> Option<f64> {
+        self.timings.get(characteristics).and_then(|timings| {
+            if timings.is_empty() {
+                return None;
+            }
+
+            let total_attempts: usize = timings.iter().map(|timing| timing.attempts).sum();
+            Some(total_attempts as f64 / timings.len() as f64)
+        })
+    }
+
+    /// Get all chunk statistics for display purposes
+    pub fn get_statistics(&self) -> Vec<(ChunkCharacteristics, Option<Duration>, Option<f64>)> {
+        self.timings
+            .keys()
+            .map(|characteristics| {
+                (
+                    *characteristics,
+                    self.get_average_timing(characteristics),
+                    self.get_average_attempts(characteristics),
+                )
+            })
+            .collect()
+    }
+}

--- a/src/nexrad/timing/chunk_timing_stats.rs
+++ b/src/nexrad/timing/chunk_timing_stats.rs
@@ -1,11 +1,17 @@
 use chrono::Duration;
 use nexrad_data::aws::realtime::ChunkType;
 use nexrad_decode::messages::volume_coverage_pattern::{ChannelConfiguration, WaveformType};
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
 use std::hash::{Hash, Hasher};
 
 /// Maximum number of timing samples to keep per chunk characteristics
 const MAX_TIMING_SAMPLES: usize = 10;
+
+/// Schema version for the serialized `ChunkTimingStats` payload in localStorage.
+/// Bump when the on-disk shape changes so old caches are ignored rather than
+/// silently misinterpreted.
+const PERSIST_SCHEMA_VERSION: u32 = 1;
 
 /// Characteristics of a chunk that affect timing.
 ///
@@ -123,5 +129,160 @@ impl ChunkTimingStats {
                 )
             })
             .collect()
+    }
+
+    /// Serialize to a compact JSON string suitable for localStorage.
+    ///
+    /// The payload includes a schema version; `from_json` ignores payloads with
+    /// a mismatched version so schema bumps cleanly invalidate old caches.
+    pub fn to_json(&self) -> Option<String> {
+        let dto = ChunkTimingStatsDto {
+            version: PERSIST_SCHEMA_VERSION,
+            timings: self
+                .timings
+                .iter()
+                .filter_map(|(k, v)| {
+                    let chars_dto = characteristics_to_dto(k)?;
+                    let samples = v
+                        .iter()
+                        .map(|t| TimingStatDto {
+                            duration_ms: t.duration.num_milliseconds(),
+                            attempts: t.attempts,
+                        })
+                        .collect();
+                    Some((chars_dto, samples))
+                })
+                .collect(),
+        };
+        serde_json::to_string(&dto).ok()
+    }
+
+    /// Deserialize from a JSON string previously produced by `to_json`.
+    ///
+    /// Returns `None` on any parse error or version mismatch. Individual samples
+    /// with unrecognised enum variants are silently dropped — a corrupted entry
+    /// should not poison the whole cache.
+    pub fn from_json(raw: &str) -> Option<Self> {
+        let dto: ChunkTimingStatsDto = serde_json::from_str(raw).ok()?;
+        if dto.version != PERSIST_SCHEMA_VERSION {
+            return None;
+        }
+        let mut timings: HashMap<ChunkCharacteristics, VecDeque<TimingStat>> = HashMap::new();
+        for (chars_dto, samples) in dto.timings {
+            let Some(chars) = characteristics_from_dto(&chars_dto) else {
+                continue;
+            };
+            let mut queue: VecDeque<TimingStat> =
+                VecDeque::with_capacity(samples.len().min(MAX_TIMING_SAMPLES));
+            for sample in samples.into_iter().rev().take(MAX_TIMING_SAMPLES).rev() {
+                queue.push_back(TimingStat {
+                    duration: Duration::milliseconds(sample.duration_ms),
+                    attempts: sample.attempts,
+                });
+            }
+            if !queue.is_empty() {
+                timings.insert(chars, queue);
+            }
+        }
+        Some(Self { timings })
+    }
+}
+
+// ── Persistence DTOs ──────────────────────────────────────────────────────
+
+#[derive(Serialize, Deserialize)]
+struct ChunkTimingStatsDto {
+    version: u32,
+    timings: Vec<(ChunkCharacteristicsDto, Vec<TimingStatDto>)>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct ChunkCharacteristicsDto {
+    chunk_type: String,
+    waveform_type: String,
+    channel_configuration: String,
+    is_first_in_sweep: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+struct TimingStatDto {
+    duration_ms: i64,
+    attempts: usize,
+}
+
+fn characteristics_to_dto(c: &ChunkCharacteristics) -> Option<ChunkCharacteristicsDto> {
+    Some(ChunkCharacteristicsDto {
+        chunk_type: chunk_type_to_str(c.chunk_type).to_string(),
+        waveform_type: waveform_type_to_str(c.waveform_type).to_string(),
+        channel_configuration: channel_configuration_to_str(c.channel_configuration).to_string(),
+        is_first_in_sweep: c.is_first_in_sweep,
+    })
+}
+
+fn characteristics_from_dto(dto: &ChunkCharacteristicsDto) -> Option<ChunkCharacteristics> {
+    Some(ChunkCharacteristics {
+        chunk_type: chunk_type_from_str(&dto.chunk_type)?,
+        waveform_type: waveform_type_from_str(&dto.waveform_type)?,
+        channel_configuration: channel_configuration_from_str(&dto.channel_configuration)?,
+        is_first_in_sweep: dto.is_first_in_sweep,
+    })
+}
+
+fn chunk_type_to_str(t: ChunkType) -> &'static str {
+    match t {
+        ChunkType::Start => "S",
+        ChunkType::Intermediate => "I",
+        ChunkType::End => "E",
+    }
+}
+
+fn chunk_type_from_str(s: &str) -> Option<ChunkType> {
+    match s {
+        "S" => Some(ChunkType::Start),
+        "I" => Some(ChunkType::Intermediate),
+        "E" => Some(ChunkType::End),
+        _ => None,
+    }
+}
+
+fn waveform_type_to_str(t: WaveformType) -> &'static str {
+    match t {
+        WaveformType::CS => "CS",
+        WaveformType::CDW => "CDW",
+        WaveformType::CDWO => "CDWO",
+        WaveformType::B => "B",
+        WaveformType::SPP => "SPP",
+        WaveformType::Unknown => "Unknown",
+    }
+}
+
+fn waveform_type_from_str(s: &str) -> Option<WaveformType> {
+    match s {
+        "CS" => Some(WaveformType::CS),
+        "CDW" => Some(WaveformType::CDW),
+        "CDWO" => Some(WaveformType::CDWO),
+        "B" => Some(WaveformType::B),
+        "SPP" => Some(WaveformType::SPP),
+        "Unknown" => Some(WaveformType::Unknown),
+        _ => None,
+    }
+}
+
+fn channel_configuration_to_str(c: ChannelConfiguration) -> &'static str {
+    match c {
+        ChannelConfiguration::ConstantPhase => "constant_phase",
+        ChannelConfiguration::RandomPhase => "random_phase",
+        ChannelConfiguration::SZ2Phase => "sz2_phase",
+        ChannelConfiguration::UnknownPhase => "unknown_phase",
+    }
+}
+
+fn channel_configuration_from_str(s: &str) -> Option<ChannelConfiguration> {
+    match s {
+        "constant_phase" => Some(ChannelConfiguration::ConstantPhase),
+        "random_phase" => Some(ChannelConfiguration::RandomPhase),
+        "sz2_phase" => Some(ChannelConfiguration::SZ2Phase),
+        "unknown_phase" => Some(ChannelConfiguration::UnknownPhase),
+        _ => None,
     }
 }

--- a/src/nexrad/timing/chunk_timing_stats.rs
+++ b/src/nexrad/timing/chunk_timing_stats.rs
@@ -7,7 +7,12 @@ use std::hash::{Hash, Hasher};
 /// Maximum number of timing samples to keep per chunk characteristics
 const MAX_TIMING_SAMPLES: usize = 10;
 
-/// Characteristics of a chunk that affect timing
+/// Characteristics of a chunk that affect timing.
+///
+/// `is_first_in_sweep` is part of the key because first-chunks-of-sweep include a
+/// substantial inter-sweep transition overhead (antenna slew + waveform mode switch),
+/// while intra-sweep chunks are purely rotation-rate-driven. Mixing the two into one
+/// statistics bucket prevents the rolling average from converging on either value.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct ChunkCharacteristics {
     /// Type of the chunk
@@ -16,6 +21,9 @@ pub struct ChunkCharacteristics {
     pub waveform_type: WaveformType,
     /// Channel configuration of the elevation
     pub channel_configuration: ChannelConfiguration,
+    /// Whether this chunk is the first in its sweep (inter-sweep transition overhead
+    /// applies). See struct docs for why this is keyed separately.
+    pub is_first_in_sweep: bool,
 }
 
 impl Hash for ChunkCharacteristics {
@@ -23,6 +31,7 @@ impl Hash for ChunkCharacteristics {
         std::mem::discriminant(&self.chunk_type).hash(state);
         std::mem::discriminant(&self.waveform_type).hash(state);
         std::mem::discriminant(&self.channel_configuration).hash(state);
+        self.is_first_in_sweep.hash(state);
     }
 }
 

--- a/src/nexrad/timing/chunk_timing_stats.rs
+++ b/src/nexrad/timing/chunk_timing_stats.rs
@@ -44,6 +44,51 @@ impl Hash for ChunkCharacteristics {
     }
 }
 
+/// Per-bucket diagnostic snapshot, returned by
+/// [`ChunkTimingStats::per_bucket_stats`]. Used in the VCP forecast
+/// diagnostics summary so we can see which buckets have warmed up and
+/// whether their availability lag deviates from the global median.
+#[derive(Debug, Clone, Copy)]
+pub struct BucketStats {
+    pub characteristics: ChunkCharacteristics,
+    pub sample_count: usize,
+    pub mean_duration_ms: i64,
+    /// Median availability lag for this bucket only. `None` until at least
+    /// one sample with a recorded `availability_lag` exists for this bucket.
+    pub median_lag_ms: Option<i64>,
+    /// How many of `sample_count` samples carried a non-`None`
+    /// `availability_lag` measurement.
+    pub lag_sample_count: usize,
+}
+
+fn chunk_type_order(t: ChunkType) -> u8 {
+    match t {
+        ChunkType::Start => 0,
+        ChunkType::Intermediate => 1,
+        ChunkType::End => 2,
+    }
+}
+
+fn waveform_order(w: WaveformType) -> u8 {
+    match w {
+        WaveformType::CS => 0,
+        WaveformType::CDW => 1,
+        WaveformType::CDWO => 2,
+        WaveformType::B => 3,
+        WaveformType::SPP => 4,
+        WaveformType::Unknown => 5,
+    }
+}
+
+fn channel_order(c: ChannelConfiguration) -> u8 {
+    match c {
+        ChannelConfiguration::ConstantPhase => 0,
+        ChannelConfiguration::RandomPhase => 1,
+        ChannelConfiguration::SZ2Phase => 2,
+        ChannelConfiguration::UnknownPhase => 3,
+    }
+}
+
 /// Statistics for a single timing sample.
 ///
 /// `duration` is the legacy S3-upload→S3-upload delta (AVAILABILITY-to-
@@ -186,6 +231,76 @@ impl ChunkTimingStats {
                 )
             })
             .collect()
+    }
+
+    /// Number of samples held for the given characteristics bucket.
+    /// 0 if the bucket has never been populated. Capped at
+    /// [`MAX_TIMING_SAMPLES`] (10) by the rolling window.
+    pub fn sample_count(&self, characteristics: &ChunkCharacteristics) -> usize {
+        self.timings.get(characteristics).map_or(0, |q| q.len())
+    }
+
+    /// Total number of samples across all buckets — useful as a "warmup
+    /// progress" metric in the diagnostics header.
+    pub fn total_sample_count(&self) -> usize {
+        self.timings.values().map(|q| q.len()).sum()
+    }
+
+    /// Per-bucket diagnostic snapshot. One entry per characteristics bucket
+    /// that has at least one sample. Sorted by `(chunk_type, waveform_type,
+    /// channel_configuration, is_first_in_sweep)` for stable display order.
+    pub fn per_bucket_stats(&self) -> Vec<BucketStats> {
+        let mut out: Vec<BucketStats> = self
+            .timings
+            .iter()
+            .filter_map(|(k, q)| {
+                if q.is_empty() {
+                    return None;
+                }
+                let n = q.len();
+                let mean_duration_ms =
+                    q.iter().map(|s| s.duration.num_milliseconds()).sum::<i64>() / n as i64;
+                let mut lags: Vec<i64> = q
+                    .iter()
+                    .filter_map(|s| s.availability_lag.map(|d| d.num_milliseconds()))
+                    .collect();
+                let median_lag_ms = if lags.is_empty() {
+                    None
+                } else {
+                    lags.sort_unstable();
+                    let mid = lags.len() / 2;
+                    Some(if lags.len().is_multiple_of(2) {
+                        (lags[mid - 1] + lags[mid]) / 2
+                    } else {
+                        lags[mid]
+                    })
+                };
+                let lag_sample_count = lags.len();
+                Some(BucketStats {
+                    characteristics: *k,
+                    sample_count: n,
+                    mean_duration_ms,
+                    median_lag_ms,
+                    lag_sample_count,
+                })
+            })
+            .collect();
+        out.sort_by(|a, b| {
+            let ka = (
+                chunk_type_order(a.characteristics.chunk_type),
+                waveform_order(a.characteristics.waveform_type),
+                channel_order(a.characteristics.channel_configuration),
+                a.characteristics.is_first_in_sweep,
+            );
+            let kb = (
+                chunk_type_order(b.characteristics.chunk_type),
+                waveform_order(b.characteristics.waveform_type),
+                channel_order(b.characteristics.channel_configuration),
+                b.characteristics.is_first_in_sweep,
+            );
+            ka.cmp(&kb)
+        });
+        out
     }
 
     /// Serialize to a compact JSON string suitable for localStorage.

--- a/src/nexrad/timing/elevation_chunk_mapper.rs
+++ b/src/nexrad/timing/elevation_chunk_mapper.rs
@@ -1,0 +1,185 @@
+use nexrad_decode::messages::volume_coverage_pattern;
+
+/// Metadata describing a chunk's position within the volume scan.
+///
+/// Each chunk in a real-time NEXRAD volume has a sequence number (1-based).
+/// Sequence 1 is always the Start chunk containing metadata (VCP, site info).
+/// Subsequent sequences contain radar data, grouped by elevation sweep.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ChunkMetadata {
+    /// Sequence number of this chunk (1-based).
+    sequence: usize,
+    /// The 1-based elevation number this chunk belongs to, or None for the Start chunk.
+    elevation_number: Option<usize>,
+    /// The chunk's 0-based index within its sweep (e.g., 0..5 for super-res, 0..2 for standard).
+    chunk_index_in_sweep: usize,
+    /// Total number of chunks in this sweep (3 for standard, 6 for super-resolution).
+    chunks_in_sweep: usize,
+    /// Whether this is the first chunk in a sweep (inter-sweep gap applies before this chunk).
+    is_first_in_sweep: bool,
+    /// Whether this is the last chunk in a sweep.
+    is_last_in_sweep: bool,
+    /// Azimuth rotation rate for this elevation in degrees/second (from VCP).
+    azimuth_rate_dps: f64,
+    /// Elevation angle in degrees (from VCP).
+    elevation_angle_deg: f64,
+    /// Whether this is the Start chunk (sequence 1, metadata-only).
+    is_start_chunk: bool,
+}
+
+impl ChunkMetadata {
+    /// The sequence number of this chunk (1-based).
+    pub fn sequence(&self) -> usize {
+        self.sequence
+    }
+
+    /// The 1-based elevation number this chunk belongs to, or None for the Start chunk.
+    pub fn elevation_number(&self) -> Option<usize> {
+        self.elevation_number
+    }
+
+    /// The chunk's 0-based index within its sweep.
+    pub fn chunk_index_in_sweep(&self) -> usize {
+        self.chunk_index_in_sweep
+    }
+
+    /// Total number of chunks in this sweep (3 for standard, 6 for super-resolution).
+    pub fn chunks_in_sweep(&self) -> usize {
+        self.chunks_in_sweep
+    }
+
+    /// Whether this is the first chunk in a sweep.
+    pub fn is_first_in_sweep(&self) -> bool {
+        self.is_first_in_sweep
+    }
+
+    /// Whether this is the last chunk in a sweep.
+    pub fn is_last_in_sweep(&self) -> bool {
+        self.is_last_in_sweep
+    }
+
+    /// Azimuth rotation rate for this elevation in degrees/second.
+    pub fn azimuth_rate_dps(&self) -> f64 {
+        self.azimuth_rate_dps
+    }
+
+    /// Elevation angle in degrees.
+    pub fn elevation_angle_deg(&self) -> f64 {
+        self.elevation_angle_deg
+    }
+
+    /// Whether this is the Start chunk (sequence 1, metadata-only).
+    pub fn is_start_chunk(&self) -> bool {
+        self.is_start_chunk
+    }
+}
+
+/// Maps between real-time chunk sequence numbers and volume coverage pattern elevation numbers.
+#[derive(Debug)]
+pub struct ElevationChunkMapper {
+    // Index is elevation number - 1, value is chunk range inclusive
+    elevation_chunk_mappings: Vec<(usize, usize)>,
+    // Metadata for every chunk, indexed by (sequence - 1)
+    chunk_metadata: Vec<ChunkMetadata>,
+}
+
+impl ElevationChunkMapper {
+    /// Create a new mapper from a volume coverage pattern.
+    pub fn new(vcp: &volume_coverage_pattern::Message) -> Self {
+        let mut elevation_chunk_mappings = Vec::new();
+        let mut chunk_metadata = Vec::new();
+
+        // Sequence 1 is the Start chunk (metadata-only)
+        chunk_metadata.push(ChunkMetadata {
+            sequence: 1,
+            elevation_number: None,
+            chunk_index_in_sweep: 0,
+            chunks_in_sweep: 1,
+            is_first_in_sweep: false,
+            is_last_in_sweep: false,
+            azimuth_rate_dps: 0.0,
+            elevation_angle_deg: 0.0,
+            is_start_chunk: true,
+        });
+
+        let mut total_chunk_count = 2;
+        for (elev_idx, elevation) in vcp.elevations().iter().enumerate() {
+            let elevation_chunk_count = if elevation.super_resolution_half_degree_azimuth() {
+                6 // 720 radials / 120 chunks per chunk
+            } else {
+                3 // 360 radials / 120 chunks per chunk
+            };
+
+            let start_seq = total_chunk_count;
+            let end_seq = total_chunk_count + elevation_chunk_count - 1;
+            elevation_chunk_mappings.push((start_seq, end_seq));
+
+            let azimuth_rate = elevation.azimuth_rate();
+            let elevation_angle = elevation.elevation_angle();
+
+            for chunk_idx in 0..elevation_chunk_count {
+                let seq = total_chunk_count + chunk_idx;
+                chunk_metadata.push(ChunkMetadata {
+                    sequence: seq,
+                    elevation_number: Some(elev_idx + 1),
+                    chunk_index_in_sweep: chunk_idx,
+                    chunks_in_sweep: elevation_chunk_count,
+                    is_first_in_sweep: chunk_idx == 0,
+                    is_last_in_sweep: chunk_idx == elevation_chunk_count - 1,
+                    azimuth_rate_dps: azimuth_rate,
+                    elevation_angle_deg: elevation_angle,
+                    is_start_chunk: false,
+                });
+            }
+
+            total_chunk_count += elevation_chunk_count;
+        }
+
+        Self {
+            elevation_chunk_mappings,
+            chunk_metadata,
+        }
+    }
+
+    /// Get the elevation number for a given sequence number. Returns None if the sequence number
+    /// does not correspond to a radar scan described by the VCP.
+    pub fn get_sequence_elevation_number(&self, sequence: usize) -> Option<usize> {
+        // The first chunk is metadata, not a radar scan described by the VCP
+        if sequence == 1 {
+            return None;
+        }
+
+        self.elevation_chunk_mappings
+            .iter()
+            .position(|(start, end)| sequence >= *start && sequence <= *end)
+            .map(|elevation_index| elevation_index + 1)
+    }
+
+    /// Returns the final sequence number for the volume.
+    pub fn final_sequence(&self) -> usize {
+        self.elevation_chunk_mappings
+            .last()
+            .map(|(_, end)| *end)
+            .unwrap_or(0)
+    }
+
+    /// Get rich metadata for a specific chunk sequence number.
+    ///
+    /// Returns None if the sequence number is out of range.
+    pub fn get_chunk_metadata(&self, sequence: usize) -> Option<&ChunkMetadata> {
+        if sequence == 0 || sequence > self.chunk_metadata.len() {
+            return None;
+        }
+        Some(&self.chunk_metadata[sequence - 1])
+    }
+
+    /// Get metadata for all chunks in the volume (including the Start chunk at index 0).
+    pub fn all_chunk_metadata(&self) -> &[ChunkMetadata] {
+        &self.chunk_metadata
+    }
+
+    /// Total number of chunks in the volume (including the Start chunk).
+    pub fn total_chunks(&self) -> usize {
+        self.chunk_metadata.len()
+    }
+}

--- a/src/nexrad/timing/elevation_chunk_mapper.rs
+++ b/src/nexrad/timing/elevation_chunk_mapper.rs
@@ -1,4 +1,4 @@
-use nexrad_decode::messages::volume_coverage_pattern;
+use nexrad_decode::messages::volume_coverage_pattern::{self, WaveformType};
 
 /// Metadata describing a chunk's position within the volume scan.
 ///
@@ -23,6 +23,8 @@ pub struct ChunkMetadata {
     azimuth_rate_dps: f64,
     /// Elevation angle in degrees (from VCP).
     elevation_angle_deg: f64,
+    /// Waveform type for this elevation (from VCP). `None` for the Start chunk.
+    waveform_type: Option<WaveformType>,
     /// Whether this is the Start chunk (sequence 1, metadata-only).
     is_start_chunk: bool,
 }
@@ -68,6 +70,11 @@ impl ChunkMetadata {
         self.elevation_angle_deg
     }
 
+    /// Waveform type for this elevation. `None` for the Start chunk.
+    pub fn waveform_type(&self) -> Option<WaveformType> {
+        self.waveform_type
+    }
+
     /// Whether this is the Start chunk (sequence 1, metadata-only).
     pub fn is_start_chunk(&self) -> bool {
         self.is_start_chunk
@@ -99,6 +106,7 @@ impl ElevationChunkMapper {
             is_last_in_sweep: false,
             azimuth_rate_dps: 0.0,
             elevation_angle_deg: 0.0,
+            waveform_type: None,
             is_start_chunk: true,
         });
 
@@ -116,6 +124,7 @@ impl ElevationChunkMapper {
 
             let azimuth_rate = elevation.azimuth_rate();
             let elevation_angle = elevation.elevation_angle();
+            let waveform_type = elevation.waveform_type();
 
             for chunk_idx in 0..elevation_chunk_count {
                 let seq = total_chunk_count + chunk_idx;
@@ -128,6 +137,7 @@ impl ElevationChunkMapper {
                     is_last_in_sweep: chunk_idx == elevation_chunk_count - 1,
                     azimuth_rate_dps: azimuth_rate,
                     elevation_angle_deg: elevation_angle,
+                    waveform_type: Some(waveform_type),
                     is_start_chunk: false,
                 });
             }

--- a/src/nexrad/timing/estimate_next_chunk_time.rs
+++ b/src/nexrad/timing/estimate_next_chunk_time.rs
@@ -38,9 +38,10 @@ pub fn estimate_chunk_processing_time(
     elevation_chunk_mapper: &ElevationChunkMapper,
     timing_stats: Option<&ChunkTimingStats>,
 ) -> Option<ChronoDuration> {
-    // Start chunks: use the inter-volume gap model
+    // Start chunks: the next chunk is the first intermediate within the same volume,
+    // which follows the Start chunk by only a few seconds (not the full inter-volume gap).
     if chunk.chunk_type() == ChunkType::Start {
-        let gap_ms = (ChunkTimingModel::inter_volume_gap_secs() * 1000.0) as i64;
+        let gap_ms = (ChunkTimingModel::start_to_first_intermediate_gap_secs() * 1000.0) as i64;
         return Some(ChronoDuration::milliseconds(gap_ms));
     }
 

--- a/src/nexrad/timing/estimate_next_chunk_time.rs
+++ b/src/nexrad/timing/estimate_next_chunk_time.rs
@@ -1,9 +1,60 @@
-use super::{ChunkCharacteristics, ChunkTimingModel, ChunkTimingStats, ElevationChunkMapper};
+use super::{
+    ChunkCharacteristics, ChunkTimingModel, ChunkTimingStats, ElevationChunkMapper,
+    PhysicsBreakdown,
+};
 use chrono::Duration as ChronoDuration;
 use chrono::{DateTime, Utc};
 use log::debug;
 use nexrad_data::aws::realtime::{ChunkIdentifier, ChunkType};
 use nexrad_decode::messages::volume_coverage_pattern;
+
+/// Which branch of [`estimate_chunk_processing_diagnostics`] produced the
+/// returned wait duration. Surfaced in the per-chunk diagnostic so we can see
+/// which estimator drove each prediction without trawling the debug log.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SchedulerPath {
+    /// Constant Start→first-Intermediate gap (no prediction needed).
+    StartConstant,
+    /// `ChunkTimingStats` has historical samples for this bucket; used the
+    /// rolling average + retry budget.
+    Historical,
+    /// Fell back to the physics model — no historical samples for this bucket
+    /// (cold start, new VCP, etc.).
+    Physics,
+    /// Final fallback when neither metadata nor stats were available.
+    Legacy,
+}
+
+impl SchedulerPath {
+    pub fn short(&self) -> &'static str {
+        match self {
+            SchedulerPath::StartConstant => "start",
+            SchedulerPath::Historical => "hist",
+            SchedulerPath::Physics => "phys",
+            SchedulerPath::Legacy => "legacy",
+        }
+    }
+}
+
+/// Rich diagnostic version of [`estimate_chunk_processing_time`]'s output.
+#[derive(Debug, Clone)]
+pub struct EstimatedChunkProcessing {
+    pub duration: ChronoDuration,
+    pub path: SchedulerPath,
+    /// Number of samples in the next chunk's bucket at prediction time. 0
+    /// when the lookup failed (e.g. legacy/start path or no metadata).
+    pub stats_n_at_prediction: usize,
+    /// Physics decomposition for the next-chunk transition. `Some` whenever
+    /// metadata for both the current and next chunk was available — this is
+    /// the case for `Historical` and `Physics` paths, never for `Legacy` or
+    /// `StartConstant`.
+    pub physics_breakdown: Option<PhysicsBreakdown>,
+    /// `ChunkCharacteristics` bucket key used by the estimator's lookup —
+    /// `Some` for `Historical` / `Physics` paths, `None` for `Legacy` /
+    /// `StartConstant`. Lets diagnostics display the same key the lookup
+    /// hit (or missed) without re-deriving it from the chunk identifier.
+    pub bucket: Option<ChunkCharacteristics>,
+}
 
 /// Attempts to estimate the time at which the next chunk will be available given the previous
 /// chunk. Requires an [ElevationChunkMapper] to describe the relationship between chunk sequence
@@ -38,16 +89,42 @@ pub fn estimate_chunk_processing_time(
     elevation_chunk_mapper: &ElevationChunkMapper,
     timing_stats: Option<&ChunkTimingStats>,
 ) -> Option<ChronoDuration> {
+    estimate_chunk_processing_diagnostics(chunk, vcp, elevation_chunk_mapper, timing_stats)
+        .map(|e| e.duration)
+}
+
+/// Like [`estimate_chunk_processing_time`] but exposes which estimator path
+/// was taken, the bucket sample count at prediction time, and (when applicable)
+/// the physics-term decomposition. Used by the diagnostics modal to attribute
+/// prediction errors to a specific component.
+pub fn estimate_chunk_processing_diagnostics(
+    chunk: &ChunkIdentifier,
+    vcp: &volume_coverage_pattern::Message,
+    elevation_chunk_mapper: &ElevationChunkMapper,
+    timing_stats: Option<&ChunkTimingStats>,
+) -> Option<EstimatedChunkProcessing> {
     // Start chunks: the next chunk is the first intermediate within the same volume,
     // which follows the Start chunk by only a few seconds (not the full inter-volume gap).
     if chunk.chunk_type() == ChunkType::Start {
         let gap_ms = (ChunkTimingModel::start_to_first_intermediate_gap_secs() * 1000.0) as i64;
-        return Some(ChronoDuration::milliseconds(gap_ms));
+        return Some(EstimatedChunkProcessing {
+            duration: ChronoDuration::milliseconds(gap_ms),
+            path: SchedulerPath::StartConstant,
+            stats_n_at_prediction: 0,
+            physics_breakdown: None,
+            bucket: None,
+        });
     }
 
     // Try to use the physics-based model via chunk metadata
     if let Some(next_metadata) = elevation_chunk_mapper.get_chunk_metadata(chunk.sequence() + 1) {
         let current_metadata = elevation_chunk_mapper.get_chunk_metadata(chunk.sequence());
+
+        // Compute the physics breakdown up-front so we can attach it to either
+        // the historical or physics path. The breakdown is purely descriptive;
+        // the historical path's wait time is unchanged.
+        let physics_breakdown = current_metadata
+            .map(|c| ChunkTimingModel::estimate_chunk_interval_breakdown(c, next_metadata));
 
         // Check for historical timing data first.
         //
@@ -68,6 +145,8 @@ pub fn estimate_chunk_processing_time(
                 is_first_in_sweep: next_metadata.is_first_in_sweep(),
             };
 
+            let stats_n_at_prediction =
+                timing_stats.map_or(0, |s| s.sample_count(&characteristics));
             let average_timing =
                 timing_stats.and_then(|stats| stats.get_average_timing(&characteristics));
             let average_attempts =
@@ -84,15 +163,31 @@ pub fn estimate_chunk_processing_time(
                     wait_time.num_milliseconds()
                 );
 
-                return Some(wait_time);
+                return Some(EstimatedChunkProcessing {
+                    duration: wait_time,
+                    path: SchedulerPath::Historical,
+                    stats_n_at_prediction,
+                    physics_breakdown,
+                    bucket: Some(characteristics),
+                });
             }
         }
 
-        // Fall back to physics-based model
-        if let Some(current) = current_metadata {
-            let interval_secs =
-                ChunkTimingModel::estimate_chunk_interval_secs(current, next_metadata);
-            let interval_ms = (interval_secs * 1000.0) as i64;
+        // Fall back to physics-based model. When we got here the bucket
+        // lookup either failed (no elevation) or had no samples — record
+        // whichever bucket we actually probed (if any) so diagnostics can
+        // still show why the fallback fired.
+        let probed_bucket = next_metadata
+            .elevation_number()
+            .and_then(|elevation_number| vcp.elevations().get(elevation_number - 1))
+            .map(|elevation| ChunkCharacteristics {
+                chunk_type: ChunkType::Intermediate,
+                waveform_type: elevation.waveform_type(),
+                channel_configuration: elevation.channel_configuration(),
+                is_first_in_sweep: next_metadata.is_first_in_sweep(),
+            });
+        if let Some(breakdown) = physics_breakdown {
+            let interval_ms = (breakdown.total_secs * 1000.0) as i64;
 
             debug!(
                 "Using physics model: interval={}ms (az_rate={:.1} dps, first_in_sweep={})",
@@ -101,7 +196,13 @@ pub fn estimate_chunk_processing_time(
                 next_metadata.is_first_in_sweep()
             );
 
-            return Some(ChronoDuration::milliseconds(interval_ms));
+            return Some(EstimatedChunkProcessing {
+                duration: ChronoDuration::milliseconds(interval_ms),
+                path: SchedulerPath::Physics,
+                stats_n_at_prediction: 0,
+                physics_breakdown: Some(breakdown),
+                bucket: probed_bucket,
+            });
         }
     }
 
@@ -120,7 +221,13 @@ pub fn estimate_chunk_processing_time(
             wait_time.num_milliseconds()
         );
 
-        return Some(wait_time);
+        return Some(EstimatedChunkProcessing {
+            duration: wait_time,
+            path: SchedulerPath::Legacy,
+            stats_n_at_prediction: 0,
+            physics_breakdown: None,
+            bucket: None,
+        });
     }
 
     None

--- a/src/nexrad/timing/estimate_next_chunk_time.rs
+++ b/src/nexrad/timing/estimate_next_chunk_time.rs
@@ -49,7 +49,12 @@ pub fn estimate_chunk_processing_time(
     if let Some(next_metadata) = elevation_chunk_mapper.get_chunk_metadata(chunk.sequence() + 1) {
         let current_metadata = elevation_chunk_mapper.get_chunk_metadata(chunk.sequence());
 
-        // Check for historical timing data first
+        // Check for historical timing data first.
+        //
+        // Note: the other fields key on the anchor chunk's elevation (pre-existing
+        // upstream convention), but `is_first_in_sweep` describes the *arriving*
+        // chunk — matching how samples are written in `StreamingState::update_timing_stats`.
+        // This keeps inter-sweep-transition samples out of the intra-sweep bucket.
         if let Some(elevation) = elevation_chunk_mapper
             .get_sequence_elevation_number(chunk.sequence())
             .and_then(|elevation_number| vcp.elevations().get(elevation_number - 1))
@@ -58,6 +63,7 @@ pub fn estimate_chunk_processing_time(
                 chunk_type: chunk.chunk_type(),
                 waveform_type: elevation.waveform_type(),
                 channel_configuration: elevation.channel_configuration(),
+                is_first_in_sweep: next_metadata.is_first_in_sweep(),
             };
 
             let average_timing =

--- a/src/nexrad/timing/estimate_next_chunk_time.rs
+++ b/src/nexrad/timing/estimate_next_chunk_time.rs
@@ -1,0 +1,136 @@
+use super::{ChunkCharacteristics, ChunkTimingModel, ChunkTimingStats, ElevationChunkMapper};
+use chrono::Duration as ChronoDuration;
+use chrono::{DateTime, Utc};
+use log::debug;
+use nexrad_data::aws::realtime::{ChunkIdentifier, ChunkType};
+use nexrad_decode::messages::volume_coverage_pattern;
+
+/// Attempts to estimate the time at which the next chunk will be available given the previous
+/// chunk. Requires an [ElevationChunkMapper] to describe the relationship between chunk sequence
+/// and VCP elevations. A None result indicates that the chunk is already available or that an
+/// estimate cannot be made.
+///
+/// The estimate is anchored to the previous chunk's upload time rather than the current time,
+/// so querying late will correctly yield a past time (indicating the chunk should already be
+/// available) rather than pushing the estimate forward.
+pub fn estimate_chunk_availability_time(
+    chunk: &ChunkIdentifier,
+    vcp: &volume_coverage_pattern::Message,
+    elevation_chunk_mapper: &ElevationChunkMapper,
+    timing_stats: Option<&ChunkTimingStats>,
+) -> Option<DateTime<Utc>> {
+    let processing_time =
+        estimate_chunk_processing_time(chunk, vcp, elevation_chunk_mapper, timing_stats)?;
+
+    let anchor = chunk.upload_date_time().unwrap_or_else(Utc::now);
+    let availability_time = anchor + processing_time;
+
+    Some(availability_time)
+}
+
+/// Attempts to estimate the time the given chunk will take to become available in the real-time S3
+/// bucket following the previous chunk. Requires an [ElevationChunkMapper] to describe the
+/// relationship between chunk sequence and VCP elevations. A None result indicates that an estimate
+/// cannot be made.
+pub fn estimate_chunk_processing_time(
+    chunk: &ChunkIdentifier,
+    vcp: &volume_coverage_pattern::Message,
+    elevation_chunk_mapper: &ElevationChunkMapper,
+    timing_stats: Option<&ChunkTimingStats>,
+) -> Option<ChronoDuration> {
+    // Start chunks: use the inter-volume gap model
+    if chunk.chunk_type() == ChunkType::Start {
+        let gap_ms = (ChunkTimingModel::inter_volume_gap_secs() * 1000.0) as i64;
+        return Some(ChronoDuration::milliseconds(gap_ms));
+    }
+
+    // Try to use the physics-based model via chunk metadata
+    if let Some(next_metadata) = elevation_chunk_mapper.get_chunk_metadata(chunk.sequence() + 1) {
+        let current_metadata = elevation_chunk_mapper.get_chunk_metadata(chunk.sequence());
+
+        // Check for historical timing data first
+        if let Some(elevation) = elevation_chunk_mapper
+            .get_sequence_elevation_number(chunk.sequence())
+            .and_then(|elevation_number| vcp.elevations().get(elevation_number - 1))
+        {
+            let characteristics = ChunkCharacteristics {
+                chunk_type: chunk.chunk_type(),
+                waveform_type: elevation.waveform_type(),
+                channel_configuration: elevation.channel_configuration(),
+            };
+
+            let average_timing =
+                timing_stats.and_then(|stats| stats.get_average_timing(&characteristics));
+            let average_attempts =
+                timing_stats.and_then(|stats| stats.get_average_attempts(&characteristics));
+
+            if let (Some(avg_timing), Some(avg_attempts)) = (average_timing, average_attempts) {
+                let mut wait_time = avg_timing;
+                wait_time += chrono::Duration::seconds(avg_attempts as i64 - 1);
+
+                debug!(
+                    "Using historical average timing of {}ms and {} attempts for {}ms",
+                    avg_timing.num_milliseconds(),
+                    avg_attempts,
+                    wait_time.num_milliseconds()
+                );
+
+                return Some(wait_time);
+            }
+        }
+
+        // Fall back to physics-based model
+        if let Some(current) = current_metadata {
+            let interval_secs =
+                ChunkTimingModel::estimate_chunk_interval_secs(current, next_metadata);
+            let interval_ms = (interval_secs * 1000.0) as i64;
+
+            debug!(
+                "Using physics model: interval={}ms (az_rate={:.1} dps, first_in_sweep={})",
+                interval_ms,
+                next_metadata.azimuth_rate_dps(),
+                next_metadata.is_first_in_sweep()
+            );
+
+            return Some(ChronoDuration::milliseconds(interval_ms));
+        }
+    }
+
+    // Final fallback: use old static estimation for edge cases where metadata is unavailable
+    if let Some(elevation) = elevation_chunk_mapper
+        .get_sequence_elevation_number(chunk.sequence())
+        .and_then(|elevation_number| vcp.elevations().get(elevation_number - 1))
+    {
+        let wait_time = get_legacy_default_wait_time(
+            elevation.waveform_type(),
+            elevation.channel_configuration(),
+        );
+
+        debug!(
+            "No metadata available, using legacy static estimation of {}ms",
+            wait_time.num_milliseconds()
+        );
+
+        return Some(wait_time);
+    }
+
+    None
+}
+
+/// Legacy default wait time based on waveform type and channel configuration.
+///
+/// Only used as a last resort when chunk metadata is unavailable (should be rare).
+fn get_legacy_default_wait_time(
+    waveform_type: nexrad_decode::messages::volume_coverage_pattern::WaveformType,
+    channel_config: nexrad_decode::messages::volume_coverage_pattern::ChannelConfiguration,
+) -> ChronoDuration {
+    use nexrad_decode::messages::volume_coverage_pattern::{ChannelConfiguration, WaveformType};
+
+    if waveform_type == WaveformType::CS {
+        ChronoDuration::seconds(11)
+    } else if channel_config == ChannelConfiguration::ConstantPhase {
+        ChronoDuration::seconds(7)
+    } else {
+        ChronoDuration::seconds(4)
+    }
+}

--- a/src/nexrad/timing/estimate_next_chunk_time.rs
+++ b/src/nexrad/timing/estimate_next_chunk_time.rs
@@ -51,16 +51,18 @@ pub fn estimate_chunk_processing_time(
 
         // Check for historical timing data first.
         //
-        // Note: the other fields key on the anchor chunk's elevation (pre-existing
-        // upstream convention), but `is_first_in_sweep` describes the *arriving*
-        // chunk — matching how samples are written in `StreamingState::update_timing_stats`.
-        // This keeps inter-sweep-transition samples out of the intra-sweep bucket.
-        if let Some(elevation) = elevation_chunk_mapper
-            .get_sequence_elevation_number(chunk.sequence())
+        // Key this lookup on the *arriving* chunk's (next_metadata) characteristics
+        // rather than the anchor's. Writes in `StreamingState::update_timing_stats`
+        // record each chunk's arrival duration under the arriving chunk's elevation,
+        // so reading under the anchor's elevation looks up the wrong bucket and
+        // silently falls back to pure physics. This cost us ~30% of the effective
+        // shift from the physics penalties on sweep transitions.
+        if let Some(elevation) = next_metadata
+            .elevation_number()
             .and_then(|elevation_number| vcp.elevations().get(elevation_number - 1))
         {
             let characteristics = ChunkCharacteristics {
-                chunk_type: chunk.chunk_type(),
+                chunk_type: ChunkType::Intermediate,
                 waveform_type: elevation.waveform_type(),
                 channel_configuration: elevation.channel_configuration(),
                 is_first_in_sweep: next_metadata.is_first_in_sweep(),

--- a/src/nexrad/timing/mod.rs
+++ b/src/nexrad/timing/mod.rs
@@ -25,12 +25,14 @@ mod elevation_chunk_mapper;
 mod estimate_next_chunk_time;
 mod scan_timing_projection;
 
-pub use chunk_timing_model::ChunkTimingModel;
-pub use chunk_timing_stats::{ChunkCharacteristics, ChunkTimingStats};
+pub use chunk_timing_model::{ChunkTimingModel, IntervalCase, PhysicsBreakdown};
+pub use chunk_timing_stats::{BucketStats, ChunkCharacteristics, ChunkTimingStats};
 pub use elevation_chunk_mapper::{ChunkMetadata, ElevationChunkMapper};
 pub use estimate_next_chunk_time::{
-    estimate_chunk_availability_time, estimate_chunk_processing_time,
+    estimate_chunk_availability_time, estimate_chunk_processing_diagnostics,
+    estimate_chunk_processing_time, EstimatedChunkProcessing, SchedulerPath,
 };
 pub use scan_timing_projection::{
-    project_full_scan_timing, project_scan_timing, ChunkProjection, ScanTimingProjection,
+    project_full_scan_timing, project_scan_timing, AnchorSource, ChunkProjection,
+    ScanTimingProjection,
 };

--- a/src/nexrad/timing/mod.rs
+++ b/src/nexrad/timing/mod.rs
@@ -1,0 +1,36 @@
+// Parts of the forked surface (e.g. `project_full_scan_timing`, the `ChunkProjection`
+// accessors, `ChunkTimingStats::get_statistics`) aren't currently wired into this
+// crate but are kept intact to preserve the upstream shape for easy diffing and
+// eventual contribution back to `nexrad-data`.
+#![allow(dead_code, unused_imports)]
+
+//! Local fork of the real-time chunk timing prediction logic from
+//! `nexrad_data::aws::realtime`. Kept here so we can iterate on the physics
+//! model, statistics blending, and projection shape without cutting a new
+//! `nexrad-data` release each time. Intended to be contributed back upstream
+//! once stabilised.
+//!
+//! Public surface mirrors the upstream module: `estimate_chunk_availability_time`,
+//! `project_scan_timing`, `project_full_scan_timing`, `ChunkTimingStats`,
+//! `ChunkCharacteristics`, `ElevationChunkMapper`, `ChunkMetadata`,
+//! `ChunkTimingModel`, `ScanTimingProjection`, `ChunkProjection`.
+//!
+//! Types that are NOT forked (still sourced from `nexrad_data::aws::realtime`):
+//! `ChunkIdentifier`, `ChunkType`, `VolumeIndex` — these are plumbing types
+//! used by the forked code but aren't part of the timing logic itself.
+
+mod chunk_timing_model;
+mod chunk_timing_stats;
+mod elevation_chunk_mapper;
+mod estimate_next_chunk_time;
+mod scan_timing_projection;
+
+pub use chunk_timing_model::ChunkTimingModel;
+pub use chunk_timing_stats::{ChunkCharacteristics, ChunkTimingStats};
+pub use elevation_chunk_mapper::{ChunkMetadata, ElevationChunkMapper};
+pub use estimate_next_chunk_time::{
+    estimate_chunk_availability_time, estimate_chunk_processing_time,
+};
+pub use scan_timing_projection::{
+    project_full_scan_timing, project_scan_timing, ChunkProjection, ScanTimingProjection,
+};

--- a/src/nexrad/timing/scan_timing_projection.rs
+++ b/src/nexrad/timing/scan_timing_projection.rs
@@ -12,12 +12,15 @@ use nexrad_decode::messages::volume_coverage_pattern;
 pub struct ScanTimingProjection {
     /// The sequence number of the anchor chunk (the last observed chunk).
     anchor_sequence: usize,
-    /// The anchor time (upload time of the anchor chunk, or current time).
-    anchor_time: DateTime<Utc>,
+    /// AVAILABILITY category: S3-upload time of the anchor chunk (or current
+    /// time as a fallback). Used as the base for projecting future chunks'
+    /// availability.
+    anchor_available_at: DateTime<Utc>,
     /// Projected timing for each future chunk, in sequence order.
     chunks: Vec<ChunkProjection>,
-    /// Projected time when the final chunk becomes available.
-    volume_end_time: DateTime<Utc>,
+    /// AVAILABILITY category: projected time the final chunk becomes
+    /// available in S3.
+    volume_end_available_at: DateTime<Utc>,
     /// Projected total remaining duration from anchor to volume end.
     remaining_duration: Duration,
 }
@@ -28,9 +31,11 @@ impl ScanTimingProjection {
         self.anchor_sequence
     }
 
-    /// The anchor time this projection is relative to.
-    pub fn anchor_time(&self) -> DateTime<Utc> {
-        self.anchor_time
+    /// AVAILABILITY category: the S3-upload time of the anchor chunk (or
+    /// current time as a fallback). Physics intervals added to this yield
+    /// projected availability times for future chunks.
+    pub fn anchor_available_at(&self) -> DateTime<Utc> {
+        self.anchor_available_at
     }
 
     /// Projected timing for each future chunk, in sequence order.
@@ -38,9 +43,10 @@ impl ScanTimingProjection {
         &self.chunks
     }
 
-    /// Projected time when the final chunk becomes available.
-    pub fn volume_end_time(&self) -> DateTime<Utc> {
-        self.volume_end_time
+    /// AVAILABILITY category: projected time the final chunk becomes
+    /// available in S3.
+    pub fn volume_end_available_at(&self) -> DateTime<Utc> {
+        self.volume_end_available_at
     }
 
     /// Projected remaining duration from anchor to volume end.
@@ -58,8 +64,9 @@ pub struct ChunkProjection {
     elevation_number: Option<usize>,
     /// Elevation angle in degrees (0.0 for the Start chunk).
     elevation_angle_deg: f64,
-    /// Projected time this chunk becomes available in S3.
-    projected_time: DateTime<Utc>,
+    /// AVAILABILITY category: projected time this chunk becomes available
+    /// in S3. Drives the download scheduler and "next in Xs" UI language.
+    projected_available_at: DateTime<Utc>,
     /// Duration from the anchor to this chunk's projected availability.
     offset_from_anchor: Duration,
     /// Duration from the previous chunk to this chunk.
@@ -84,9 +91,10 @@ impl ChunkProjection {
         self.elevation_angle_deg
     }
 
-    /// Projected time this chunk becomes available in S3.
-    pub fn projected_time(&self) -> DateTime<Utc> {
-        self.projected_time
+    /// AVAILABILITY category: projected time this chunk becomes available
+    /// in S3.
+    pub fn projected_available_at(&self) -> DateTime<Utc> {
+        self.projected_available_at
     }
 
     /// Duration from the anchor to this chunk's projected availability.
@@ -121,7 +129,7 @@ pub fn project_scan_timing(
     timing_stats: Option<&ChunkTimingStats>,
 ) -> Option<ScanTimingProjection> {
     let anchor_sequence = anchor_chunk.sequence();
-    let anchor_time = anchor_chunk.upload_date_time().unwrap_or_else(Utc::now);
+    let anchor_available_at = anchor_chunk.upload_date_time().unwrap_or_else(Utc::now);
     let final_sequence = mapper.final_sequence();
 
     // Nothing to project if we're at or past the final chunk
@@ -167,13 +175,13 @@ pub fn project_scan_timing(
 
         let interval_duration = Duration::milliseconds(interval_ms);
         let offset_duration = Duration::milliseconds(cumulative_offset_ms);
-        let projected_time = anchor_time + offset_duration;
+        let projected_available_at = anchor_available_at + offset_duration;
 
         projections.push(ChunkProjection {
             sequence: seq,
             elevation_number: next_metadata.elevation_number(),
             elevation_angle_deg: next_metadata.elevation_angle_deg(),
-            projected_time,
+            projected_available_at,
             offset_from_anchor: offset_duration,
             interval_from_previous: interval_duration,
             starts_new_sweep: next_metadata.is_first_in_sweep(),
@@ -182,17 +190,17 @@ pub fn project_scan_timing(
         prev_metadata = next_metadata;
     }
 
-    let volume_end_time = projections
+    let volume_end_available_at = projections
         .last()
-        .map(|p| p.projected_time)
-        .unwrap_or(anchor_time);
+        .map(|p| p.projected_available_at)
+        .unwrap_or(anchor_available_at);
     let remaining_duration = Duration::milliseconds(cumulative_offset_ms);
 
     Some(ScanTimingProjection {
         anchor_sequence,
-        anchor_time,
+        anchor_available_at,
         chunks: projections,
-        volume_end_time,
+        volume_end_available_at,
         remaining_duration,
     })
 }

--- a/src/nexrad/timing/scan_timing_projection.rs
+++ b/src/nexrad/timing/scan_timing_projection.rs
@@ -5,9 +5,12 @@ use nexrad_decode::messages::volume_coverage_pattern;
 
 /// A projected timeline for all remaining chunks in a volume scan.
 ///
-/// Built from the VCP's azimuth rates and elevation angles using a physics-based model,
-/// optionally refined with historical timing observations. This enables UIs to show
-/// projected timelines for the entire remaining scan, not just the next chunk.
+/// Carries two parallel time axes for each chunk:
+///   - ACTUAL + physics → projected COLLECTION time (when the radar emits/receives).
+///   - Collection + lag → projected AVAILABILITY time (when the chunk appears on S3).
+///
+/// The collection axis anchors on the parsed volume header time when the caller
+/// supplies one; otherwise it falls back to a lag-adjusted S3 upload time.
 #[derive(Debug, Clone)]
 pub struct ScanTimingProjection {
     /// The sequence number of the anchor chunk (the last observed chunk).
@@ -16,6 +19,14 @@ pub struct ScanTimingProjection {
     /// time as a fallback). Used as the base for projecting future chunks'
     /// availability.
     anchor_available_at: DateTime<Utc>,
+    /// COLLECTION category: parsed radial-header collection time of the
+    /// current volume when available, else `anchor_available_at -
+    /// observed_anchor_lag_secs` as an estimate.
+    anchor_collection_time_secs: f64,
+    /// AVAILABILITY-lag category: empirical delay between ACTUAL collection
+    /// time of the anchor and its S3 upload time. `None` when the header
+    /// time is unavailable (falls back to `DEFAULT_AVAILABILITY_LAG_SECS`).
+    observed_anchor_lag_secs: Option<f64>,
     /// Projected timing for each future chunk, in sequence order.
     chunks: Vec<ChunkProjection>,
     /// AVAILABILITY category: projected time the final chunk becomes
@@ -24,6 +35,12 @@ pub struct ScanTimingProjection {
     /// Projected total remaining duration from anchor to volume end.
     remaining_duration: Duration,
 }
+
+/// Fallback NEXRAD ingest lag (Unix seconds) used when we have no observed
+/// anchor lag yet. Chosen to roughly match typical S3 upload latencies
+/// observed during live streaming (~5-15 s). A later commit replaces this
+/// with a median from the split `ChunkTimingStats`.
+const DEFAULT_AVAILABILITY_LAG_SECS: f64 = 5.0;
 
 impl ScanTimingProjection {
     /// The sequence number of the anchor chunk this projection is relative to.
@@ -36,6 +53,22 @@ impl ScanTimingProjection {
     /// projected availability times for future chunks.
     pub fn anchor_available_at(&self) -> DateTime<Utc> {
         self.anchor_available_at
+    }
+
+    /// COLLECTION category: Unix-seconds collection time of the anchor
+    /// chunk — parsed from a radial header when available, otherwise
+    /// estimated as `anchor_available_at - observed_anchor_lag`.
+    #[allow(dead_code)] // Consumed by debug UI in a later commit.
+    pub fn anchor_collection_time_secs(&self) -> f64 {
+        self.anchor_collection_time_secs
+    }
+
+    /// AVAILABILITY-lag category: observed anchor lag, if the caller
+    /// provided an ACTUAL collection anchor. `None` signals the default
+    /// fallback lag was used and projections carry more uncertainty.
+    #[allow(dead_code)] // Consumed by debug UI in a later commit.
+    pub fn observed_anchor_lag_secs(&self) -> Option<f64> {
+        self.observed_anchor_lag_secs
     }
 
     /// Projected timing for each future chunk, in sequence order.
@@ -64,6 +97,10 @@ pub struct ChunkProjection {
     elevation_number: Option<usize>,
     /// Elevation angle in degrees (0.0 for the Start chunk).
     elevation_angle_deg: f64,
+    /// COLLECTION category: projected Unix-seconds time the radar physically
+    /// emits/receives for this chunk. Drives timeline placeholders for
+    /// future sweeps and chunks.
+    projected_collection_time_secs: f64,
     /// AVAILABILITY category: projected time this chunk becomes available
     /// in S3. Drives the download scheduler and "next in Xs" UI language.
     projected_available_at: DateTime<Utc>,
@@ -97,6 +134,12 @@ impl ChunkProjection {
         self.projected_available_at
     }
 
+    /// COLLECTION category: projected Unix-seconds time the radar physically
+    /// emits/receives for this chunk.
+    pub fn projected_collection_time_secs(&self) -> f64 {
+        self.projected_collection_time_secs
+    }
+
     /// Duration from the anchor to this chunk's projected availability.
     pub fn offset_from_anchor(&self) -> Duration {
         self.offset_from_anchor
@@ -116,20 +159,27 @@ impl ChunkProjection {
 /// Build a timing projection for all remaining chunks in the current volume.
 ///
 /// The projection starts from `anchor_chunk` (the most recently observed chunk) and
-/// projects forward through the final chunk in the volume. Each chunk's projected
-/// availability time is computed using the VCP's azimuth rates, elevation angles,
-/// and optionally historical timing data.
+/// projects forward through the final chunk in the volume. Each chunk carries both a
+/// projected COLLECTION time (ACTUAL collection anchor + physics intervals) and a
+/// projected AVAILABILITY time (COLLECTION + empirical ingest lag).
+///
+/// When `anchor_collection_time_secs` is `Some`, projections are anchored in real
+/// collection time and availability uses the observed anchor lag. Otherwise the
+/// function falls back to anchoring on `anchor_chunk.upload_date_time()` with a
+/// default lag estimate, which keeps behavior identical to the pre-split model.
 ///
 /// Returns `None` if the anchor chunk's metadata cannot be resolved or if there are
 /// no remaining chunks to project.
 pub fn project_scan_timing(
     anchor_chunk: &ChunkIdentifier,
+    anchor_collection_time_secs: Option<f64>,
     _vcp: &volume_coverage_pattern::Message,
     mapper: &ElevationChunkMapper,
     timing_stats: Option<&ChunkTimingStats>,
 ) -> Option<ScanTimingProjection> {
     let anchor_sequence = anchor_chunk.sequence();
     let anchor_available_at = anchor_chunk.upload_date_time().unwrap_or_else(Utc::now);
+    let anchor_available_at_secs = anchor_available_at.timestamp_millis() as f64 / 1000.0;
     let final_sequence = mapper.final_sequence();
 
     // Nothing to project if we're at or past the final chunk
@@ -138,6 +188,24 @@ pub fn project_scan_timing(
     }
 
     let anchor_metadata = mapper.get_chunk_metadata(anchor_sequence)?;
+
+    // Split anchor into collection + lag. When the caller knows the ACTUAL
+    // volume header collection time, use it and derive the empirical lag as
+    // upload − collection. Otherwise fall back to a default lag (collection
+    // estimated as upload − default_lag) so behavior matches the pre-split
+    // availability projection.
+    let (anchor_collection_secs, observed_lag_secs, availability_lag_secs) =
+        match anchor_collection_time_secs {
+            Some(collection_secs) => {
+                let lag = anchor_available_at_secs - collection_secs;
+                (collection_secs, Some(lag), lag)
+            }
+            None => (
+                anchor_available_at_secs - DEFAULT_AVAILABILITY_LAG_SECS,
+                None,
+                DEFAULT_AVAILABILITY_LAG_SECS,
+            ),
+        };
 
     let mut projections = Vec::new();
     let mut cumulative_offset_ms: i64 = 0;
@@ -175,12 +243,19 @@ pub fn project_scan_timing(
 
         let interval_duration = Duration::milliseconds(interval_ms);
         let offset_duration = Duration::milliseconds(cumulative_offset_ms);
-        let projected_available_at = anchor_available_at + offset_duration;
+        let offset_secs = cumulative_offset_ms as f64 / 1000.0;
+
+        let projected_collection_time_secs = anchor_collection_secs + offset_secs;
+        let projected_available_at_secs = projected_collection_time_secs + availability_lag_secs;
+        let projected_available_at =
+            DateTime::<Utc>::from_timestamp_millis((projected_available_at_secs * 1000.0) as i64)
+                .unwrap_or(anchor_available_at);
 
         projections.push(ChunkProjection {
             sequence: seq,
             elevation_number: next_metadata.elevation_number(),
             elevation_angle_deg: next_metadata.elevation_angle_deg(),
+            projected_collection_time_secs,
             projected_available_at,
             offset_from_anchor: offset_duration,
             interval_from_previous: interval_duration,
@@ -199,6 +274,8 @@ pub fn project_scan_timing(
     Some(ScanTimingProjection {
         anchor_sequence,
         anchor_available_at,
+        anchor_collection_time_secs: anchor_collection_secs,
+        observed_anchor_lag_secs: observed_lag_secs,
         chunks: projections,
         volume_end_available_at,
         remaining_duration,
@@ -228,5 +305,5 @@ pub fn project_full_scan_timing(
         Some(start_time),
     );
 
-    project_scan_timing(&start_chunk, vcp, mapper, timing_stats)
+    project_scan_timing(&start_chunk, None, vcp, mapper, timing_stats)
 }

--- a/src/nexrad/timing/scan_timing_projection.rs
+++ b/src/nexrad/timing/scan_timing_projection.rs
@@ -191,20 +191,20 @@ pub fn project_scan_timing(
 
     // Split anchor into collection + lag. When the caller knows the ACTUAL
     // volume header collection time, use it and derive the empirical lag as
-    // upload − collection. Otherwise fall back to a default lag (collection
-    // estimated as upload − default_lag) so behavior matches the pre-split
-    // availability projection.
+    // upload − collection. Otherwise fall back to a lag estimate: prefer the
+    // median lag observed in `ChunkTimingStats`, else a static default.
     let (anchor_collection_secs, observed_lag_secs, availability_lag_secs) =
         match anchor_collection_time_secs {
             Some(collection_secs) => {
                 let lag = anchor_available_at_secs - collection_secs;
                 (collection_secs, Some(lag), lag)
             }
-            None => (
-                anchor_available_at_secs - DEFAULT_AVAILABILITY_LAG_SECS,
-                None,
-                DEFAULT_AVAILABILITY_LAG_SECS,
-            ),
+            None => {
+                let fallback_lag = timing_stats
+                    .and_then(|s| s.median_availability_lag_secs())
+                    .unwrap_or(DEFAULT_AVAILABILITY_LAG_SECS);
+                (anchor_available_at_secs - fallback_lag, None, fallback_lag)
+            }
         };
 
     let mut projections = Vec::new();

--- a/src/nexrad/timing/scan_timing_projection.rs
+++ b/src/nexrad/timing/scan_timing_projection.rs
@@ -150,6 +150,7 @@ pub fn project_scan_timing(
                         chunk_type: ChunkType::Intermediate,
                         waveform_type: elev_data.waveform_type(),
                         channel_configuration: elev_data.channel_configuration(),
+                        is_first_in_sweep: next_metadata.is_first_in_sweep(),
                     };
 
                     if let Some(avg_timing) = stats.get_average_timing(&characteristics) {

--- a/src/nexrad/timing/scan_timing_projection.rs
+++ b/src/nexrad/timing/scan_timing_projection.rs
@@ -1,0 +1,223 @@
+use super::{ChunkCharacteristics, ChunkTimingModel, ChunkTimingStats, ElevationChunkMapper};
+use chrono::{DateTime, Duration, Utc};
+use nexrad_data::aws::realtime::{ChunkIdentifier, ChunkType, VolumeIndex};
+use nexrad_decode::messages::volume_coverage_pattern;
+
+/// A projected timeline for all remaining chunks in a volume scan.
+///
+/// Built from the VCP's azimuth rates and elevation angles using a physics-based model,
+/// optionally refined with historical timing observations. This enables UIs to show
+/// projected timelines for the entire remaining scan, not just the next chunk.
+#[derive(Debug, Clone)]
+pub struct ScanTimingProjection {
+    /// The sequence number of the anchor chunk (the last observed chunk).
+    anchor_sequence: usize,
+    /// The anchor time (upload time of the anchor chunk, or current time).
+    anchor_time: DateTime<Utc>,
+    /// Projected timing for each future chunk, in sequence order.
+    chunks: Vec<ChunkProjection>,
+    /// Projected time when the final chunk becomes available.
+    volume_end_time: DateTime<Utc>,
+    /// Projected total remaining duration from anchor to volume end.
+    remaining_duration: Duration,
+}
+
+impl ScanTimingProjection {
+    /// The sequence number of the anchor chunk this projection is relative to.
+    pub fn anchor_sequence(&self) -> usize {
+        self.anchor_sequence
+    }
+
+    /// The anchor time this projection is relative to.
+    pub fn anchor_time(&self) -> DateTime<Utc> {
+        self.anchor_time
+    }
+
+    /// Projected timing for each future chunk, in sequence order.
+    pub fn chunks(&self) -> &[ChunkProjection] {
+        &self.chunks
+    }
+
+    /// Projected time when the final chunk becomes available.
+    pub fn volume_end_time(&self) -> DateTime<Utc> {
+        self.volume_end_time
+    }
+
+    /// Projected remaining duration from anchor to volume end.
+    pub fn remaining_duration(&self) -> Duration {
+        self.remaining_duration
+    }
+}
+
+/// Projection for a single future chunk.
+#[derive(Debug, Clone)]
+pub struct ChunkProjection {
+    /// The chunk's sequence number.
+    sequence: usize,
+    /// The elevation number (1-based), or None for the Start chunk.
+    elevation_number: Option<usize>,
+    /// Elevation angle in degrees (0.0 for the Start chunk).
+    elevation_angle_deg: f64,
+    /// Projected time this chunk becomes available in S3.
+    projected_time: DateTime<Utc>,
+    /// Duration from the anchor to this chunk's projected availability.
+    offset_from_anchor: Duration,
+    /// Duration from the previous chunk to this chunk.
+    interval_from_previous: Duration,
+    /// Whether this chunk starts a new sweep (useful for UI grouping).
+    starts_new_sweep: bool,
+}
+
+impl ChunkProjection {
+    /// The chunk's sequence number.
+    pub fn sequence(&self) -> usize {
+        self.sequence
+    }
+
+    /// The elevation number (1-based), or None for the Start chunk.
+    pub fn elevation_number(&self) -> Option<usize> {
+        self.elevation_number
+    }
+
+    /// Elevation angle in degrees.
+    pub fn elevation_angle_deg(&self) -> f64 {
+        self.elevation_angle_deg
+    }
+
+    /// Projected time this chunk becomes available in S3.
+    pub fn projected_time(&self) -> DateTime<Utc> {
+        self.projected_time
+    }
+
+    /// Duration from the anchor to this chunk's projected availability.
+    pub fn offset_from_anchor(&self) -> Duration {
+        self.offset_from_anchor
+    }
+
+    /// Duration from the previous chunk to this chunk.
+    pub fn interval_from_previous(&self) -> Duration {
+        self.interval_from_previous
+    }
+
+    /// Whether this chunk starts a new sweep.
+    pub fn starts_new_sweep(&self) -> bool {
+        self.starts_new_sweep
+    }
+}
+
+/// Build a timing projection for all remaining chunks in the current volume.
+///
+/// The projection starts from `anchor_chunk` (the most recently observed chunk) and
+/// projects forward through the final chunk in the volume. Each chunk's projected
+/// availability time is computed using the VCP's azimuth rates, elevation angles,
+/// and optionally historical timing data.
+///
+/// Returns `None` if the anchor chunk's metadata cannot be resolved or if there are
+/// no remaining chunks to project.
+pub fn project_scan_timing(
+    anchor_chunk: &ChunkIdentifier,
+    _vcp: &volume_coverage_pattern::Message,
+    mapper: &ElevationChunkMapper,
+    timing_stats: Option<&ChunkTimingStats>,
+) -> Option<ScanTimingProjection> {
+    let anchor_sequence = anchor_chunk.sequence();
+    let anchor_time = anchor_chunk.upload_date_time().unwrap_or_else(Utc::now);
+    let final_sequence = mapper.final_sequence();
+
+    // Nothing to project if we're at or past the final chunk
+    if anchor_sequence >= final_sequence {
+        return None;
+    }
+
+    let anchor_metadata = mapper.get_chunk_metadata(anchor_sequence)?;
+
+    let mut projections = Vec::new();
+    let mut cumulative_offset_ms: i64 = 0;
+    let mut prev_metadata = anchor_metadata;
+
+    for seq in (anchor_sequence + 1)..=final_sequence {
+        let next_metadata = mapper.get_chunk_metadata(seq)?;
+
+        // Compute interval using physics model
+        let mut interval_secs =
+            ChunkTimingModel::estimate_chunk_interval_secs(prev_metadata, next_metadata);
+
+        // Blend with historical data if available
+        if let Some(stats) = timing_stats {
+            if let Some(elev_num) = next_metadata.elevation_number() {
+                if let Some(elev_data) = _vcp.elevations().get(elev_num - 1) {
+                    let characteristics = ChunkCharacteristics {
+                        chunk_type: ChunkType::Intermediate,
+                        waveform_type: elev_data.waveform_type(),
+                        channel_configuration: elev_data.channel_configuration(),
+                    };
+
+                    if let Some(avg_timing) = stats.get_average_timing(&characteristics) {
+                        let historical_secs = avg_timing.num_milliseconds() as f64 / 1000.0;
+                        // Blend: 70% physics, 30% historical
+                        interval_secs = interval_secs * 0.7 + historical_secs * 0.3;
+                    }
+                }
+            }
+        }
+
+        let interval_ms = (interval_secs * 1000.0) as i64;
+        cumulative_offset_ms += interval_ms;
+
+        let interval_duration = Duration::milliseconds(interval_ms);
+        let offset_duration = Duration::milliseconds(cumulative_offset_ms);
+        let projected_time = anchor_time + offset_duration;
+
+        projections.push(ChunkProjection {
+            sequence: seq,
+            elevation_number: next_metadata.elevation_number(),
+            elevation_angle_deg: next_metadata.elevation_angle_deg(),
+            projected_time,
+            offset_from_anchor: offset_duration,
+            interval_from_previous: interval_duration,
+            starts_new_sweep: next_metadata.is_first_in_sweep(),
+        });
+
+        prev_metadata = next_metadata;
+    }
+
+    let volume_end_time = projections
+        .last()
+        .map(|p| p.projected_time)
+        .unwrap_or(anchor_time);
+    let remaining_duration = Duration::milliseconds(cumulative_offset_ms);
+
+    Some(ScanTimingProjection {
+        anchor_sequence,
+        anchor_time,
+        chunks: projections,
+        volume_end_time,
+        remaining_duration,
+    })
+}
+
+/// Build a timing projection for an entire volume from the Start chunk.
+///
+/// This projects all chunks from sequence 1 through the final sequence, useful when
+/// starting a fresh volume and wanting to display the full expected timeline.
+///
+/// The `start_time` parameter is the time the Start chunk was uploaded (or current time).
+pub fn project_full_scan_timing(
+    site: &str,
+    volume: VolumeIndex,
+    start_time: DateTime<Utc>,
+    vcp: &volume_coverage_pattern::Message,
+    mapper: &ElevationChunkMapper,
+    timing_stats: Option<&ChunkTimingStats>,
+) -> Option<ScanTimingProjection> {
+    let start_chunk = ChunkIdentifier::new(
+        site.to_string(),
+        volume,
+        start_time.naive_utc(),
+        1,
+        ChunkType::Start,
+        Some(start_time),
+    );
+
+    project_scan_timing(&start_chunk, vcp, mapper, timing_stats)
+}

--- a/src/nexrad/timing/scan_timing_projection.rs
+++ b/src/nexrad/timing/scan_timing_projection.rs
@@ -3,6 +3,33 @@ use chrono::{DateTime, Duration, Utc};
 use nexrad_data::aws::realtime::{ChunkIdentifier, ChunkType, VolumeIndex};
 use nexrad_decode::messages::volume_coverage_pattern;
 
+/// Which branch [`project_scan_timing`] used to anchor the collection axis.
+/// Surfaced on per-chunk diagnostics so we can tell whether a projection was
+/// based on a real radial-derived anchor or had to fall back.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AnchorSource {
+    /// Used the caller-supplied ACTUAL collection time (parsed from a radial
+    /// header). Best case — projections are anchored on real data.
+    ObservedCollection,
+    /// No collection time available; estimated as `upload − median lag` from
+    /// `ChunkTimingStats`. Reasonable once stats have warmed up.
+    UploadMinusMedian,
+    /// No collection time and no lag stats; fell back to
+    /// `upload − DEFAULT_AVAILABILITY_LAG_SECS`. Cold start only — projections
+    /// will carry the largest uncertainty.
+    UploadMinusDefault,
+}
+
+impl AnchorSource {
+    pub fn short(&self) -> &'static str {
+        match self {
+            AnchorSource::ObservedCollection => "obs",
+            AnchorSource::UploadMinusMedian => "median",
+            AnchorSource::UploadMinusDefault => "default",
+        }
+    }
+}
+
 /// A projected timeline for all remaining chunks in a volume scan.
 ///
 /// Carries two parallel time axes for each chunk:
@@ -27,6 +54,9 @@ pub struct ScanTimingProjection {
     /// time of the anchor and its S3 upload time. `None` when the header
     /// time is unavailable (falls back to `DEFAULT_AVAILABILITY_LAG_SECS`).
     observed_anchor_lag_secs: Option<f64>,
+    /// Which branch the anchor came from — surfaced in diagnostics so we
+    /// can tell when a projection is degraded by a fallback anchor.
+    anchor_source: AnchorSource,
     /// Projected timing for each future chunk, in sequence order.
     chunks: Vec<ChunkProjection>,
     /// AVAILABILITY category: projected time the final chunk becomes
@@ -69,6 +99,12 @@ impl ScanTimingProjection {
     #[allow(dead_code)] // Consumed by debug UI in a later commit.
     pub fn observed_anchor_lag_secs(&self) -> Option<f64> {
         self.observed_anchor_lag_secs
+    }
+
+    /// Which branch the anchor came from. Used by the diagnostics modal to
+    /// flag projections built on a fallback anchor.
+    pub fn anchor_source(&self) -> AnchorSource {
+        self.anchor_source
     }
 
     /// Projected timing for each future chunk, in sequence order.
@@ -193,18 +229,31 @@ pub fn project_scan_timing(
     // volume header collection time, use it and derive the empirical lag as
     // upload − collection. Otherwise fall back to a lag estimate: prefer the
     // median lag observed in `ChunkTimingStats`, else a static default.
-    let (anchor_collection_secs, observed_lag_secs, availability_lag_secs) =
+    let (anchor_collection_secs, observed_lag_secs, availability_lag_secs, anchor_source) =
         match anchor_collection_time_secs {
             Some(collection_secs) => {
                 let lag = anchor_available_at_secs - collection_secs;
-                (collection_secs, Some(lag), lag)
+                (
+                    collection_secs,
+                    Some(lag),
+                    lag,
+                    AnchorSource::ObservedCollection,
+                )
             }
-            None => {
-                let fallback_lag = timing_stats
-                    .and_then(|s| s.median_availability_lag_secs())
-                    .unwrap_or(DEFAULT_AVAILABILITY_LAG_SECS);
-                (anchor_available_at_secs - fallback_lag, None, fallback_lag)
-            }
+            None => match timing_stats.and_then(|s| s.median_availability_lag_secs()) {
+                Some(median_lag) => (
+                    anchor_available_at_secs - median_lag,
+                    None,
+                    median_lag,
+                    AnchorSource::UploadMinusMedian,
+                ),
+                None => (
+                    anchor_available_at_secs - DEFAULT_AVAILABILITY_LAG_SECS,
+                    None,
+                    DEFAULT_AVAILABILITY_LAG_SECS,
+                    AnchorSource::UploadMinusDefault,
+                ),
+            },
         };
 
     let mut projections = Vec::new();
@@ -276,6 +325,7 @@ pub fn project_scan_timing(
         anchor_available_at,
         anchor_collection_time_secs: anchor_collection_secs,
         observed_anchor_lag_secs: observed_lag_secs,
+        anchor_source,
         chunks: projections,
         volume_end_available_at,
         remaining_duration,

--- a/src/state/live_mode.rs
+++ b/src/state/live_mode.rs
@@ -2,6 +2,29 @@
 //!
 //! This module handles the state machine for real-time streaming mode,
 //! including phase tracking, animation state, and exit conditions.
+//!
+//! # Timing model invariants
+//!
+//! Fields in `LiveModeState` are labelled by category in their doc comments:
+//! - ACTUAL — parsed from radial/message headers (`current_volume_start`,
+//!   `completed_sweep_metas`, `last_radial_time_secs`, `chunk_elev_spans`).
+//!   Drives the radar canvas, the current-time indicator, and "Age" labels.
+//! - PROJECTED COLLECTION — derived from VCP physics anchored on an ACTUAL
+//!   reference (`projected_volume_end_collection_secs`, `chunk_projections`
+//!   via `projected_collection_time_secs`). Drives timeline placeholders
+//!   for future sweeps and chunks.
+//! - PROJECTED AVAILABILITY — empirical S3-upload estimates
+//!   (`projected_volume_end_available_at_secs`,
+//!   `next_chunk_available_at_secs`, `chunk_projections` via
+//!   `projected_available_at_secs`). Drives the scheduler and the
+//!   "next in Xs" countdown language.
+//!
+//! Live playhead (`TimeModel::playback_position` when `realtime_lock`
+//! is on) deliberately tracks wall clock rather than clamping to the
+//! latest received sweep's end. Clamping would cause visible stutter at
+//! each chunk boundary; the canvas already resolves whichever sweep has
+//! `end ≤ playback_position`, so wall-clock tracking satisfies principle
+//! 1 (canvas shows ACTUAL data) without the stutter.
 
 use std::time::Duration;
 

--- a/src/state/live_mode.rs
+++ b/src/state/live_mode.rs
@@ -614,6 +614,15 @@ impl LiveModeState {
         }
     }
 
+    /// Back-fill the empirical availability lag (`s3_last_modified − chunk_max_collection_time`)
+    /// onto the most recent chunk arrival record. Computed in `main.rs` once
+    /// the worker ingest yields the chunk's last-radial time.
+    pub fn attach_availability_lag_to_last_arrival(&mut self, lag_ms: i64) {
+        if let Some(last) = self.chunk_arrivals.last_mut() {
+            last.availability_lag_ms = Some(lag_ms);
+        }
+    }
+
     /// Record last radial azimuth and timestamp from a chunk.
     pub fn record_last_radial(&mut self, azimuth: Option<f32>, time_secs: Option<f64>) {
         if let Some(az) = azimuth {

--- a/src/state/live_mode.rs
+++ b/src/state/live_mode.rs
@@ -614,12 +614,20 @@ impl LiveModeState {
         }
     }
 
-    /// Back-fill the empirical availability lag (`s3_last_modified − chunk_max_collection_time`)
-    /// onto the most recent chunk arrival record. Computed in `main.rs` once
-    /// the worker ingest yields the chunk's last-radial time.
-    pub fn attach_availability_lag_to_last_arrival(&mut self, lag_ms: i64) {
+    /// Back-fill the per-chunk collection-end time and (when available)
+    /// empirical availability lag onto the most recent chunk arrival record.
+    /// Both quantities come from the worker ingest (which parses the chunk's
+    /// last-radial timestamp) and are dispatched together from `main.rs`.
+    pub fn attach_collection_data_to_last_arrival(
+        &mut self,
+        collection_time_secs: f64,
+        availability_lag_ms: Option<i64>,
+    ) {
         if let Some(last) = self.chunk_arrivals.last_mut() {
-            last.availability_lag_ms = Some(lag_ms);
+            last.collection_time_secs = Some(collection_time_secs);
+            if let Some(lag_ms) = availability_lag_ms {
+                last.availability_lag_ms = Some(lag_ms);
+            }
         }
     }
 

--- a/src/state/live_mode.rs
+++ b/src/state/live_mode.rs
@@ -179,6 +179,12 @@ pub struct LiveModeState {
     /// model (sweep_duration = 360/rate - 0.67s).
     pub projected_volume_end_available_at_secs: Option<f64>,
 
+    /// COLLECTION category: projected Unix-seconds time the radar finishes
+    /// physically scanning the final chunk of the current volume. Drives
+    /// timeline placeholders for future-chunk positioning, whereas
+    /// `projected_volume_end_available_at_secs` drives countdown language.
+    pub projected_volume_end_collection_secs: Option<f64>,
+
     /// Per-chunk projection info from the library's physics model.
     /// Structural metadata covers all chunks; projected times only for future chunks.
     /// Updated each time a new chunk arrives.
@@ -241,6 +247,7 @@ impl Default for LiveModeState {
             last_radial_azimuth: None,
             last_radial_time_secs: None,
             projected_volume_end_available_at_secs: None,
+            projected_volume_end_collection_secs: None,
             chunk_projections: None,
             current_volume_forecast: None,
             last_volume_forecast: None,
@@ -315,6 +322,7 @@ impl LiveModeState {
         self.last_radial_azimuth = None;
         self.last_radial_time_secs = None;
         self.projected_volume_end_available_at_secs = None;
+        self.projected_volume_end_collection_secs = None;
         self.chunk_projections = None;
         self.current_volume_forecast = None;
         self.last_volume_forecast = None;
@@ -418,6 +426,7 @@ impl LiveModeState {
     ///
     /// This is the main integration point between the RealtimeChannel and
     /// the live mode state machine.
+    #[allow(clippy::too_many_arguments)]
     pub fn handle_realtime_chunk(
         &mut self,
         chunks_in_volume: u32,
@@ -425,10 +434,12 @@ impl LiveModeState {
         is_volume_end: bool,
         now: f64,
         projected_volume_end_available_at_secs: Option<f64>,
+        projected_volume_end_collection_secs: Option<f64>,
         chunk_projections: Option<Vec<crate::nexrad::ChunkProjectionInfo>>,
     ) {
         self.chunks_received = chunks_in_volume;
         self.projected_volume_end_available_at_secs = projected_volume_end_available_at_secs;
+        self.projected_volume_end_collection_secs = projected_volume_end_collection_secs;
         self.chunk_projections = chunk_projections;
 
         if is_volume_end {
@@ -494,6 +505,7 @@ impl LiveModeState {
         self.last_radial_azimuth = None;
         self.last_radial_time_secs = None;
         self.projected_volume_end_available_at_secs = None;
+        self.projected_volume_end_collection_secs = None;
         self.chunk_projections = None;
     }
 
@@ -614,12 +626,17 @@ impl LiveModeState {
         let is_clear_air = crate::data::vcp::is_clear_air_vcp(vcp_number);
 
         let total_vol_dur = vcp.estimated_volume_duration().unwrap_or(300.0);
+        // Predicted end of volume on the timeline is the COLLECTION time of
+        // the final chunk — not its S3 availability. Timeline placeholders
+        // reflect when the radar finishes physically scanning.
         let predicted_volume_end = self
-            .projected_volume_end_available_at_secs
+            .projected_volume_end_collection_secs
             .unwrap_or(vol_start + total_vol_dur);
         let sweep_durations = vcp.sweep_durations(total_vol_dur);
 
         // Group chunk_projections by elevation for per-sweep predictions.
+        // Uses projected COLLECTION times so future-sweep bounds on the
+        // timeline reflect when the radar will scan, not when chunks upload.
         let chunk_projections_available = self.chunk_projections.is_some();
         let projected_per_elev: Option<
             std::collections::BTreeMap<u8, (f64, f64, u32, f64)>, // (min_time, max_time, chunk_count, rate)
@@ -635,7 +652,7 @@ impl LiveModeState {
                         chunk.azimuth_rate_dps,
                     ));
                     entry.2 += 1;
-                    if let Some(t) = chunk.projected_available_at_secs {
+                    if let Some(t) = chunk.projected_collection_time_secs {
                         entry.0 = entry.0.min(t);
                         entry.1 = entry.1.max(t);
                     }
@@ -824,7 +841,10 @@ impl LiveModeState {
             let mut max_t = f64::MIN;
             for chunk in projs {
                 if chunk.elevation_number == Some(elev as usize) {
-                    if let Some(t) = chunk.projected_available_at_secs {
+                    // COLLECTION time — elevation bounds on the timeline
+                    // represent when the radar will physically scan, not
+                    // when chunks will upload.
+                    if let Some(t) = chunk.projected_collection_time_secs {
                         min_t = min_t.min(t);
                         max_t = max_t.max(t);
                     }

--- a/src/state/live_mode.rs
+++ b/src/state/live_mode.rs
@@ -88,8 +88,9 @@ pub struct LiveModeState {
     /// Typical interval between chunks in seconds (~12s)
     pub chunk_interval_secs: f64,
 
-    /// Expected arrival time of next chunk (Unix seconds)
-    pub next_chunk_expected_at: Option<f64>,
+    /// AVAILABILITY category: projected Unix-seconds arrival time of the
+    /// next chunk in S3. Drives the "next in Xs" countdown.
+    pub next_chunk_available_at_secs: Option<f64>,
 
     /// Error message if in Error phase
     pub error_message: Option<String>,
@@ -173,9 +174,10 @@ pub struct LiveModeState {
     /// `last_radial_azimuth`, allows linear extrapolation of sweep line.
     pub last_radial_time_secs: Option<f64>,
 
-    /// Library-projected volume end time (Unix seconds).
-    /// From nexrad-data's physics-based model (sweep_duration = 360/rate - 0.67s).
-    pub projected_volume_end_secs: Option<f64>,
+    /// AVAILABILITY category: projected Unix-seconds S3-arrival time of the
+    /// final chunk in the current volume. From nexrad-data's physics-based
+    /// model (sweep_duration = 360/rate - 0.67s).
+    pub projected_volume_end_available_at_secs: Option<f64>,
 
     /// Per-chunk projection info from the library's physics model.
     /// Structural metadata covers all chunks; projected times only for future chunks.
@@ -215,7 +217,7 @@ impl Default for LiveModeState {
             phase: LivePhase::Idle,
             phase_started_at: None,
             chunk_interval_secs: 12.0,
-            next_chunk_expected_at: None,
+            next_chunk_available_at_secs: None,
             error_message: None,
             last_exit_reason: None,
             chunks_received: 0,
@@ -238,7 +240,7 @@ impl Default for LiveModeState {
             live_data_azimuth_range: None,
             last_radial_azimuth: None,
             last_radial_time_secs: None,
-            projected_volume_end_secs: None,
+            projected_volume_end_available_at_secs: None,
             chunk_projections: None,
             current_volume_forecast: None,
             last_volume_forecast: None,
@@ -269,7 +271,7 @@ impl LiveModeState {
             }
             LivePhase::WaitingForChunk => {
                 state.chunks_received = 10;
-                state.next_chunk_expected_at = Some(now + 8.0); // 8 seconds remaining
+                state.next_chunk_available_at_secs = Some(now + 8.0); // 8 seconds remaining
             }
             LivePhase::AcquiringLock => {
                 // Just acquiring, no chunks yet
@@ -297,7 +299,7 @@ impl LiveModeState {
     pub fn stop(&mut self, reason: LiveExitReason) {
         self.phase = LivePhase::Idle;
         self.phase_started_at = None;
-        self.next_chunk_expected_at = None;
+        self.next_chunk_available_at_secs = None;
         self.last_exit_reason = Some(reason);
         self.elevations_received.clear();
         self.current_volume_start = None;
@@ -312,7 +314,7 @@ impl LiveModeState {
         self.live_data_azimuth_range = None;
         self.last_radial_azimuth = None;
         self.last_radial_time_secs = None;
-        self.projected_volume_end_secs = None;
+        self.projected_volume_end_available_at_secs = None;
         self.chunk_projections = None;
         self.current_volume_forecast = None;
         self.last_volume_forecast = None;
@@ -340,7 +342,7 @@ impl LiveModeState {
     pub fn wait_for_next_chunk(&mut self, now: f64) {
         self.phase = LivePhase::WaitingForChunk;
         self.phase_started_at = Some(now);
-        self.next_chunk_expected_at = Some(now + self.chunk_interval_secs);
+        self.next_chunk_available_at_secs = Some(now + self.chunk_interval_secs);
         self.chunks_received += 1;
     }
 
@@ -362,7 +364,7 @@ impl LiveModeState {
     /// Get remaining countdown for WaitingForChunk phase.
     pub fn countdown_remaining_secs(&self, now: f64) -> Option<f64> {
         if self.phase == LivePhase::WaitingForChunk {
-            self.next_chunk_expected_at
+            self.next_chunk_available_at_secs
                 .map(|expected| (expected - now).max(0.0))
         } else {
             None
@@ -422,11 +424,11 @@ impl LiveModeState {
         time_until_next: Option<Duration>,
         is_volume_end: bool,
         now: f64,
-        projected_volume_end_secs: Option<f64>,
+        projected_volume_end_available_at_secs: Option<f64>,
         chunk_projections: Option<Vec<crate::nexrad::ChunkProjectionInfo>>,
     ) {
         self.chunks_received = chunks_in_volume;
-        self.projected_volume_end_secs = projected_volume_end_secs;
+        self.projected_volume_end_available_at_secs = projected_volume_end_available_at_secs;
         self.chunk_projections = chunk_projections;
 
         if is_volume_end {
@@ -437,7 +439,7 @@ impl LiveModeState {
             // Waiting for next chunk
             self.phase = LivePhase::WaitingForChunk;
             self.phase_started_at = Some(now);
-            self.next_chunk_expected_at = Some(now + duration.as_secs_f64());
+            self.next_chunk_available_at_secs = Some(now + duration.as_secs_f64());
             self.chunk_interval_secs = duration.as_secs_f64();
         } else {
             // Actively receiving
@@ -491,7 +493,7 @@ impl LiveModeState {
         self.live_data_azimuth_range = None;
         self.last_radial_azimuth = None;
         self.last_radial_time_secs = None;
-        self.projected_volume_end_secs = None;
+        self.projected_volume_end_available_at_secs = None;
         self.chunk_projections = None;
     }
 
@@ -613,7 +615,7 @@ impl LiveModeState {
 
         let total_vol_dur = vcp.estimated_volume_duration().unwrap_or(300.0);
         let predicted_volume_end = self
-            .projected_volume_end_secs
+            .projected_volume_end_available_at_secs
             .unwrap_or(vol_start + total_vol_dur);
         let sweep_durations = vcp.sweep_durations(total_vol_dur);
 
@@ -633,7 +635,7 @@ impl LiveModeState {
                         chunk.azimuth_rate_dps,
                     ));
                     entry.2 += 1;
-                    if let Some(t) = chunk.projected_time_secs {
+                    if let Some(t) = chunk.projected_available_at_secs {
                         entry.0 = entry.0.min(t);
                         entry.1 = entry.1.max(t);
                     }
@@ -822,7 +824,7 @@ impl LiveModeState {
             let mut max_t = f64::MIN;
             for chunk in projs {
                 if chunk.elevation_number == Some(elev as usize) {
-                    if let Some(t) = chunk.projected_time_secs {
+                    if let Some(t) = chunk.projected_available_at_secs {
                         min_t = min_t.min(t);
                         max_t = max_t.max(t);
                     }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -15,6 +15,7 @@ mod playback;
 pub(crate) mod playback_manager;
 mod preferences;
 pub(crate) mod radar_data;
+pub(crate) mod render_cache;
 mod saved_events;
 mod settings;
 mod stats;
@@ -38,6 +39,7 @@ pub use live_radar_model::LiveRadarModel;
 pub use playback::{LoopMode, PlaybackMode, PlaybackSpeed, PlaybackState, TimeModel};
 pub use preferences::UserPreferences;
 pub use radar_data::RadarTimeline;
+pub use render_cache::{PrevSweepCacheKey, RenderCache};
 pub use saved_events::{SavedEvent, SavedEvents};
 pub use settings::{format_bytes, StorageSettings};
 pub use stats::{
@@ -272,6 +274,10 @@ pub struct AppState {
     /// the `SiteModalState` that lives outside `AppState`, avoiding a direct
     /// state dependency from the bottom-bar renderer.
     pub mobile_geolocate_requested: bool,
+
+    /// Per-frame render caches: camera-motion tracking for label-tier
+    /// debouncing, prev-sweep lookup memoization, and theme-gating state.
+    pub render_cache: RenderCache,
 }
 
 /// Tabs in the mobile settings modal. Order matches the tab strip layout.

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -190,6 +190,11 @@ pub struct AppState {
     /// Whether to display times in local timezone (false = UTC).
     pub use_local_time: bool,
 
+    /// Developer mode: shows perf timings, FPS, network metrics, and the COI
+    /// badge in the status bar, and enables the code paths that feed them.
+    /// Mirrored to/from the `?dev=true` URL parameter.
+    pub dev_mode: bool,
+
     /// Whether the stats detail popup is open.
     pub stats_detail_open: bool,
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -35,9 +35,7 @@ pub use app_mode::AppMode;
 pub use layer::{GeoLayerVisibility, LayerState};
 pub use live_mode::{LiveExitReason, LiveModeState, LivePhase};
 pub use live_radar_model::LiveRadarModel;
-pub use playback::{
-    LoopMode, PlaybackMode, PlaybackSpeed, PlaybackState, TimeModel, MICRO_ZOOM_THRESHOLD,
-};
+pub use playback::{LoopMode, PlaybackMode, PlaybackSpeed, PlaybackState, TimeModel};
 pub use preferences::UserPreferences;
 pub use radar_data::RadarTimeline;
 pub use saved_events::{SavedEvent, SavedEvents};

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -47,7 +47,9 @@ pub use stats::{
 // AppCommand is defined directly in this module above.
 pub use theme::ThemeMode;
 pub use vcp::get_vcp_definition;
-pub use vcp_forecast::{ChunkArrivalStat, RateSource, SweepForecast, VolumeForecastSnapshot};
+pub use vcp_forecast::{
+    BucketKey, ChunkArrivalStat, RateSource, SweepForecast, VolumeForecastSnapshot,
+};
 pub use vcp_position::{SweepPosition, SweepStatus, SweepTiming, VcpPositionModel};
 pub use viz::{
     ElevationListEntry, ElevationSelection, InterpolationMode, RadarProduct, RenderProcessing,

--- a/src/state/render_cache.rs
+++ b/src/state/render_cache.rs
@@ -1,0 +1,87 @@
+//! Per-frame render-cache state.
+//!
+//! Tracks camera motion so expensive rendering work (label layout, centroid
+//! math) can be deferred until the user has stopped panning/zooming, plus a
+//! handful of small caches that smooth over per-frame recomputation.
+
+use crate::geo::ProjectionFingerprint;
+
+/// Default settle window: how long the camera must be stable before the
+/// label tier rebuilds its cache. 180 ms feels responsive without thrashing
+/// the cache during a continuous pan/zoom gesture.
+pub const SETTLE_WINDOW_SECS: f64 = 0.18;
+
+/// Tracks whether the map camera (projection) has come to rest. Consumers
+/// (e.g. the label tier in the geo renderer) check `is_settled()` to decide
+/// whether to do expensive recomputation this frame.
+#[derive(Debug, Clone)]
+pub struct CameraMotion {
+    last_fingerprint: Option<ProjectionFingerprint>,
+    last_change_secs: f64,
+    settle_window_secs: f64,
+}
+
+impl Default for CameraMotion {
+    fn default() -> Self {
+        Self {
+            last_fingerprint: None,
+            last_change_secs: 0.0,
+            settle_window_secs: SETTLE_WINDOW_SECS,
+        }
+    }
+}
+
+impl CameraMotion {
+    /// Record the projection observed this frame.
+    pub fn observe(&mut self, fp: ProjectionFingerprint, now_secs: f64) {
+        if self.last_fingerprint != Some(fp) {
+            self.last_fingerprint = Some(fp);
+            self.last_change_secs = now_secs;
+        }
+    }
+
+    /// True iff the camera has been at the most-recently-observed projection
+    /// for at least `settle_window_secs`. Always true once any fingerprint
+    /// has been observed *and* enough time has passed since the last change.
+    pub fn is_settled(&self, now_secs: f64) -> bool {
+        self.last_fingerprint.is_some()
+            && (now_secs - self.last_change_secs) >= self.settle_window_secs
+    }
+
+    /// Seconds remaining until settle, given a wall-clock `now`. Returns
+    /// `None` if already settled (or never observed).
+    pub fn time_until_settle(&self, now_secs: f64) -> Option<f64> {
+        let target = self.last_change_secs + self.settle_window_secs;
+        if self.last_fingerprint.is_some() && now_secs < target {
+            Some(target - now_secs)
+        } else {
+            None
+        }
+    }
+}
+
+/// Inputs that determine the previous-sweep search result. When any of these
+/// change, the cached `find_prev_sweep` result must be recomputed.
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct PrevSweepCacheKey {
+    pub playback_ts_bits: u64,
+    pub displayed_elev: u8,
+    pub is_auto: bool,
+    pub scan_count: usize,
+}
+
+/// Bundle of small caches used by the per-frame render path.
+#[derive(Debug, Default, Clone)]
+pub struct RenderCache {
+    pub camera_motion: CameraMotion,
+
+    /// Last value of `is_dark` pushed to `egui::Context::set_visuals`. Used
+    /// to skip the per-frame `Visuals` reconstruction unless the theme
+    /// actually changed.
+    pub last_dark: Option<bool>,
+
+    /// Cached key + result for `PlaybackManager::find_prev_sweep`. Reused
+    /// across frames while the inputs are unchanged.
+    pub prev_sweep_cache_key: Option<PrevSweepCacheKey>,
+    pub prev_sweep_cache_value: Option<(i64, u8, f32, f64, f64)>,
+}

--- a/src/state/url_state.rs
+++ b/src/state/url_state.rs
@@ -79,6 +79,8 @@ pub struct UrlParams {
     pub lat: Option<f64>,
     pub lon: Option<f64>,
     pub view: ViewState,
+    /// Developer mode flag — `true` only when `?dev=true` is present.
+    pub dev: bool,
 }
 
 /// Parse URL query parameters from the current browser URL.
@@ -90,6 +92,7 @@ pub fn parse_from_url() -> UrlParams {
         lat: None,
         lon: None,
         view: ViewState::default(),
+        dev: false,
     };
 
     let Ok(search) = web_sys::window().expect("no window").location().search() else {
@@ -118,6 +121,7 @@ pub fn parse_from_url() -> UrlParams {
                     }
                 }
             }
+            "dev" => params.dev = value == "true",
             _ => {}
         }
     }
@@ -126,14 +130,28 @@ pub fn parse_from_url() -> UrlParams {
 }
 
 /// Push current state to the URL query string using `replaceState`.
-pub fn push_to_url(site: &str, time: f64, product: &str, lat: f64, lon: f64, view: &ViewState) {
+///
+/// `dev` is appended as `&dev=true` only when true; when false the parameter
+/// is omitted so off-mode URLs stay clean.
+pub fn push_to_url(
+    site: &str,
+    time: f64,
+    product: &str,
+    lat: f64,
+    lon: f64,
+    view: &ViewState,
+    dev: bool,
+) {
     let v_json = serde_json::to_vec(view).unwrap_or_default();
     let v_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&v_json);
 
-    let query = format!(
+    let mut query = format!(
         "?site={}&t={:.0}&product={}&lat={:.4}&lon={:.4}&v={}",
         site, time, product, lat, lon, v_b64
     );
+    if dev {
+        query.push_str("&dev=true");
+    }
 
     let window = web_sys::window().expect("no window");
     let history = window.history().expect("no history");

--- a/src/state/vcp_forecast.rs
+++ b/src/state/vcp_forecast.rs
@@ -190,6 +190,20 @@ pub struct ChunkArrivalStat {
     /// `attach_availability_lag_ms`. `None` until that back-fill happens (or
     /// permanently if either timestamp is unavailable).
     pub availability_lag_ms: Option<i64>,
+    /// ACTUAL chunk collection-end time (Unix seconds, ms-precise) — the
+    /// last radial timestamp parsed by the worker for this chunk. Back-filled
+    /// from `main.rs` alongside `availability_lag_ms`. `None` until the
+    /// worker ingest completes for this chunk. Together with the previous
+    /// arrival's `collection_time_secs`, lets us compute the actual
+    /// collection-space interval per chunk free of S3 1-second quantization.
+    pub collection_time_secs: Option<f64>,
+    /// Wait the scheduler returned for this chunk on its first poll —
+    /// `EstimatedChunkProcessing.duration` from the estimator. The interval
+    /// the projector/scheduler *actually* used (already includes the 70/30
+    /// historical blend when `path == Historical`). Pair with
+    /// `collection_time_secs` to compute the per-chunk interval prediction
+    /// error in collection space.
+    pub predicted_wait_secs: Option<f64>,
 }
 
 /// Compact serialisable bucket key. Mirrors `ChunkCharacteristics` but
@@ -267,5 +281,26 @@ impl ChunkArrivalStat {
     pub fn wait_after_last_empty_ms(&self) -> Option<f64> {
         self.last_empty_poll_at
             .map(|t| (self.success_at - t) * 1000.0)
+    }
+
+    /// Actual collection-space interval between this chunk and `prev` — the
+    /// ground truth the predicted wait should be compared against. Returns
+    /// `None` if either chunk hasn't had its collection time back-filled.
+    pub fn actual_interval_secs(&self, prev: &ChunkArrivalStat) -> Option<f64> {
+        match (self.collection_time_secs, prev.collection_time_secs) {
+            (Some(c), Some(p)) if c > p => Some(c - p),
+            _ => None,
+        }
+    }
+
+    /// Per-chunk interval prediction error in collection space, milliseconds:
+    /// `actual_interval − predicted_wait`. Positive means we underestimated
+    /// the gap (the chunk took longer to arrive than predicted), which is
+    /// the dominant signal for "sweep too short" / "sweeps shifted earlier"
+    /// symptoms.
+    pub fn interval_error_ms(&self, prev: &ChunkArrivalStat) -> Option<f64> {
+        let actual = self.actual_interval_secs(prev)?;
+        let predicted = self.predicted_wait_secs?;
+        Some((actual - predicted) * 1000.0)
     }
 }

--- a/src/state/vcp_forecast.rs
+++ b/src/state/vcp_forecast.rs
@@ -8,6 +8,9 @@
 //! algorithms can be iterated on from real session data.
 
 use super::{SweepStatus, SweepTiming};
+use crate::nexrad::timing::{AnchorSource, ChunkCharacteristics, PhysicsBreakdown, SchedulerPath};
+use nexrad_data::aws::realtime::ChunkType;
+use nexrad_decode::messages::volume_coverage_pattern::{ChannelConfiguration, WaveformType};
 
 /// Where the azimuth-rate value driving the prediction came from.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -32,7 +35,14 @@ impl RateSource {
 
 /// Per-elevation predicted values captured at volume start, with slots for
 /// actuals filled in as the sweep completes.
+///
+/// Several structural fields (`prf_number`, `is_sails`, etc.) are populated
+/// from the VCP message but no longer rendered in the diagnostics modal —
+/// they're retained for symmetry with the upstream `ExtractedVcp` and so the
+/// snapshot can survive a future feature that needs them. `#[allow(dead_code)]`
+/// keeps the warning quiet without forcing us to gut the construction site.
 #[derive(Clone, Debug)]
+#[allow(dead_code)]
 pub struct SweepForecast {
     pub elev_number: u8,
     pub elev_angle: f32,
@@ -51,7 +61,6 @@ pub struct SweepForecast {
     pub rate_source: RateSource,
 
     pub predicted_start: f64,
-    #[allow(dead_code)] // stored for future use; rendered via predicted_duration today
     pub predicted_end: f64,
     pub predicted_duration: f64,
     /// `None` when no `ChunkProjectionInfo` was available at snapshot time
@@ -83,7 +92,14 @@ impl SweepForecast {
 }
 
 /// Volume-level snapshot. Serialized into the clipboard text.
+///
+/// `chunk_projections_available_at_start` and `previous_volume_end` are
+/// populated by the live-mode capture path but no longer rendered — they
+/// gave context to columns that have since been removed. Kept on the struct
+/// to keep the capture site compact; `#[allow(dead_code)]` silences the
+/// resulting unused-field warnings.
 #[derive(Clone, Debug)]
+#[allow(dead_code)]
 pub struct VolumeForecastSnapshot {
     pub vcp_number: u16,
     /// Name from the static `get_vcp_definition` table; `None` for unknown VCPs.
@@ -137,30 +153,104 @@ pub struct ChunkArrivalStat {
     /// What the iterator's `time_until_next()` said the chunk would be
     /// available at (Unix seconds). `None` if the iterator had no prediction.
     pub predicted_available_at: Option<f64>,
-    /// Time the first poll for this chunk was issued (end of the predicted
-    /// sleep), Unix seconds. The gap `scheduled_at - predicted_available_at`
-    /// is the scheduler slop (how precisely we woke on the predicted time).
-    pub scheduled_at: f64,
     /// Number of empty `Ok(None)` polls before the successful fetch.
     pub empty_polls: u32,
-    /// Time of the first empty poll for this chunk (Unix seconds). `None`
-    /// when `empty_polls == 0`. Together with `last_empty_poll_at` bounds
-    /// the retry cluster.
-    pub first_empty_poll_at: Option<f64>,
     /// Time of the most recent empty poll (Unix seconds). `None` when
-    /// `empty_polls == 0`. Crude lower bound on when the chunk actually
-    /// became available on S3 — we only learn it via polling.
+    /// `empty_polls == 0`. Used to compute `wait_after_last_empty_ms`,
+    /// the time from the last failed poll to success.
     pub last_empty_poll_at: Option<f64>,
-    /// S3's `Last-Modified` header for the object (Unix seconds). When
-    /// present this is the authoritative earliest-possible-download time
-    /// and strictly tighter than `last_empty_poll_at`. Note: header has
-    /// 1-second resolution, so derived `wait_after_s3_publish_ms` values
-    /// are ±1s noisy.
+    /// S3's `Last-Modified` header for the object (Unix seconds). Used by
+    /// `main.rs` to compute the per-chunk availability lag once the worker
+    /// ingest yields the chunk's last-radial collection time.
     pub s3_last_modified_at: Option<f64>,
     /// Time the successful poll received its response (Unix seconds).
     pub success_at: f64,
-    /// HTTP round-trip time for the successful fetch, milliseconds.
-    pub fetch_latency_ms: f64,
+
+    /// Bucket key used by `ChunkTimingStats` for the chunk that *was* arriving
+    /// at the time the prediction was made. `None` for chunks where no
+    /// metadata-driven prediction was available (Start chunk, or legacy path).
+    pub bucket_key: Option<BucketKey>,
+    /// Number of samples in the bucket above at the moment the prediction
+    /// was made. Lets us tell "model wrong" from "stats not warm yet" when
+    /// the prediction error is large.
+    pub stats_n_at_prediction: usize,
+    /// Which estimator branch produced `predicted_available_at`. `None` only
+    /// when no prediction was made at all (e.g. resume-from-cache emissions).
+    pub scheduler_path: Option<SchedulerPath>,
+    /// Physics decomposition for the inter-chunk transition that fed the
+    /// prediction. Populated whenever both current and next metadata existed
+    /// at prediction time.
+    pub physics_breakdown: Option<PhysicsBreakdown>,
+    /// Which anchor branch the projector was using at prediction time.
+    /// Tells us when projections were degraded by a fallback anchor.
+    pub anchor_source: Option<AnchorSource>,
+    /// `s3_last_modified_at − chunk_max_collection_time_secs`, in milliseconds.
+    /// Computed in `main.rs` once worker ingest yields the chunk's last
+    /// radial time, then back-filled onto this struct via
+    /// `attach_availability_lag_ms`. `None` until that back-fill happens (or
+    /// permanently if either timestamp is unavailable).
+    pub availability_lag_ms: Option<i64>,
+}
+
+/// Compact serialisable bucket key. Mirrors `ChunkCharacteristics` but
+/// without depending on the timing crate's enum types — keeps the diagnostics
+/// state layer free of upstream imports.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BucketKey {
+    pub chunk_type: &'static str,
+    pub waveform: &'static str,
+    pub channel: &'static str,
+    pub first_in_sweep: bool,
+}
+
+impl BucketKey {
+    /// Compact label for diagnostics output (e.g. `"I|CS|RP|F"`).
+    pub fn short(&self) -> String {
+        format!(
+            "{}|{}|{}|{}",
+            self.chunk_type,
+            self.waveform,
+            self.channel,
+            if self.first_in_sweep { "T" } else { "F" }
+        )
+    }
+
+    pub fn from_characteristics(c: &ChunkCharacteristics) -> Self {
+        Self {
+            chunk_type: chunk_type_str(c.chunk_type),
+            waveform: waveform_str(c.waveform_type),
+            channel: channel_str(c.channel_configuration),
+            first_in_sweep: c.is_first_in_sweep,
+        }
+    }
+}
+
+fn chunk_type_str(t: ChunkType) -> &'static str {
+    match t {
+        ChunkType::Start => "S",
+        ChunkType::Intermediate => "I",
+        ChunkType::End => "E",
+    }
+}
+
+fn waveform_str(w: WaveformType) -> &'static str {
+    match w {
+        WaveformType::CS => "CS",
+        WaveformType::CDW => "CDW",
+        WaveformType::CDWO => "CDWO",
+        WaveformType::B => "B",
+        WaveformType::SPP => "SPP",
+        WaveformType::Unknown => "?",
+    }
+}
+
+fn channel_str(c: ChannelConfiguration) -> &'static str {
+    match c {
+        ChannelConfiguration::ConstantPhase => "CP",
+        ChannelConfiguration::RandomPhase => "RP",
+        ChannelConfiguration::SZ2Phase => "SZ2",
+        ChannelConfiguration::UnknownPhase => "?",
+    }
 }
 
 impl ChunkArrivalStat {
@@ -171,30 +261,11 @@ impl ChunkArrivalStat {
         self.predicted_available_at.map(|p| self.success_at - p)
     }
 
-    /// Milliseconds between when we intended to wake and when we actually
-    /// polled — the scheduler's precision relative to the prediction.
-    pub fn scheduler_slop_ms(&self) -> Option<f64> {
-        self.predicted_available_at
-            .map(|p| (self.scheduled_at - p) * 1000.0)
-    }
-
     /// Time between the last empty poll and the successful download.
     /// Represents wait that could potentially have been avoided if the
     /// poll schedule were better aligned to S3 publishing time.
     pub fn wait_after_last_empty_ms(&self) -> Option<f64> {
         self.last_empty_poll_at
-            .map(|t| (self.success_at - t) * 1000.0)
-    }
-
-    /// Time between S3's `Last-Modified` and our successful download.
-    /// Unlike `wait_after_last_empty_ms`, this tries to be authoritative
-    /// (the object was provably available at `s3_last_modified_at`), but
-    /// `Last-Modified` has 1-second resolution so individual values carry
-    /// ±1 s of quantization noise — including sign flips. Magnitudes
-    /// smaller than 1000 ms are indistinguishable from zero; treat only
-    /// `|wait| > 1000 ms` as real client-side wait (or real clock skew).
-    pub fn wait_after_s3_publish_ms(&self) -> Option<f64> {
-        self.s3_last_modified_at
             .map(|t| (self.success_at - t) * 1000.0)
     }
 }

--- a/src/state/vcp_position.rs
+++ b/src/state/vcp_position.rs
@@ -131,12 +131,12 @@ impl VcpPositionModel {
         // Prefer the library's physics-based projection, fall back to measured/estimated.
         let expected_dur = live.last_volume_duration_secs.unwrap_or(300.0);
         let volume_end = live
-            .projected_volume_end_secs
+            .projected_volume_end_available_at_secs
             .unwrap_or(vol_start + expected_dur);
 
         // ── Build projected sweep bounds from library projections ──────
         // Group ChunkProjectionInfo by elevation_number to get per-sweep timing.
-        // Only chunks with projected_time_secs contribute to projected bounds.
+        // Only chunks with projected_available_at_secs contribute to projected bounds.
         let projected_sweeps: Option<std::collections::BTreeMap<u8, ProjectedSweepBounds>> =
             live.chunk_projections.as_ref().map(|projections| {
                 let mut map: std::collections::BTreeMap<u8, ProjectedSweepBounds> =
@@ -151,7 +151,7 @@ impl VcpPositionModel {
                             chunk_count: 0,
                         });
                         entry.chunk_count += 1;
-                        if let Some(t) = chunk.projected_time_secs {
+                        if let Some(t) = chunk.projected_available_at_secs {
                             entry.min_time = entry.min_time.min(t);
                             entry.max_time = entry.max_time.max(t);
                         }

--- a/src/state/vcp_position.rs
+++ b/src/state/vcp_position.rs
@@ -128,15 +128,18 @@ impl VcpPositionModel {
         let vcp_number = live.current_vcp_number.unwrap_or(0);
 
         // ── Volume end time ───────────────────────────────────────────
-        // Prefer the library's physics-based projection, fall back to measured/estimated.
+        // COLLECTION time — right edge of the in-progress volume on the
+        // timeline is when the radar finishes scanning, not when the final
+        // chunk uploads.
         let expected_dur = live.last_volume_duration_secs.unwrap_or(300.0);
         let volume_end = live
-            .projected_volume_end_available_at_secs
+            .projected_volume_end_collection_secs
             .unwrap_or(vol_start + expected_dur);
 
         // ── Build projected sweep bounds from library projections ──────
-        // Group ChunkProjectionInfo by elevation_number to get per-sweep timing.
-        // Only chunks with projected_available_at_secs contribute to projected bounds.
+        // Sweep bounds are COLLECTION times (when the radar will physically
+        // scan), so timeline placeholders line up with the in-progress
+        // sweep's own collection-time axis.
         let projected_sweeps: Option<std::collections::BTreeMap<u8, ProjectedSweepBounds>> =
             live.chunk_projections.as_ref().map(|projections| {
                 let mut map: std::collections::BTreeMap<u8, ProjectedSweepBounds> =
@@ -151,7 +154,7 @@ impl VcpPositionModel {
                             chunk_count: 0,
                         });
                         entry.chunk_count += 1;
-                        if let Some(t) = chunk.projected_available_at_secs {
+                        if let Some(t) = chunk.projected_collection_time_secs {
                             entry.min_time = entry.min_time.min(t);
                             entry.max_time = entry.max_time.max(t);
                         }

--- a/src/ui/bottom_panel.rs
+++ b/src/ui/bottom_panel.rs
@@ -76,6 +76,23 @@ pub fn render_bottom_panel(ctx: &egui::Context, state: &mut AppState) {
             PlaybackMode::Macro => state.playback_state.advance_macro(dt as f64),
         }
 
+        // In real-time streaming mode, keep the playhead on-screen. Pan/zoom is
+        // otherwise free; this only fires when "now" would fall outside the
+        // visible range, scrolling the view minimally to put it at the edge.
+        if state.live_mode_state.is_active() {
+            let view_width = state.playback_state.view_width_secs();
+            if view_width > 0.0 {
+                let now = state.playback_state.playback_position();
+                let view_start = state.playback_state.timeline_view_start;
+                let view_end = view_start + view_width;
+                if now > view_end {
+                    state.playback_state.timeline_view_start = now - view_width;
+                } else if now < view_start {
+                    state.playback_state.timeline_view_start = now;
+                }
+            }
+        }
+
         // Repaint at 30 FPS while playing — smooth for continuous micro-mode
         // advances and well above the 1–15 FPS frame cadence macro mode emits.
         ctx.request_repaint_after(std::time::Duration::from_millis(33));

--- a/src/ui/bottom_panel.rs
+++ b/src/ui/bottom_panel.rs
@@ -76,21 +76,6 @@ pub fn render_bottom_panel(ctx: &egui::Context, state: &mut AppState) {
             PlaybackMode::Macro => state.playback_state.advance_macro(dt as f64),
         }
 
-        // Pin playback position on the visible timeline during playback.
-        // In live/real-time mode, pin at 75% from left (right quarter) so more
-        // history is visible. In archive playback, pin at 25% from left.
-        let view_width_secs = state.playback_state.view_width_secs();
-        if view_width_secs > 0.0 {
-            let pin_fraction = if state.live_mode_state.is_active() {
-                0.75
-            } else {
-                0.25
-            };
-            let target_offset = view_width_secs * pin_fraction;
-            let pos = state.playback_state.playback_position();
-            state.playback_state.timeline_view_start = pos - target_offset;
-        }
-
         // Repaint at 30 FPS while playing — smooth for continuous micro-mode
         // advances and well above the 1–15 FPS frame cadence macro mode emits.
         ctx.request_repaint_after(std::time::Duration::from_millis(33));

--- a/src/ui/bottom_panel.rs
+++ b/src/ui/bottom_panel.rs
@@ -98,7 +98,10 @@ pub fn render_bottom_panel(ctx: &egui::Context, state: &mut AppState) {
         ctx.request_repaint_after(std::time::Duration::from_millis(33));
     }
 
-    let drawer_expanded = state.acquisition.drawer_expanded;
+    // The acquisition drawer is reachable only via the dev-mode-only network
+    // metric label. Force it closed when dev mode is off so a previously
+    // expanded drawer doesn't linger after the user toggles dev off.
+    let drawer_expanded = state.dev_mode && state.acquisition.drawer_expanded;
     let controls_height = 104.0;
     let top_bar_height = 36.0;
     let min_central_height = 100.0;

--- a/src/ui/canvas.rs
+++ b/src/ui/canvas.rs
@@ -439,21 +439,6 @@ fn compute_gpu_sweep_state(
         None
     };
 
-    // Debug: log gpu_sweep once per change
-    if state.live_radar_model.active {
-        if let Some((az, start)) = gpu_sweep {
-            let prev_cache = state.viz_state.last_sweep_line_cache;
-            if prev_cache.is_none_or(|(pa, ps)| (pa - az).abs() > 1.0 || (ps - start).abs() > 1.0) {
-                log::debug!(
-                    "gpu_sweep live: az={:.1} start={:.1} swept_arc={:.1}",
-                    az,
-                    start,
-                    ((az - start) % 360.0 + 360.0) % 360.0,
-                );
-            }
-        }
-    }
-
     // Cache sweep position for between-sweep display
     if let Some((az, start)) = gpu_sweep {
         if az != 0.0 || start != 0.0 {

--- a/src/ui/canvas.rs
+++ b/src/ui/canvas.rs
@@ -121,6 +121,7 @@ pub fn render_canvas_with_geo(
                         &projection,
                         state.viz_state.zoom,
                         state.layer_state.geo.labels,
+                        crate::geo::GeoPass::Lines,
                     );
                 }
 
@@ -129,6 +130,7 @@ pub fn render_canvas_with_geo(
                     &projection,
                     &state.viz_state.site_id,
                     &state.layer_state.geo,
+                    crate::geo::GeoPass::Lines,
                 );
 
                 let sweep_info = compute_sweep_line_azimuth(state);
@@ -187,6 +189,29 @@ pub fn render_canvas_with_geo(
                 if state.layer_state.geo.alerts && !state.alerts.alerts.is_empty() {
                     render_alerts(&painter, &projection, &state.alerts.alerts);
                 }
+
+                // Labels pass: draw on top of radar + alerts so text stays
+                // legible over bright reflectivity fills. Halo-stroked inside
+                // the renderer for contrast.
+                if let Some(layers) = geo_layers {
+                    crate::geo::render_geo_layers(
+                        &painter,
+                        layers,
+                        &state.layer_state.geo,
+                        &projection,
+                        state.viz_state.zoom,
+                        state.layer_state.geo.labels,
+                        crate::geo::GeoPass::Labels,
+                    );
+                }
+
+                render_nexrad_sites(
+                    &painter,
+                    &projection,
+                    &state.viz_state.site_id,
+                    &state.layer_state.geo,
+                    crate::geo::GeoPass::Labels,
+                );
 
                 if state.viz_state.storm_cells_visible
                     && !state.viz_state.detected_storm_cells.is_empty()

--- a/src/ui/canvas.rs
+++ b/src/ui/canvas.rs
@@ -78,6 +78,29 @@ pub fn render_canvas_with_geo(
                 // the projection.
                 state.viz_state.last_visible_bounds = Some(projection.visible_bounds());
 
+                // Camera-motion tracking for the label-tier debounce. The
+                // projection fingerprint changes whenever pan, zoom, center,
+                // or rect changes; we record the time of last change and
+                // expose `camera_settled` so the label cache only rebuilds
+                // after motion has stopped for `SETTLE_WINDOW_SECS`.
+                let now_secs = js_sys::Date::now() / 1000.0;
+                state
+                    .render_cache
+                    .camera_motion
+                    .observe(projection.fingerprint(), now_secs);
+                let camera_settled = state.render_cache.camera_motion.is_settled(now_secs);
+                // Schedule exactly one wake-up at the settle moment so the
+                // label tier rebuilds on time even when nothing else is
+                // animating. No-op if already settled.
+                if let Some(remaining) =
+                    state.render_cache.camera_motion.time_until_settle(now_secs)
+                {
+                    ui.ctx()
+                        .request_repaint_after(std::time::Duration::from_millis(
+                            (remaining * 1000.0).ceil().max(1.0) as u64,
+                        ));
+                }
+
                 // Screen-space cutout circle for the active radar's coverage.
                 // Fixed at the WSR-88D reflectivity range so the hole stays
                 // stable as the user scrubs elevations/products instead of
@@ -122,6 +145,8 @@ pub fn render_canvas_with_geo(
                         state.viz_state.zoom,
                         state.layer_state.geo.labels,
                         crate::geo::GeoPass::Lines,
+                        dark,
+                        camera_settled,
                     );
                 }
 
@@ -202,6 +227,8 @@ pub fn render_canvas_with_geo(
                         state.viz_state.zoom,
                         state.layer_state.geo.labels,
                         crate::geo::GeoPass::Labels,
+                        dark,
+                        camera_settled,
                     );
                 }
 

--- a/src/ui/canvas.rs
+++ b/src/ui/canvas.rs
@@ -131,10 +131,6 @@ pub fn render_canvas_with_geo(
                     &state.layer_state.geo,
                 );
 
-                if state.layer_state.geo.alerts && !state.alerts.alerts.is_empty() {
-                    render_alerts(&painter, &projection, &state.alerts.alerts);
-                }
-
                 let sweep_info = compute_sweep_line_azimuth(state);
                 let (gpu_sweep, between_sweeps) = compute_gpu_sweep_state(state, sweep_info);
 
@@ -186,6 +182,10 @@ pub fn render_canvas_with_geo(
                         ui.ctx()
                             .request_repaint_after(std::time::Duration::from_millis(100));
                     }
+                }
+
+                if state.layer_state.geo.alerts && !state.alerts.alerts.is_empty() {
+                    render_alerts(&painter, &projection, &state.alerts.alerts);
                 }
 
                 if state.viz_state.storm_cells_visible

--- a/src/ui/canvas_overlays/alerts.rs
+++ b/src/ui/canvas_overlays/alerts.rs
@@ -22,6 +22,10 @@ pub(crate) fn render_alerts(painter: &Painter, projection: &MapProjection, alert
         .collect();
     ordered.sort_by_key(|a| a.severity.rank());
 
+    // Slightly wider black halo underneath so colored strokes stay legible
+    // against bright radar fills.
+    let halo_stroke = Stroke::new(4.5, Color32::BLACK);
+
     for alert in ordered {
         let (r, g, b) = alert.severity.color();
         let stroke_color = Color32::from_rgba_unmultiplied(r, g, b, 220);
@@ -42,6 +46,7 @@ pub(crate) fn render_alerts(painter: &Painter, projection: &MapProjection, alert
                 if ring.len() < 3 {
                     continue;
                 }
+                painter.add(Shape::closed_line(ring.clone(), halo_stroke));
                 painter.add(Shape::closed_line(ring.clone(), stroke));
             }
         }

--- a/src/ui/canvas_overlays/alerts.rs
+++ b/src/ui/canvas_overlays/alerts.rs
@@ -1,8 +1,7 @@
 //! NWS alerts canvas overlay.
 //!
 //! Draws the polygon footprints of every alert whose bounding box intersects
-//! the currently visible area. Each polygon is filled with a transparent
-//! severity color and outlined with a solid stroke.
+//! the currently visible area as a severity-colored outline.
 //!
 //! Only runs in 2D flat mode.
 
@@ -25,9 +24,8 @@ pub(crate) fn render_alerts(painter: &Painter, projection: &MapProjection, alert
 
     for alert in ordered {
         let (r, g, b) = alert.severity.color();
-        let fill = Color32::from_rgba_unmultiplied(r, g, b, 48);
         let stroke_color = Color32::from_rgba_unmultiplied(r, g, b, 220);
-        let stroke = Stroke::new(1.5, stroke_color);
+        let stroke = Stroke::new(2.5, stroke_color);
 
         for polygon in &alert.geometry.polygons {
             // Project all rings once.
@@ -40,28 +38,11 @@ pub(crate) fn render_alerts(painter: &Painter, projection: &MapProjection, alert
                 })
                 .collect();
 
-            let Some(outer) = projected_rings.first() else {
-                continue;
-            };
-            if outer.len() < 3 {
-                continue;
-            }
-
-            // Filled outline — use a closed path with a tinted fill. egui's
-            // convex_polygon handles non-convex rings reasonably well for
-            // visualization purposes; self-intersecting rings are very rare
-            // in NWS alert data and if they occur, the fill will still give
-            // a meaningful visual indication.
-            painter.add(Shape::convex_polygon(outer.clone(), fill, Stroke::NONE));
-            painter.add(Shape::closed_line(outer.clone(), stroke));
-
-            // Hole rings: draw outline only so the user can see the cutout
-            // even though we don't actually subtract it from the fill.
-            for hole in projected_rings.iter().skip(1) {
-                if hole.len() < 3 {
+            for ring in &projected_rings {
+                if ring.len() < 3 {
                     continue;
                 }
-                painter.add(Shape::closed_line(hole.clone(), stroke));
+                painter.add(Shape::closed_line(ring.clone(), stroke));
             }
         }
     }

--- a/src/ui/canvas_overlays/info.rs
+++ b/src/ui/canvas_overlays/info.rs
@@ -2,6 +2,12 @@
 //!
 //! Displays the current site and product at top, followed by symmetric
 //! "Current" and "Previous" sections showing elevation, time, and age.
+//!
+//! INVARIANT: every time/age value shown here is ACTUAL — derived from
+//! real radial collection timestamps (via `viz_state.timestamp` and
+//! `data_staleness_*`) and the wall clock. No projected collection or
+//! availability times reach the canvas; principle 1 of the timing model
+//! requires the canvas and current-time indicator to show only actuals.
 
 use crate::state::AppState;
 use eframe::egui::{self, Color32, Rect, RichText, Vec2};

--- a/src/ui/canvas_overlays/sites.rs
+++ b/src/ui/canvas_overlays/sites.rs
@@ -5,7 +5,7 @@
 //! highlighted; off-screen sites are culled for performance.
 
 use crate::data::{get_site, NEXRAD_SITES};
-use crate::geo::MapProjection;
+use crate::geo::{text_with_halo, GeoPass, MapProjection};
 use crate::state::GeoLayerVisibility;
 use eframe::egui::{self, Painter, Stroke, Vec2};
 use geo_types::Coord;
@@ -17,6 +17,7 @@ pub(crate) fn render_nexrad_sites(
     projection: &MapProjection,
     current_site_id: &str,
     visibility: &GeoLayerVisibility,
+    pass: GeoPass,
 ) {
     let current_site_id_upper = current_site_id.to_uppercase();
     let (min_lon, min_lat, max_lon, max_lat) = projection.visible_bounds();
@@ -41,17 +42,27 @@ pub(crate) fn render_nexrad_sites(
                 y: site.lat,
             });
 
-            painter.circle_filled(screen_pos, 4.0, site_colors::OTHER);
-            painter.circle_stroke(screen_pos, 4.0, Stroke::new(1.0, site_colors::OTHER_STROKE));
-
-            if visibility.labels {
-                painter.text(
-                    screen_pos + Vec2::new(6.0, -2.0),
-                    egui::Align2::LEFT_CENTER,
-                    site.id,
-                    egui::FontId::proportional(10.0),
-                    site_colors::LABEL,
-                );
+            match pass {
+                GeoPass::Lines => {
+                    painter.circle_filled(screen_pos, 4.0, site_colors::OTHER);
+                    painter.circle_stroke(
+                        screen_pos,
+                        4.0,
+                        Stroke::new(1.0, site_colors::OTHER_STROKE),
+                    );
+                }
+                GeoPass::Labels => {
+                    if visibility.labels {
+                        text_with_halo(
+                            painter,
+                            screen_pos + Vec2::new(6.0, -2.0),
+                            egui::Align2::LEFT_CENTER,
+                            site.id,
+                            egui::FontId::proportional(10.0),
+                            site_colors::LABEL,
+                        );
+                    }
+                }
             }
         }
     }
@@ -62,19 +73,25 @@ pub(crate) fn render_nexrad_sites(
             y: site.lat,
         });
 
-        painter.circle_filled(screen_pos, 6.0, site_colors::CURRENT);
-        painter.circle_stroke(
-            screen_pos,
-            6.0,
-            Stroke::new(1.5, site_colors::CURRENT_STROKE),
-        );
-
-        painter.text(
-            screen_pos + Vec2::new(8.0, -2.0),
-            egui::Align2::LEFT_CENTER,
-            site.id,
-            egui::FontId::proportional(11.0),
-            site_colors::CURRENT_LABEL,
-        );
+        match pass {
+            GeoPass::Lines => {
+                painter.circle_filled(screen_pos, 6.0, site_colors::CURRENT);
+                painter.circle_stroke(
+                    screen_pos,
+                    6.0,
+                    Stroke::new(1.5, site_colors::CURRENT_STROKE),
+                );
+            }
+            GeoPass::Labels => {
+                text_with_halo(
+                    painter,
+                    screen_pos + Vec2::new(8.0, -2.0),
+                    egui::Align2::LEFT_CENTER,
+                    site.id,
+                    egui::FontId::proportional(11.0),
+                    site_colors::CURRENT_LABEL,
+                );
+            }
+        }
     }
 }

--- a/src/ui/canvas_overlays/sweep.rs
+++ b/src/ui/canvas_overlays/sweep.rs
@@ -11,8 +11,85 @@ use crate::geo::MapProjection;
 use crate::nexrad::RADAR_COVERAGE_RANGE_KM;
 use crate::state::AppState;
 use eframe::egui::{self, Color32, Painter, Pos2, Rect, Stroke, Vec2};
+use eframe::epaint::Galley;
 use geo_types::Coord;
+use std::cell::RefCell;
 use std::f32::consts::PI;
+use std::sync::Arc;
+
+/// Cached range-ring lon-degree extent for the active site. The km→deg
+/// conversion is invariant under pan/zoom — only `(site_lat, site_lon,
+/// range_km)` matter. Recomputing it each frame is cheap, but caching means
+/// no trig per-frame and no allocation. Keyed on bit-pattern equality so
+/// continuous playback with constant lat/lon hits the cache exactly.
+#[derive(Default)]
+struct RangeRingCache {
+    /// `(lat_bits, lon_bits, range_km_bits)` of the most recent compute.
+    key: Option<(u64, u64, u64)>,
+    /// Cached lon-range in degrees corresponding to `range_km`.
+    lon_range_deg: f64,
+}
+
+thread_local! {
+    static RANGE_RING_CACHE: RefCell<RangeRingCache> = RefCell::new(RangeRingCache::default());
+}
+
+fn cached_lon_range_deg(lat: f64, lon: f64, range_km: f64) -> f64 {
+    let key = (lat.to_bits(), lon.to_bits(), range_km.to_bits());
+    RANGE_RING_CACHE.with(|c| {
+        let mut cache = c.borrow_mut();
+        if cache.key == Some(key) {
+            return cache.lon_range_deg;
+        }
+        let km_to_deg = 1.0 / 111.0;
+        let lat_correction = lat.to_radians().cos();
+        let v = range_km * km_to_deg / lat_correction;
+        cache.key = Some(key);
+        cache.lon_range_deg = v;
+        v
+    })
+}
+
+/// Cached cardinal direction galleys (N, E, S, W). The font + color are
+/// fixed; the only thing that changes is theme. Build once per (font_size,
+/// dark) and reuse.
+#[derive(Default)]
+struct CardinalGalleyCache {
+    key: Option<(u32, bool)>, // (font_size_bits, dark)
+    galleys: Option<[Arc<Galley>; 4]>,
+}
+
+thread_local! {
+    static CARDINAL_GALLEY_CACHE: RefCell<CardinalGalleyCache> =
+        RefCell::new(CardinalGalleyCache::default());
+}
+
+fn cached_cardinal_galleys(
+    painter: &Painter,
+    font_size: f32,
+    color: Color32,
+    dark: bool,
+) -> [Arc<Galley>; 4] {
+    let key = (font_size.to_bits(), dark);
+    CARDINAL_GALLEY_CACHE.with(|c| {
+        let mut cache = c.borrow_mut();
+        if cache.key == Some(key) {
+            if let Some(ref g) = cache.galleys {
+                return g.clone();
+            }
+        }
+        let font = egui::FontId::proportional(font_size);
+        let g = [
+            painter.layout_no_wrap("N".to_string(), font.clone(), color),
+            painter.layout_no_wrap("E".to_string(), font.clone(), color),
+            painter.layout_no_wrap("S".to_string(), font.clone(), color),
+            painter.layout_no_wrap("W".to_string(), font, color),
+        ];
+        cache.key = Some(key);
+        cache.galleys = Some(g.clone());
+        g
+    })
+}
 
 pub(crate) fn render_radar_sweep(
     painter: &Painter,
@@ -31,11 +108,11 @@ pub(crate) fn render_radar_sweep(
         y: radar_lat,
     });
 
-    // Compute radius in screen pixels for the coverage range
-    let range_km = RADAR_COVERAGE_RANGE_KM;
-    let km_to_deg = 1.0 / 111.0;
-    let lat_correction = radar_lat.to_radians().cos();
-    let lon_range = range_km * km_to_deg / lat_correction;
+    // Compute radius in screen pixels for the coverage range. The
+    // km→deg conversion is invariant under pan/zoom — cached behind a
+    // thread-local so changing the projection alone doesn't redo the
+    // trig.
+    let lon_range = cached_lon_range_deg(radar_lat, radar_lon, RADAR_COVERAGE_RANGE_KM);
 
     let edge = projection.geo_to_screen(Coord {
         x: radar_lon + lon_range,
@@ -71,39 +148,23 @@ pub(crate) fn render_radar_sweep(
         );
     }
 
-    // Draw cardinal direction labels
+    // Draw cardinal direction labels using cached galleys to skip the
+    // text layout each frame.
     let label_offset = radius + 15.0;
-    let font_id = egui::FontId::proportional(12.0);
     let cardinal_color = canvas_colors::cardinal_label(dark);
-
-    painter.text(
-        center + Vec2::new(0.0, -label_offset),
-        egui::Align2::CENTER_BOTTOM,
-        "N",
-        font_id.clone(),
-        cardinal_color,
-    );
-    painter.text(
-        center + Vec2::new(label_offset, 0.0),
-        egui::Align2::LEFT_CENTER,
-        "E",
-        font_id.clone(),
-        cardinal_color,
-    );
-    painter.text(
-        center + Vec2::new(0.0, label_offset),
-        egui::Align2::CENTER_TOP,
-        "S",
-        font_id.clone(),
-        cardinal_color,
-    );
-    painter.text(
-        center + Vec2::new(-label_offset, 0.0),
-        egui::Align2::RIGHT_CENTER,
-        "W",
-        font_id,
-        cardinal_color,
-    );
+    let cardinals = cached_cardinal_galleys(painter, 12.0, cardinal_color, dark);
+    let cardinal_specs: [(Vec2, egui::Align2); 4] = [
+        (Vec2::new(0.0, -label_offset), egui::Align2::CENTER_BOTTOM),
+        (Vec2::new(label_offset, 0.0), egui::Align2::LEFT_CENTER),
+        (Vec2::new(0.0, label_offset), egui::Align2::CENTER_TOP),
+        (Vec2::new(-label_offset, 0.0), egui::Align2::RIGHT_CENTER),
+    ];
+    for (galley, (offset, align)) in cardinals.iter().zip(cardinal_specs.iter()) {
+        let anchor = center + *offset;
+        let size = galley.size();
+        let pos = align_pos(anchor, size, *align);
+        painter.galley(pos, galley.clone(), cardinal_color);
+    }
 
     // Draw center marker (radar site)
     painter.circle_filled(center, 4.0, canvas_colors::center_marker(dark));

--- a/src/ui/playback_controls.rs
+++ b/src/ui/playback_controls.rs
@@ -536,75 +536,79 @@ fn render_session_stats(ui: &mut egui::Ui, state: &mut AppState) {
     let transferred = state.session_stats.format_transferred();
     let cache_size = state.session_stats.format_cache_size();
 
-    if let Some(fps) = fps {
-        ui.label(
-            RichText::new(format!("{:.0} fps", fps))
-                .size(11.0)
-                .color(ui_colors::value(dark)),
-        );
-        ui.separator();
-    }
-
-    // Pipeline status — clickable phase boxes open detail modal
-    render_pipeline_indicator(ui, state);
-
-    // Download group: requests + transferred
-    // Use service worker aggregate if available, otherwise fall back to channel stats
-    let sw_total = state.network_aggregate.total_requests;
-    let (display_count, display_transferred) = if sw_total > 0 {
-        (
-            sw_total,
-            crate::state::format_bytes(state.network_aggregate.total_bytes),
-        )
-    } else {
-        (request_count, transferred)
-    };
-
-    if active_count > 0 {
-        ui.label(
-            RichText::new(format!("({} active)", active_count))
-                .size(10.0)
-                .italics()
-                .color(ui_colors::ACTIVE),
-        );
-    }
-    if display_count > 0 {
-        // Clickable to toggle acquisition drawer (subsumes network log modal)
-        let queued = state.acquisition.queued_count();
-        let req_text = if queued > 0 {
-            format!("{}r / {} | {}q", display_count, display_transferred, queued)
-        } else {
-            format!("{}r / {}", display_count, display_transferred)
-        };
-
-        let drawer_icon = if state.acquisition.drawer_expanded {
-            egui_phosphor::regular::CARET_DOWN
-        } else {
-            egui_phosphor::regular::CARET_UP
-        };
-
-        if ui
-            .add(
-                egui::Label::new(
-                    RichText::new(format!("{} {}", drawer_icon, req_text))
-                        .size(10.0)
-                        .color(ui_colors::value(dark)),
-                )
-                .sense(egui::Sense::click()),
-            )
-            .on_hover_text("Click to toggle acquisition drawer")
-            .clicked()
-        {
-            state.acquisition.drawer_expanded = !state.acquisition.drawer_expanded;
+    // FPS, pipeline indicator, network metrics, and COI badge are all
+    // dev-mode-only diagnostics — hidden by default.
+    if state.dev_mode {
+        if let Some(fps) = fps {
+            ui.label(
+                RichText::new(format!("{:.0} fps", fps))
+                    .size(11.0)
+                    .color(ui_colors::value(dark)),
+            );
+            ui.separator();
         }
-        ui.separator();
-    }
 
-    // Cross-origin isolation indicator
-    if state.cross_origin_isolated {
-        ui.label(RichText::new("COI").size(9.0).color(ui_colors::SUCCESS))
-            .on_hover_text("Cross-Origin Isolated: SharedArrayBuffer available");
-        ui.separator();
+        // Pipeline status — clickable phase boxes open detail modal
+        render_pipeline_indicator(ui, state);
+
+        // Download group: requests + transferred
+        // Use service worker aggregate if available, otherwise fall back to channel stats
+        let sw_total = state.network_aggregate.total_requests;
+        let (display_count, display_transferred) = if sw_total > 0 {
+            (
+                sw_total,
+                crate::state::format_bytes(state.network_aggregate.total_bytes),
+            )
+        } else {
+            (request_count, transferred)
+        };
+
+        if active_count > 0 {
+            ui.label(
+                RichText::new(format!("({} active)", active_count))
+                    .size(10.0)
+                    .italics()
+                    .color(ui_colors::ACTIVE),
+            );
+        }
+        if display_count > 0 {
+            // Clickable to toggle acquisition drawer (subsumes network log modal)
+            let queued = state.acquisition.queued_count();
+            let req_text = if queued > 0 {
+                format!("{}r / {} | {}q", display_count, display_transferred, queued)
+            } else {
+                format!("{}r / {}", display_count, display_transferred)
+            };
+
+            let drawer_icon = if state.acquisition.drawer_expanded {
+                egui_phosphor::regular::CARET_DOWN
+            } else {
+                egui_phosphor::regular::CARET_UP
+            };
+
+            if ui
+                .add(
+                    egui::Label::new(
+                        RichText::new(format!("{} {}", drawer_icon, req_text))
+                            .size(10.0)
+                            .color(ui_colors::value(dark)),
+                    )
+                    .sense(egui::Sense::click()),
+                )
+                .on_hover_text("Click to toggle acquisition drawer")
+                .clicked()
+            {
+                state.acquisition.drawer_expanded = !state.acquisition.drawer_expanded;
+            }
+            ui.separator();
+        }
+
+        // Cross-origin isolation indicator
+        if state.cross_origin_isolated {
+            ui.label(RichText::new("COI").size(9.0).color(ui_colors::SUCCESS))
+                .on_hover_text("Cross-Origin Isolated: SharedArrayBuffer available");
+            ui.separator();
+        }
     }
 
     // Cache group: size with clear button

--- a/src/ui/right_panel.rs
+++ b/src/ui/right_panel.rs
@@ -39,7 +39,22 @@ pub fn render_right_panel(ctx: &egui::Context, state: &mut AppState) {
                 ui.add_space(5.0);
 
                 render_storage_section(ui, state);
+                ui.add_space(5.0);
+
+                render_developer_section(ui, state);
             });
+        });
+}
+
+fn render_developer_section(ui: &mut egui::Ui, state: &mut AppState) {
+    egui::CollapsingHeader::new(RichText::new("Developer").strong())
+        .default_open(false)
+        .show(ui, |ui| {
+            ui.checkbox(&mut state.dev_mode, "Developer mode")
+                .on_hover_text(
+                    "Show network metrics, pipeline timings, FPS, and the COI badge \
+                     in the status bar. Adds ?dev=true to the URL when enabled.",
+                );
         });
 }
 

--- a/src/ui/site_modal.rs
+++ b/src/ui/site_modal.rs
@@ -9,6 +9,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::data::{all_sites_sorted, get_site, nearest_site};
+use crate::net::retry::{with_retry, Verdict, DEFAULT_POLICY};
 use crate::state::AppState;
 use eframe::egui::{self, Color32, RichText, Vec2};
 use wasm_bindgen::prelude::*;
@@ -175,51 +176,21 @@ fn start_zip_lookup(zip: &str, results: Rc<RefCell<Vec<LocationResult>>>, ctx: e
     let results = results.clone();
 
     wasm_bindgen_futures::spawn_local(async move {
-        let result = async {
-            let window = web_sys::window().ok_or("No browser window")?;
-            let resp_value = wasm_bindgen_futures::JsFuture::from(window.fetch_with_str(&url))
-                .await
-                .map_err(|_| "Network error looking up zip code".to_string())?;
-            let resp: web_sys::Response = resp_value
-                .dyn_into()
-                .map_err(|_| "Invalid response".to_string())?;
-
-            if !resp.ok() {
-                return Err("Zip code not found".to_string());
-            }
-
-            let json = wasm_bindgen_futures::JsFuture::from(
-                resp.json()
-                    .map_err(|_| "Failed to parse response".to_string())?,
-            )
+        let result: Result<(f64, f64), String> =
+            with_retry(&DEFAULT_POLICY, "zip_lookup", |_attempt| {
+                let url = url.clone();
+                async move { zip_lookup_attempt(&url).await }
+            })
             .await
-            .map_err(|_| "Failed to read response body".to_string())?;
-
-            // Zippopotam response: { "places": [{ "latitude": "...", "longitude": "..." }] }
-            let places = js_sys::Reflect::get(&json, &"places".into())
-                .map_err(|_| "Invalid response format".to_string())?;
-            let first = js_sys::Reflect::get_u32(&places, 0)
-                .map_err(|_| "No location data for zip code".to_string())?;
-
-            let lat_str = js_sys::Reflect::get(&first, &"latitude".into())
-                .map_err(|_| "Missing latitude".to_string())?
-                .as_string()
-                .ok_or("Invalid latitude")?;
-            let lon_str = js_sys::Reflect::get(&first, &"longitude".into())
-                .map_err(|_| "Missing longitude".to_string())?
-                .as_string()
-                .ok_or("Invalid longitude")?;
-
-            let lat: f64 = lat_str
-                .parse()
-                .map_err(|_| "Invalid latitude value".to_string())?;
-            let lon: f64 = lon_str
-                .parse()
-                .map_err(|_| "Invalid longitude value".to_string())?;
-
-            Ok((lat, lon))
-        }
-        .await;
+            .map_err(|msg| {
+                // Zippopotam returns 404 for invalid zips; surface a friendlier
+                // message than the raw HTTP status.
+                if msg.contains("HTTP 404") {
+                    "Zip code not found".to_string()
+                } else {
+                    msg
+                }
+            });
 
         match result {
             Ok((lat, lon)) => {
@@ -231,6 +202,77 @@ fn start_zip_lookup(zip: &str, results: Rc<RefCell<Vec<LocationResult>>>, ctx: e
         }
         ctx.request_repaint();
     });
+}
+
+/// One attempt against the Zippopotam.us API. Network errors and 5xx are
+/// retryable; 404 (invalid zip) and parse failures are terminal.
+async fn zip_lookup_attempt(url: &str) -> Verdict<(f64, f64)> {
+    let window = match web_sys::window() {
+        Some(w) => w,
+        None => return Verdict::Terminal("No browser window".into()),
+    };
+
+    let resp_value = match wasm_bindgen_futures::JsFuture::from(window.fetch_with_str(url)).await {
+        Ok(v) => v,
+        Err(_) => return Verdict::Retry { after: None },
+    };
+    let resp: web_sys::Response = match resp_value.dyn_into() {
+        Ok(r) => r,
+        Err(_) => return Verdict::Terminal("Invalid response".into()),
+    };
+
+    let status = resp.status();
+    if status == 408 || status == 429 || (500..=599).contains(&status) {
+        return Verdict::Retry { after: None };
+    }
+    if !resp.ok() {
+        return Verdict::Terminal(format!("HTTP {}", status));
+    }
+
+    let json_promise = match resp.json() {
+        Ok(p) => p,
+        Err(_) => return Verdict::Terminal("Failed to parse response".into()),
+    };
+    let json = match wasm_bindgen_futures::JsFuture::from(json_promise).await {
+        Ok(v) => v,
+        Err(_) => return Verdict::Retry { after: None },
+    };
+
+    // Zippopotam response: { "places": [{ "latitude": "...", "longitude": "..." }] }
+    let places = match js_sys::Reflect::get(&json, &"places".into()) {
+        Ok(p) => p,
+        Err(_) => return Verdict::Terminal("Invalid response format".into()),
+    };
+    let first = match js_sys::Reflect::get_u32(&places, 0) {
+        Ok(f) => f,
+        Err(_) => return Verdict::Terminal("No location data for zip code".into()),
+    };
+
+    let lat_str = match js_sys::Reflect::get(&first, &"latitude".into()) {
+        Ok(v) => match v.as_string() {
+            Some(s) => s,
+            None => return Verdict::Terminal("Invalid latitude".into()),
+        },
+        Err(_) => return Verdict::Terminal("Missing latitude".into()),
+    };
+    let lon_str = match js_sys::Reflect::get(&first, &"longitude".into()) {
+        Ok(v) => match v.as_string() {
+            Some(s) => s,
+            None => return Verdict::Terminal("Invalid longitude".into()),
+        },
+        Err(_) => return Verdict::Terminal("Missing longitude".into()),
+    };
+
+    let lat: f64 = match lat_str.parse() {
+        Ok(v) => v,
+        Err(_) => return Verdict::Terminal("Invalid latitude value".into()),
+    };
+    let lon: f64 = match lon_str.parse() {
+        Ok(v) => v,
+        Err(_) => return Verdict::Terminal("Invalid longitude value".into()),
+    };
+
+    Verdict::Ok((lat, lon))
 }
 
 /// Render the site selection modal if open.

--- a/src/ui/stats_modal.rs
+++ b/src/ui/stats_modal.rs
@@ -12,6 +12,12 @@ pub fn render_stats_modal(ctx: &egui::Context, state: &mut AppState) {
     if !state.stats_detail_open {
         return;
     }
+    // The modal is only reachable from the dev-mode pipeline indicator.
+    // If dev mode was disabled while it was open, close it silently.
+    if !state.dev_mode {
+        state.stats_detail_open = false;
+        return;
+    }
 
     if super::modal_helper::modal_backdrop(ctx, "stats_modal_backdrop", 160) {
         state.stats_detail_open = false;

--- a/src/ui/timeline/interaction.rs
+++ b/src/ui/timeline/interaction.rs
@@ -1,6 +1,6 @@
 //! Timeline interaction: click, shift+click, drag-to-pan, scroll-to-zoom.
 
-use crate::state::{AppState, LiveExitReason, MICRO_ZOOM_THRESHOLD};
+use crate::state::{AppState, LiveExitReason};
 use eframe::egui::{self, Rect};
 
 /// Handle mouse interaction on the timeline: click, shift+click, drag-to-pan, scroll-to-zoom.
@@ -86,14 +86,7 @@ pub(super) fn handle_timeline_interaction(
         if scroll_delta.y != 0.0 {
             let zoom_factor = 1.0 + scroll_delta.y as f64 * 0.002;
             let old_zoom = state.playback_state.timeline_zoom;
-            // In live mode, never let the user zoom out past micro-mode — they
-            // must be able to see individual sweeps and chunks.
-            let min_zoom = if state.live_mode_state.is_active() {
-                MICRO_ZOOM_THRESHOLD
-            } else {
-                0.000001
-            };
-            let new_zoom = (old_zoom * zoom_factor).clamp(min_zoom, 1000.0);
+            let new_zoom = (old_zoom * zoom_factor).clamp(0.000001, 1000.0);
 
             if let Some(cursor_pos) = response.hover_pos() {
                 let cursor_ts = view_start + (cursor_pos.x - full_rect.left()) as f64 / old_zoom;

--- a/src/ui/vcp_forecast_modal.rs
+++ b/src/ui/vcp_forecast_modal.rs
@@ -196,7 +196,7 @@ fn render_snapshot(
                 .show(ui, |ui| {
                     for header in [
                         "elv", "ang", "wf", "used", "src", "pred_dur", "act_dur", "Δdur",
-                        "pred_ch", "act_ch", "Δch", "timing", "status",
+                        "Δstart", "pred_ch", "act_ch", "Δch", "timing", "status",
                     ] {
                         ui.label(
                             RichText::new(header)
@@ -287,8 +287,21 @@ fn render_snapshot(
                 if let Some((mean, median, max_abs)) = stats_on(&pred_errs) {
                     kv(
                         ui,
-                        "Chunk pred error (success − predicted)",
+                        "Chunk pred error (avail-space)",
                         &format!("mean {mean:+.2}s  median {median:+.2}s  max|{max_abs:.2}s|"),
+                        label_color,
+                        value_color,
+                    );
+                }
+                let interval_errs_ms = collect_interval_errors_ms(arrivals);
+                if let Some((mean, median, max_abs)) = stats_on(&interval_errs_ms) {
+                    kv(
+                        ui,
+                        "Interval err (collection-space, +ve = underestimated)",
+                        &format!(
+                            "mean {mean:+.0}ms  median {median:+.0}ms  max|{max_abs:.0}ms|  (n={})",
+                            interval_errs_ms.len()
+                        ),
                         label_color,
                         value_color,
                     );
@@ -437,6 +450,7 @@ fn render_snapshot(
                     RichText::new(
                         "elev = elevation# (chunk-i+1/N);  \
                          path = hist|phys|legacy|start;  anchor = obs|median|default;  \
+                         act_int / pred_wait / Δint are collection-space (Δint = act_int − pred_wait);  \
                          physics shows the dominant case + key terms",
                     )
                     .size(10.0)
@@ -457,7 +471,9 @@ fn render_snapshot(
                             "path",
                             "anchor",
                             "pred_err",
-                            "wait_empty",
+                            "act_int",
+                            "pred_wait",
+                            "Δint",
                             "lag_ms",
                             "physics",
                         ] {
@@ -471,15 +487,17 @@ fn render_snapshot(
                         ui.end_row();
 
                         let mut prev_elev: Option<u8> = None;
+                        let mut prev_arrival: Option<&ChunkArrivalStat> = None;
                         for a in arrivals {
                             if prev_elev.is_some() && a.elevation_number != prev_elev {
-                                for _ in 0..12 {
+                                for _ in 0..14 {
                                     ui.label("");
                                 }
                                 ui.end_row();
                             }
                             prev_elev = a.elevation_number;
-                            arrival_row(ui, a, label_color, value_color);
+                            arrival_row(ui, a, prev_arrival, label_color, value_color);
+                            prev_arrival = Some(a);
                         }
                     });
             }
@@ -505,6 +523,7 @@ fn render_snapshot(
 fn arrival_row(
     ui: &mut egui::Ui,
     a: &ChunkArrivalStat,
+    prev: Option<&ChunkArrivalStat>,
     label_color: egui::Color32,
     value_color: egui::Color32,
 ) {
@@ -551,12 +570,32 @@ fn arrival_row(
             .unwrap_or_else(|| "—".into()),
         value_color,
     );
+    let act_int = prev.and_then(|p| a.actual_interval_secs(p));
     mono_label(
         ui,
-        &a.wait_after_last_empty_ms()
-            .map(|ms| format!("{ms:.0}ms"))
+        &act_int
+            .map(|s| format!("{s:.2}s"))
             .unwrap_or_else(|| "—".into()),
         value_color,
+    );
+    mono_label(
+        ui,
+        &a.predicted_wait_secs
+            .map(|s| format!("{s:.2}s"))
+            .unwrap_or_else(|| "—".into()),
+        value_color,
+    );
+    let int_err = prev.and_then(|p| a.interval_error_ms(p));
+    let int_err_color = match int_err {
+        Some(e) if e.abs() > 1000.0 => egui::Color32::from_rgb(220, 140, 60),
+        _ => value_color,
+    };
+    mono_label_color(
+        ui,
+        &int_err
+            .map(|ms| format!("{ms:+.0}ms"))
+            .unwrap_or_else(|| "—".into()),
+        int_err_color,
     );
     mono_label(
         ui,
@@ -607,6 +646,13 @@ fn grid_row(
         ui,
         &s.actual_duration()
             .map(|d| format!("{:+.2}s", d - s.predicted_duration))
+            .unwrap_or_else(|| "—".into()),
+        value_color,
+    );
+    mono_label(
+        ui,
+        &s.actual_start
+            .map(|a| format!("{:+.2}s", a - s.predicted_start))
             .unwrap_or_else(|| "—".into()),
         value_color,
     );
@@ -786,6 +832,23 @@ struct BucketRow {
     median_wait_after_empty_ms: Option<f64>,
 }
 
+/// Collect per-chunk interval-prediction errors in collection space (ms).
+/// Walks pairs of consecutive arrivals; only contributes when both have a
+/// `collection_time_secs` and the later has a `predicted_wait_secs`.
+fn collect_interval_errors_ms(arrivals: &[ChunkArrivalStat]) -> Vec<f64> {
+    let mut out = Vec::new();
+    let mut prev: Option<&ChunkArrivalStat> = None;
+    for a in arrivals {
+        if let Some(p) = prev {
+            if let Some(e) = a.interval_error_ms(p) {
+                out.push(e);
+            }
+        }
+        prev = Some(a);
+    }
+    out
+}
+
 /// Per-bucket sample collector — one entry per bucket key seen.
 struct BucketAccum {
     bucket: BucketKey,
@@ -951,12 +1014,12 @@ pub fn serialize_forecast(
     // ── Per-elevation table ─────────────────────────────────────────
     let _ = writeln!(
         out,
-        "elv  ang    wf    used  src | pred_dur act_dur Δdur   | pred_ch act_ch Δch | timing status"
+        "elv  ang    wf    used  src | pred_dur act_dur Δdur   Δstart | pred_ch act_ch Δch | timing status"
     );
     for s in &snap.sweeps {
         let _ = writeln!(
             out,
-            "{:>3}  {:>5.2}  {:<4} {:>5.2} {:<3} | {:>6.1}s {:>6}s {:>5} | {:>6} {:>6} {:>3} | {:<6} {}",
+            "{:>3}  {:>5.2}  {:<4} {:>5.2} {:<3} | {:>6.1}s {:>6}s {:>5} {:>6} | {:>6} {:>6} {:>3} | {:<6} {}",
             s.elev_number,
             s.elev_angle,
             trim_str(&s.waveform, 4),
@@ -968,6 +1031,9 @@ pub fn serialize_forecast(
                 .unwrap_or_else(|| "—".into()),
             s.actual_duration()
                 .map(|d| format!("{:+.2}s", d - s.predicted_duration))
+                .unwrap_or_else(|| "—".into()),
+            s.actual_start
+                .map(|a| format!("{:+.2}s", a - s.predicted_start))
                 .unwrap_or_else(|| "—".into()),
             s.predicted_chunks
                 .map(|c| format!("{c}"))
@@ -1045,7 +1111,15 @@ pub fn serialize_forecast(
     if let Some((mean, median, max_abs)) = stats_on(&pred_errs) {
         let _ = writeln!(
             out,
-            "chunk_pred_err: mean={mean:+.2}s median={median:+.2}s max_abs={max_abs:.2}s"
+            "chunk_pred_err: mean={mean:+.2}s median={median:+.2}s max_abs={max_abs:.2}s  (availability-space)"
+        );
+    }
+    let interval_errs_ms = collect_interval_errors_ms(arrivals);
+    if let Some((mean, median, max_abs)) = stats_on(&interval_errs_ms) {
+        let _ = writeln!(
+            out,
+            "interval_err: mean={mean:+.0}ms median={median:+.0}ms max_abs={max_abs:.0}ms  (collection-space, n={}; positive = chunk took longer than predicted)",
+            interval_errs_ms.len()
         );
     }
     let wait_after_empty_ms: Vec<f64> = arrivals
@@ -1116,21 +1190,24 @@ pub fn serialize_forecast(
     if !arrivals.is_empty() {
         let _ = writeln!(
             out,
-            "chunk_arrivals  (path = hist|phys|legacy|start;  anchor = obs|median|default)"
+            "chunk_arrivals  (path = hist|phys|legacy|start;  anchor = obs|median|default;  Δint = act_int − pred_wait, collection-space)"
         );
         let _ = writeln!(
             out,
-            "  seq  type          elev        empty  bucket            stats_n  path    anchor   pred_err  wait_empty   lag_ms    physics"
+            "  seq  type          elev        empty  bucket            stats_n  path    anchor   pred_err  act_int  pred_wait    Δint     lag_ms    physics"
         );
         let mut prev_elev: Option<u8> = None;
+        let mut prev_arrival: Option<&ChunkArrivalStat> = None;
         for a in arrivals {
             if prev_elev.is_some() && a.elevation_number != prev_elev {
                 out.push('\n');
             }
             prev_elev = a.elevation_number;
+            let act_int = prev_arrival.and_then(|p| a.actual_interval_secs(p));
+            let int_err = prev_arrival.and_then(|p| a.interval_error_ms(p));
             let _ = writeln!(
                 out,
-                "  {:>3}  {:<12}  {:<10}  {:>5}  {:<16}  {:>7}  {:<6}  {:<7}  {:>8}  {:>10}  {:>7}  {}",
+                "  {:>3}  {:<12}  {:<10}  {:>5}  {:<16}  {:>7}  {:<6}  {:<7}  {:>8}  {:>7}  {:>9}  {:>8}  {:>7}  {}",
                 a.sequence,
                 a.chunk_type,
                 fmt_elev(a),
@@ -1149,14 +1226,21 @@ pub fn serialize_forecast(
                 a.prediction_error_secs()
                     .map(|e| format!("{e:+.2}s"))
                     .unwrap_or_else(|| "—".into()),
-                a.wait_after_last_empty_ms()
-                    .map(|ms| format!("{ms:.0}ms"))
+                act_int
+                    .map(|s| format!("{s:.2}s"))
+                    .unwrap_or_else(|| "—".into()),
+                a.predicted_wait_secs
+                    .map(|s| format!("{s:.2}s"))
+                    .unwrap_or_else(|| "—".into()),
+                int_err
+                    .map(|ms| format!("{ms:+.0}ms"))
                     .unwrap_or_else(|| "—".into()),
                 a.availability_lag_ms
                     .map(|ms| format!("{ms:+}ms"))
                     .unwrap_or_else(|| "—".into()),
                 fmt_physics(a.physics_breakdown.as_ref()),
             );
+            prev_arrival = Some(a);
         }
     }
 

--- a/src/ui/vcp_forecast_modal.rs
+++ b/src/ui/vcp_forecast_modal.rs
@@ -4,13 +4,23 @@
 //! snapshot side-by-side with observed actuals, and provides a copy-to-
 //! clipboard button so the plain-text output can be pasted into a chat
 //! message for iterating on the forecasting algorithms.
+//!
+//! The data shown here is intentionally curated for an "optimize the model"
+//! workflow: every column either drives a tuning decision (which estimator
+//! path fired, which bucket key was used, sample count, anchor source,
+//! per-chunk lag) or quantifies prediction error against actuals. Raw
+//! wall-clock timestamps and structural metadata that don't influence the
+//! model are deliberately omitted — they can be reconstructed from the
+//! deltas if needed and would otherwise bloat the clipboard payload.
 
 use super::colors::ui as ui_colors;
+use crate::nexrad::timing::{AnchorSource, IntervalCase, PhysicsBreakdown, SchedulerPath};
 use crate::state::{
-    AppState, ChunkArrivalStat, RateSource, SweepForecast, SweepStatus, SweepTiming,
+    AppState, BucketKey, ChunkArrivalStat, SweepForecast, SweepStatus, SweepTiming,
     VolumeForecastSnapshot,
 };
 use eframe::egui::{self, RichText, Vec2};
+use std::collections::BTreeMap;
 use std::fmt::Write as _;
 
 pub fn render_vcp_forecast_modal(ctx: &egui::Context, state: &mut AppState) {
@@ -24,6 +34,7 @@ pub fn render_vcp_forecast_modal(ctx: &egui::Context, state: &mut AppState) {
     }
 
     let dark = state.is_dark;
+    let site_id = state.viz_state.site_id.clone();
     let (snap_opt, arrivals) = {
         let live = &state.live_mode_state;
         if live.current_volume_forecast.is_some() {
@@ -45,7 +56,7 @@ pub fn render_vcp_forecast_modal(ctx: &egui::Context, state: &mut AppState) {
         .collapsible(false)
         .resizable(false)
         .anchor(egui::Align2::CENTER_CENTER, Vec2::ZERO)
-        .fixed_size(Vec2::new(860.0, 560.0))
+        .fixed_size(Vec2::new(940.0, 580.0))
         .order(egui::Order::Foreground)
         .show(ctx, |ui| match snap_opt {
             None => {
@@ -70,7 +81,7 @@ pub fn render_vcp_forecast_modal(ctx: &egui::Context, state: &mut AppState) {
                 }
             }
             Some(snap) => {
-                render_snapshot(ui, ctx, &snap, &arrivals, dark, state);
+                render_snapshot(ui, ctx, &snap, &arrivals, &site_id, dark, state);
             }
         });
 }
@@ -80,6 +91,7 @@ fn render_snapshot(
     ctx: &egui::Context,
     snap: &VolumeForecastSnapshot,
     arrivals: &[ChunkArrivalStat],
+    site_id: &str,
     dark: bool,
     state: &mut AppState,
 ) {
@@ -88,7 +100,7 @@ fn render_snapshot(
     let heading_color = ui_colors::ACTIVE;
 
     egui::ScrollArea::vertical()
-        .max_height(480.0)
+        .max_height(500.0)
         .show(ui, |ui| {
             // ── Volume metadata ─────────────────────────────────────────
             ui.label(
@@ -101,26 +113,15 @@ fn render_snapshot(
                 let name = snap.vcp_name.unwrap_or("?");
                 kv(
                     ui,
-                    "VCP",
-                    &format!("{} ({})", snap.vcp_number, name),
-                    label_color,
-                    value_color,
-                );
-                kv(
-                    ui,
-                    "Mode",
-                    if snap.is_clear_air {
-                        "clear air"
-                    } else {
-                        "precip"
-                    },
-                    label_color,
-                    value_color,
-                );
-                kv(
-                    ui,
-                    "Elevations",
-                    &format!("{}", snap.expected_elevation_count),
+                    "Site / VCP",
+                    &format!(
+                        "{} · {} ({}) · {} · {} elev",
+                        site_id,
+                        snap.vcp_number,
+                        name,
+                        if snap.is_clear_air { "clear" } else { "precip" },
+                        snap.expected_elevation_count
+                    ),
                     label_color,
                     value_color,
                 );
@@ -132,51 +133,18 @@ fn render_snapshot(
                     value_color,
                 );
                 let predicted_dur = snap.predicted_volume_end - snap.volume_start;
+                let drift_str = snap
+                    .actual_volume_end
+                    .map(|e| format!("{:+.1}s", e - snap.predicted_volume_end))
+                    .unwrap_or_else(|| "—".into());
+                let actual_dur_str = snap
+                    .actual_volume_end
+                    .map(|e| format!("{:.1}s", e - snap.volume_start))
+                    .unwrap_or_else(|| "—".into());
                 kv(
                     ui,
-                    "Predicted end",
-                    &format!(
-                        "{} (+{:.1}s)",
-                        format_time(snap.predicted_volume_end),
-                        predicted_dur
-                    ),
-                    label_color,
-                    value_color,
-                );
-                match snap.actual_volume_end {
-                    Some(end) => {
-                        let drift = end - snap.predicted_volume_end;
-                        kv(
-                            ui,
-                            "Actual end",
-                            &format!(
-                                "{} (+{:.1}s, drift {:+.1}s)",
-                                format_time(end),
-                                end - snap.volume_start,
-                                drift
-                            ),
-                            label_color,
-                            value_color,
-                        );
-                    }
-                    None => kv(ui, "Actual end", "—", label_color, value_color),
-                }
-                kv(
-                    ui,
-                    "Projections at start",
-                    if snap.chunk_projections_available_at_start {
-                        "yes"
-                    } else {
-                        "no"
-                    },
-                    label_color,
-                    value_color,
-                );
-                let (m_a, m_b, m_lib) = rate_source_tally(snap);
-                kv(
-                    ui,
-                    "Rate sources",
-                    &format!("VCP={m_a}  fallback={m_b}  library={m_lib}"),
+                    "Duration (pred / actual / drift)",
+                    &format!("{predicted_dur:.1}s / {actual_dur_str} / {drift_str}"),
                     label_color,
                     value_color,
                 );
@@ -202,15 +170,6 @@ fn render_snapshot(
                     label_color,
                     value_color,
                 );
-                if let Some(prev_end) = snap.previous_volume_end {
-                    kv(
-                        ui,
-                        "  prev volume end",
-                        &format_time(prev_end),
-                        label_color,
-                        value_color,
-                    );
-                }
             });
 
             ui.separator();
@@ -222,12 +181,10 @@ fn render_snapshot(
                     .strong()
                     .color(heading_color),
             );
-
             ui.label(
                 RichText::new(
-                    "legend: tag = SAILS / MRLE / BASE / — (standard);  \
-                     src = LIB (projection library) / VCP (message rate) / FB (fallback);  \
-                     Δ values are actual − predicted",
+                    "src = LIB (projection library) / VCP (msg rate) / FB (Method-B fallback);  \
+                     Δ = actual − predicted",
                 )
                 .size(10.0)
                 .color(label_color),
@@ -238,9 +195,8 @@ fn render_snapshot(
                 .spacing(Vec2::new(10.0, 4.0))
                 .show(ui, |ui| {
                     for header in [
-                        "elv", "ang", "wf", "prf", "tag", "vcp_r", "fb_r", "used", "src",
-                        "pred_dur", "act_dur", "Δdur", "pred_ch", "act_ch", "Δch", "Δstart",
-                        "timing", "status",
+                        "elv", "ang", "wf", "used", "src", "pred_dur", "act_dur", "Δdur",
+                        "pred_ch", "act_ch", "Δch", "timing", "status",
                     ] {
                         ui.label(
                             RichText::new(header)
@@ -252,7 +208,7 @@ fn render_snapshot(
                     ui.end_row();
 
                     for s in &snap.sweeps {
-                        grid_row(ui, s, snap.volume_start, label_color, value_color);
+                        grid_row(ui, s, label_color, value_color);
                     }
                 });
 
@@ -282,16 +238,8 @@ fn render_snapshot(
                 if let Some((mean, median, max_abs)) = stats_on(&dur_errs) {
                     kv(
                         ui,
-                        "Duration error (actual - predicted)",
+                        "Sweep duration error",
                         &format!("mean {mean:+.2}s  median {median:+.2}s  max|{max_abs:.2}s|"),
-                        label_color,
-                        value_color,
-                    );
-                } else {
-                    kv(
-                        ui,
-                        "Duration error",
-                        "— (no complete sweeps yet)",
                         label_color,
                         value_color,
                     );
@@ -307,25 +255,13 @@ fn render_snapshot(
                 if let Some((mean, _median, max_abs)) = stats_on(&chunk_errs) {
                     kv(
                         ui,
-                        "Chunk count error",
+                        "Sweep chunk-count error",
                         &format!("mean {mean:+.2}  max|{max_abs:.0}|"),
-                        label_color,
-                        value_color,
-                    );
-                } else {
-                    kv(ui, "Chunk count error", "—", label_color, value_color);
-                }
-                if let Some(end) = snap.actual_volume_end {
-                    kv(
-                        ui,
-                        "Volume-end drift",
-                        &format!("{:+.2}s", end - snap.predicted_volume_end),
                         label_color,
                         value_color,
                     );
                 }
 
-                // Chunk-level aggregates
                 let total_empty = total_empty_polls(arrivals);
                 let any_retry = arrivals.iter().filter(|a| a.empty_polls > 0).count();
                 let total_requests = arrivals.len() as u32 + total_empty;
@@ -336,17 +272,11 @@ fn render_snapshot(
                 };
                 kv(
                     ui,
-                    "S3 requests (total / wasted)",
+                    "S3 requests / wasted",
                     &format!(
-                        "{total_requests} total → {total_empty} wasted ({waste_pct:.1}%)"
+                        "{total_requests} → {total_empty} wasted ({waste_pct:.1}%);  retries on {any_retry}/{} chunks",
+                        arrivals.len()
                     ),
-                    label_color,
-                    value_color,
-                );
-                kv(
-                    ui,
-                    "Chunks with ≥1 retry",
-                    &format!("{any_retry}/{}", arrivals.len()),
                     label_color,
                     value_color,
                 );
@@ -357,7 +287,7 @@ fn render_snapshot(
                 if let Some((mean, median, max_abs)) = stats_on(&pred_errs) {
                     kv(
                         ui,
-                        "Chunk prediction error (success - predicted)",
+                        "Chunk pred error (success − predicted)",
                         &format!("mean {mean:+.2}s  median {median:+.2}s  max|{max_abs:.2}s|"),
                         label_color,
                         value_color,
@@ -370,59 +300,122 @@ fn render_snapshot(
                 if let Some((mean, median, max_abs)) = stats_on(&wait_after_last_empty) {
                     kv(
                         ui,
-                        "Wait after last empty (success - last_empty)",
+                        "Wait after last empty",
                         &format!("mean {mean:.0}ms  median {median:.0}ms  max {max_abs:.0}ms"),
                         label_color,
                         value_color,
                     );
                 }
-                // Lag vs. S3 publish time (Last-Modified header).
-                // The header is rendered with 1-second resolution, so individual
-                // values carry ±1s of quantization noise — treat magnitudes below
-                // that as indistinguishable from zero.
-                let wait_after_s3: Vec<f64> = arrivals
+                let lag_ms_values: Vec<f64> = arrivals
                     .iter()
-                    .filter_map(|a| a.wait_after_s3_publish_ms())
+                    .filter_map(|a| a.availability_lag_ms.map(|m| m as f64))
                     .collect();
-                if let Some((mean, median, max_abs)) = stats_on(&wait_after_s3) {
+                if let Some((mean, median, max_abs)) = stats_on(&lag_ms_values) {
                     kv(
                         ui,
-                        "Wait after S3 publish (success - Last-Modified)",
+                        "Availability lag (s3_last_mod − chunk_collection_end)",
                         &format!(
-                            "mean {mean:.0}ms  median {median:.0}ms  max {max_abs:.0}ms  (±1s quantized)"
+                            "mean {mean:.0}ms  median {median:.0}ms  max|{max_abs:.0}ms|  ({}/{} samples)",
+                            lag_ms_values.len(),
+                            arrivals.len()
                         ),
                         label_color,
                         value_color,
                     );
-                    // Values outside ±1s are real client-side wait (or real skew).
-                    // Values within ±1s are noise from Last-Modified truncation.
-                    let measurable: Vec<f64> =
-                        wait_after_s3.iter().copied().filter(|v| v.abs() > 1000.0).collect();
-                    if let Some((mean_m, _median_m, max_m)) = stats_on(&measurable) {
-                        kv(
-                            ui,
-                            "  measurable waits (|>1s|)",
-                            &format!(
-                                "{}/{}  mean {mean_m:.0}ms  max {max_m:.0}ms",
-                                measurable.len(),
-                                wait_after_s3.len()
-                            ),
-                            label_color,
-                            value_color,
-                        );
-                    } else {
-                        kv(
-                            ui,
-                            "  measurable waits (|>1s|)",
-                            "none — all chunks within ±1s quantization noise",
-                            label_color,
-                            value_color,
-                        );
-                    }
+                }
+                let path_tally = scheduler_path_tally(arrivals);
+                if path_tally.iter().any(|(_, n)| *n > 0) {
+                    kv(
+                        ui,
+                        "Estimator path",
+                        &format_path_tally(&path_tally),
+                        label_color,
+                        value_color,
+                    );
+                }
+                let anchor_tally = anchor_source_tally(arrivals);
+                if anchor_tally.iter().any(|(_, n)| *n > 0) {
+                    kv(
+                        ui,
+                        "Anchor source",
+                        &format_anchor_tally(&anchor_tally),
+                        label_color,
+                        value_color,
+                    );
                 }
             });
 
             ui.separator();
+
+            // ── Per-bucket stats ───────────────────────────────────────
+            let bucket_rows = compute_per_bucket_stats(arrivals);
+            if !bucket_rows.is_empty() {
+                ui.label(
+                    RichText::new("Per-bucket stats (chunks observed this volume)")
+                        .size(12.0)
+                        .strong()
+                        .color(heading_color),
+                );
+                ui.label(
+                    RichText::new(
+                        "bucket = chunk_type|waveform|channel|first_in_sweep;  \
+                         lag = s3_last_mod − chunk_collection_end",
+                    )
+                    .size(10.0)
+                    .color(label_color),
+                );
+                egui::Grid::new("vcp_forecast_bucket_grid")
+                    .striped(true)
+                    .min_col_width(44.0)
+                    .spacing(Vec2::new(10.0, 4.0))
+                    .show(ui, |ui| {
+                        for header in [
+                            "bucket",
+                            "n",
+                            "med_pred_err",
+                            "med_lag_ms",
+                            "n_lag",
+                            "med_wait_after_empty",
+                        ] {
+                            ui.label(
+                                RichText::new(header)
+                                    .size(10.0)
+                                    .strong()
+                                    .color(heading_color),
+                            );
+                        }
+                        ui.end_row();
+
+                        for row in &bucket_rows {
+                            mono_label(ui, &row.bucket.short(), value_color);
+                            mono_label(ui, &format!("{}", row.n), value_color);
+                            mono_label(
+                                ui,
+                                &row.median_pred_err_ms
+                                    .map(|m| format!("{m:+.0}ms"))
+                                    .unwrap_or_else(|| "—".into()),
+                                value_color,
+                            );
+                            mono_label(
+                                ui,
+                                &row.median_lag_ms
+                                    .map(|m| format!("{m:+.0}ms"))
+                                    .unwrap_or_else(|| "—".into()),
+                                value_color,
+                            );
+                            mono_label(ui, &format!("{}", row.n_lag), value_color);
+                            mono_label(
+                                ui,
+                                &row.median_wait_after_empty_ms
+                                    .map(|m| format!("{m:.0}ms"))
+                                    .unwrap_or_else(|| "—".into()),
+                                value_color,
+                            );
+                            ui.end_row();
+                        }
+                    });
+                ui.separator();
+            }
 
             // ── Chunk arrivals ─────────────────────────────────────────
             ui.label(
@@ -442,15 +435,16 @@ fn render_snapshot(
             } else {
                 ui.label(
                     RichText::new(
-                        "legend: elev shows elevation# (chunk-index/chunks-in-sweep);  \
-                         times are offsets from volume_start;  wait_after_s3 has ±1s precision",
+                        "elev = elevation# (chunk-i+1/N);  \
+                         path = hist|phys|legacy|start;  anchor = obs|median|default;  \
+                         physics shows the dominant case + key terms",
                     )
                     .size(10.0)
                     .color(label_color),
                 );
                 egui::Grid::new("vcp_forecast_arrivals_grid")
                     .striped(true)
-                    .min_col_width(44.0)
+                    .min_col_width(40.0)
                     .spacing(Vec2::new(10.0, 4.0))
                     .show(ui, |ui| {
                         for header in [
@@ -458,15 +452,14 @@ fn render_snapshot(
                             "type",
                             "elev",
                             "empty",
-                            "predicted_at",
-                            "success_at",
+                            "bucket",
+                            "stats_n",
+                            "path",
+                            "anchor",
                             "pred_err",
-                            "first_empty",
-                            "last_empty",
-                            "wait_after_empty",
-                            "s3_last_mod",
-                            "wait_after_s3",
-                            "fetch_ms",
+                            "wait_empty",
+                            "lag_ms",
+                            "physics",
                         ] {
                             ui.label(
                                 RichText::new(header)
@@ -479,15 +472,14 @@ fn render_snapshot(
 
                         let mut prev_elev: Option<u8> = None;
                         for a in arrivals {
-                            // Insert a blank visual break between elevations.
                             if prev_elev.is_some() && a.elevation_number != prev_elev {
-                                for _ in 0..13 {
+                                for _ in 0..12 {
                                     ui.label("");
                                 }
                                 ui.end_row();
                             }
                             prev_elev = a.elevation_number;
-                            arrival_row(ui, a, snap.volume_start, label_color, value_color);
+                            arrival_row(ui, a, label_color, value_color);
                         }
                     });
             }
@@ -498,7 +490,7 @@ fn render_snapshot(
     ui.separator();
     ui.horizontal(|ui| {
         if ui.button("Copy to clipboard").clicked() {
-            let text = serialize_forecast(snap, arrivals);
+            let text = serialize_forecast(snap, arrivals, site_id);
             ctx.copy_text(text);
             state.status_message = "Forecast diagnostics copied to clipboard".to_string();
         }
@@ -513,190 +505,154 @@ fn render_snapshot(
 fn arrival_row(
     ui: &mut egui::Ui,
     a: &ChunkArrivalStat,
-    vol_start: f64,
     label_color: egui::Color32,
     value_color: egui::Color32,
 ) {
-    let mono = |ui: &mut egui::Ui, text: String, color: egui::Color32| {
-        ui.label(RichText::new(text).size(10.0).monospace().color(color));
-    };
-    let fmt_off = |t: f64| format!("+{:.2}s", t - vol_start);
-
-    mono(ui, format!("{}", a.sequence), value_color);
-    mono(ui, a.chunk_type.to_string(), label_color);
-    mono(ui, fmt_elev(a), label_color);
+    mono_label(ui, &format!("{}", a.sequence), value_color);
+    mono_label(ui, a.chunk_type, label_color);
+    mono_label(ui, &fmt_elev(a), label_color);
     let empty_color = if a.empty_polls > 0 {
         egui::Color32::from_rgb(220, 140, 60)
     } else {
         value_color
     };
-    mono(ui, format!("{}", a.empty_polls), empty_color);
-    mono(
+    mono_label_color(ui, &format!("{}", a.empty_polls), empty_color);
+    mono_label(
         ui,
-        a.predicted_available_at
-            .map(fmt_off)
+        &a.bucket_key
+            .as_ref()
+            .map(BucketKey::short)
             .unwrap_or_else(|| "—".into()),
+        label_color,
+    );
+    mono_label(
+        ui,
+        &if a.stats_n_at_prediction == 0 {
+            "—".into()
+        } else {
+            format!("{}", a.stats_n_at_prediction)
+        },
         value_color,
     );
-    mono(ui, fmt_off(a.success_at), value_color);
-    mono(
+    mono_label(
         ui,
-        a.prediction_error_secs()
+        a.scheduler_path.map(|p| p.short()).unwrap_or("—"),
+        label_color,
+    );
+    mono_label(
+        ui,
+        a.anchor_source.map(|s| s.short()).unwrap_or("—"),
+        label_color,
+    );
+    mono_label(
+        ui,
+        &a.prediction_error_secs()
             .map(|e| format!("{e:+.2}s"))
             .unwrap_or_else(|| "—".into()),
         value_color,
     );
-    mono(
+    mono_label(
         ui,
-        a.first_empty_poll_at
-            .map(fmt_off)
-            .unwrap_or_else(|| "—".into()),
-        value_color,
-    );
-    mono(
-        ui,
-        a.last_empty_poll_at
-            .map(fmt_off)
-            .unwrap_or_else(|| "—".into()),
-        value_color,
-    );
-    mono(
-        ui,
-        a.wait_after_last_empty_ms()
+        &a.wait_after_last_empty_ms()
             .map(|ms| format!("{ms:.0}ms"))
             .unwrap_or_else(|| "—".into()),
         value_color,
     );
-    mono(
+    mono_label(
         ui,
-        a.s3_last_modified_at
-            .map(fmt_off)
+        &a.availability_lag_ms
+            .map(|ms| format!("{ms:+}ms"))
             .unwrap_or_else(|| "—".into()),
         value_color,
     );
-    mono(
-        ui,
-        a.wait_after_s3_publish_ms()
-            .map(|ms| format!("{ms:.0}ms"))
-            .unwrap_or_else(|| "—".into()),
-        value_color,
-    );
-    mono(ui, format!("{:.0}ms", a.fetch_latency_ms), value_color);
+    mono_label(ui, &fmt_physics(a.physics_breakdown.as_ref()), value_color);
     ui.end_row();
+}
+
+fn mono_label(ui: &mut egui::Ui, text: &str, color: egui::Color32) {
+    ui.label(RichText::new(text).size(10.0).monospace().color(color));
+}
+
+fn mono_label_color(ui: &mut egui::Ui, text: &str, color: egui::Color32) {
+    ui.label(RichText::new(text).size(10.0).monospace().color(color));
 }
 
 fn total_empty_polls(arrivals: &[ChunkArrivalStat]) -> u32 {
     arrivals.iter().map(|a| a.empty_polls).sum()
 }
 
-// ── Grid row ────────────────────────────────────────────────────────────
+// ── Per-elevation grid row ──────────────────────────────────────────────
 
 fn grid_row(
     ui: &mut egui::Ui,
     s: &SweepForecast,
-    vol_start: f64,
     label_color: egui::Color32,
     value_color: egui::Color32,
 ) {
-    let mono = |ui: &mut egui::Ui, text: String, color: egui::Color32| {
-        ui.label(RichText::new(text).size(10.0).monospace().color(color));
-    };
+    mono_label(ui, &format!("{}", s.elev_number), value_color);
+    mono_label(ui, &format!("{:.2}°", s.elev_angle), value_color);
+    mono_label(ui, &s.waveform, value_color);
+    mono_label(ui, &format!("{:.2}", s.azimuth_rate_used), value_color);
+    mono_label(ui, s.rate_source.short(), label_color);
 
-    mono(ui, format!("{}", s.elev_number), value_color);
-    mono(ui, format!("{:.2}°", s.elev_angle), value_color);
-    mono(ui, s.waveform.clone(), value_color);
-    mono(ui, format!("{}", s.prf_number), value_color);
-    mono(ui, cut_type_tag(s).to_string(), label_color);
-    mono(
+    mono_label(ui, &format!("{:.1}s", s.predicted_duration), value_color);
+    mono_label(
         ui,
-        s.vcp_azimuth_rate
-            .map(|r| format!("{r:.2}"))
-            .unwrap_or_else(|| "—".into()),
-        value_color,
-    );
-    mono(ui, format!("{:.2}", s.fallback_azimuth_rate), value_color);
-    mono(ui, format!("{:.2}", s.azimuth_rate_used), value_color);
-    mono(ui, s.rate_source.short().to_string(), label_color);
-
-    mono(ui, format!("{:.1}s", s.predicted_duration), value_color);
-    mono(
-        ui,
-        s.actual_duration()
+        &s.actual_duration()
             .map(|d| format!("{d:.1}s"))
             .unwrap_or_else(|| "—".into()),
         value_color,
     );
-    mono(
+    mono_label(
         ui,
-        s.actual_duration()
+        &s.actual_duration()
             .map(|d| format!("{:+.2}s", d - s.predicted_duration))
             .unwrap_or_else(|| "—".into()),
         value_color,
     );
 
-    mono(
+    mono_label(
         ui,
-        s.predicted_chunks
+        &s.predicted_chunks
             .map(|c| format!("{c}"))
             .unwrap_or_else(|| "—".into()),
         value_color,
     );
-    mono(
+    mono_label(
         ui,
-        s.actual_chunks
+        &s.actual_chunks
             .map(|c| format!("{c}"))
             .unwrap_or_else(|| "—".into()),
         value_color,
     );
-    mono(
+    mono_label(
         ui,
-        match (s.actual_chunks, s.predicted_chunks) {
+        &match (s.actual_chunks, s.predicted_chunks) {
             (Some(a), Some(p)) => format!("{:+}", a as i32 - p as i32),
             _ => "—".into(),
         },
         value_color,
     );
-
-    mono(
-        ui,
-        s.actual_start
-            .map(|a| format!("{:+.2}s", a - s.predicted_start))
-            .unwrap_or_else(|| "—".into()),
-        value_color,
-    );
-    mono(
+    mono_label(
         ui,
         match s.timing_source {
-            Some(SweepTiming::Observed) => "Observed".to_string(),
-            Some(SweepTiming::Anchored) => "Anchored".to_string(),
-            Some(SweepTiming::Estimated) => "Estimated".to_string(),
-            None => "—".into(),
+            Some(SweepTiming::Observed) => "Obs",
+            Some(SweepTiming::Anchored) => "Anch",
+            Some(SweepTiming::Estimated) => "Est",
+            None => "—",
         },
         label_color,
     );
-    mono(
+    mono_label(
         ui,
         match s.status {
-            SweepStatus::Complete => "Complete".to_string(),
-            SweepStatus::InProgress { .. } => "InProg".to_string(),
-            SweepStatus::Future => "Future".to_string(),
+            SweepStatus::Complete => "Complete",
+            SweepStatus::InProgress { .. } => "InProg",
+            SweepStatus::Future => "Future",
         },
         label_color,
     );
-    let _ = vol_start; // reserved for future per-row offset columns
     ui.end_row();
-}
-
-fn cut_type_tag(s: &SweepForecast) -> &'static str {
-    if s.is_sails {
-        "SAILS"
-    } else if s.is_mrle {
-        "MRLE"
-    } else if s.is_base_tilt {
-        "BASE"
-    } else {
-        "—"
-    }
 }
 
 fn kv(
@@ -719,8 +675,6 @@ fn kv(
     });
 }
 
-/// Format the elevation / chunk-in-sweep identifier for display.
-/// E.g. "1 (1/3)" for elevation 1, chunk 1 of 3. "—" for the volume Start chunk.
 fn fmt_elev(a: &ChunkArrivalStat) -> String {
     match (
         a.elevation_number,
@@ -733,18 +687,35 @@ fn fmt_elev(a: &ChunkArrivalStat) -> String {
     }
 }
 
-fn rate_source_tally(snap: &VolumeForecastSnapshot) -> (usize, usize, usize) {
-    let mut a = 0;
-    let mut b = 0;
-    let mut lib = 0;
-    for s in &snap.sweeps {
-        match s.rate_source {
-            RateSource::VcpMessage => a += 1,
-            RateSource::MethodBFallback => b += 1,
-            RateSource::ProjectionLibrary => lib += 1,
+/// Compact one-cell summary of the physics decomposition. Format:
+///   intra: chunk_dur
+///   inter_sweep: gap+wf=total
+///   inter_volume: total
+fn fmt_physics(b: Option<&PhysicsBreakdown>) -> String {
+    let Some(b) = b else {
+        return "—".into();
+    };
+    match b.case {
+        IntervalCase::IntraSweep => match b.chunk_duration_secs {
+            Some(d) => format!("intra {d:.2}s"),
+            None => format!("intra ~{:.2}s", b.total_secs),
+        },
+        IntervalCase::InterSweep => {
+            let gap = b.inter_sweep_gap_secs.unwrap_or(0.0);
+            let wf = b.waveform_penalty_secs.unwrap_or(0.0);
+            let chunk = b.chunk_duration_secs.unwrap_or(0.0);
+            // wf is included inside `gap` already; show it separately so
+            // the source of any anomaly is obvious at a glance.
+            format!(
+                "is g={:.2} (wf={:.1}) ch={:.2} → {:.2}s",
+                gap - wf,
+                wf,
+                chunk,
+                b.total_secs
+            )
         }
+        IntervalCase::InterVolume => format!("inter_vol {:.2}s", b.total_secs),
     }
-    (a, b, lib)
 }
 
 fn count_statuses(snap: &VolumeForecastSnapshot) -> (usize, usize, usize) {
@@ -778,12 +749,24 @@ fn stats_on(values: &[f64]) -> Option<(f64, f64, f64)> {
     Some((mean, median, max_abs))
 }
 
+fn median_of(mut values: Vec<f64>) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    values.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let mid = values.len() / 2;
+    Some(if values.len().is_multiple_of(2) {
+        (values[mid - 1] + values[mid]) / 2.0
+    } else {
+        values[mid]
+    })
+}
+
 /// Format a Unix-seconds timestamp as `YYYY-MM-DD HH:MM:SSZ`.
 fn format_time(secs: f64) -> String {
     let ms = (secs * 1000.0) as i64;
     let date = js_sys::Date::new(&wasm_bindgen::JsValue::from_f64(ms as f64));
     let iso = date.to_iso_string().as_string().unwrap_or_default();
-    // "2026-04-21T18:14:03.000Z" → "2026-04-21 18:14:03Z"
     if iso.len() >= 20 {
         format!("{} {}Z", &iso[0..10], &iso[11..19])
     } else {
@@ -791,74 +774,192 @@ fn format_time(secs: f64) -> String {
     }
 }
 
+// ── Per-bucket aggregation (computed from arrivals) ─────────────────────
+
+#[derive(Debug, Clone)]
+struct BucketRow {
+    bucket: BucketKey,
+    n: usize,
+    median_pred_err_ms: Option<f64>,
+    median_lag_ms: Option<f64>,
+    n_lag: usize,
+    median_wait_after_empty_ms: Option<f64>,
+}
+
+/// Per-bucket sample collector — one entry per bucket key seen.
+struct BucketAccum {
+    bucket: BucketKey,
+    pred_errs_ms: Vec<f64>,
+    lags_ms: Vec<f64>,
+    waits_ms: Vec<f64>,
+}
+
+fn compute_per_bucket_stats(arrivals: &[ChunkArrivalStat]) -> Vec<BucketRow> {
+    let mut by_bucket: BTreeMap<String, BucketAccum> = BTreeMap::new();
+    for a in arrivals {
+        let Some(bucket) = a.bucket_key else {
+            continue;
+        };
+        let entry = by_bucket.entry(bucket.short()).or_insert(BucketAccum {
+            bucket,
+            pred_errs_ms: Vec::new(),
+            lags_ms: Vec::new(),
+            waits_ms: Vec::new(),
+        });
+        if let Some(e) = a.prediction_error_secs() {
+            entry.pred_errs_ms.push(e * 1000.0);
+        }
+        if let Some(l) = a.availability_lag_ms {
+            entry.lags_ms.push(l as f64);
+        }
+        if let Some(w) = a.wait_after_last_empty_ms() {
+            entry.waits_ms.push(w);
+        }
+    }
+    by_bucket
+        .into_values()
+        .map(|acc| {
+            let n = acc
+                .pred_errs_ms
+                .len()
+                .max(acc.lags_ms.len())
+                .max(acc.waits_ms.len())
+                .max(1);
+            let n_lag = acc.lags_ms.len();
+            BucketRow {
+                bucket: acc.bucket,
+                n,
+                median_pred_err_ms: median_of(acc.pred_errs_ms),
+                median_lag_ms: median_of(acc.lags_ms),
+                n_lag,
+                median_wait_after_empty_ms: median_of(acc.waits_ms),
+            }
+        })
+        .collect()
+}
+
+fn scheduler_path_tally(arrivals: &[ChunkArrivalStat]) -> [(SchedulerPath, u32); 4] {
+    let mut t = [
+        (SchedulerPath::StartConstant, 0u32),
+        (SchedulerPath::Historical, 0),
+        (SchedulerPath::Physics, 0),
+        (SchedulerPath::Legacy, 0),
+    ];
+    for a in arrivals {
+        if let Some(p) = a.scheduler_path {
+            for slot in t.iter_mut() {
+                if slot.0 == p {
+                    slot.1 += 1;
+                }
+            }
+        }
+    }
+    t
+}
+
+fn format_path_tally(t: &[(SchedulerPath, u32); 4]) -> String {
+    t.iter()
+        .filter(|(_, n)| *n > 0)
+        .map(|(p, n)| format!("{}={}", p.short(), n))
+        .collect::<Vec<_>>()
+        .join("  ")
+}
+
+fn anchor_source_tally(arrivals: &[ChunkArrivalStat]) -> [(AnchorSource, u32); 3] {
+    let mut t = [
+        (AnchorSource::ObservedCollection, 0u32),
+        (AnchorSource::UploadMinusMedian, 0),
+        (AnchorSource::UploadMinusDefault, 0),
+    ];
+    for a in arrivals {
+        if let Some(s) = a.anchor_source {
+            for slot in t.iter_mut() {
+                if slot.0 == s {
+                    slot.1 += 1;
+                }
+            }
+        }
+    }
+    t
+}
+
+fn format_anchor_tally(t: &[(AnchorSource, u32); 3]) -> String {
+    t.iter()
+        .filter(|(_, n)| *n > 0)
+        .map(|(s, n)| format!("{}={}", s.short(), n))
+        .collect::<Vec<_>>()
+        .join("  ")
+}
+
 // ── Plain-text serialization (clipboard payload) ────────────────────────
 
-pub fn serialize_forecast(snap: &VolumeForecastSnapshot, arrivals: &[ChunkArrivalStat]) -> String {
+pub fn serialize_forecast(
+    snap: &VolumeForecastSnapshot,
+    arrivals: &[ChunkArrivalStat],
+    site_id: &str,
+) -> String {
     let mut out = String::new();
 
     let name = snap.vcp_name.unwrap_or("?");
     let _ = writeln!(
         out,
-        "VCP {} ({})  clear_air={}  elevations={}",
-        snap.vcp_number, name, snap.is_clear_air, snap.expected_elevation_count
+        "site={} VCP={} ({}) mode={} elevations={}",
+        site_id,
+        snap.vcp_number,
+        name,
+        if snap.is_clear_air {
+            "clear_air"
+        } else {
+            "precip"
+        },
+        snap.expected_elevation_count
     );
     let _ = writeln!(out, "volume_start={}", format_time(snap.volume_start));
     let predicted_dur = snap.predicted_volume_end - snap.volume_start;
+    let actual_dur_str = snap
+        .actual_volume_end
+        .map(|e| format!("{:.1}s", e - snap.volume_start))
+        .unwrap_or_else(|| "—".into());
+    let drift_str = snap
+        .actual_volume_end
+        .map(|e| format!("{:+.1}s", e - snap.predicted_volume_end))
+        .unwrap_or_else(|| "—".into());
     let _ = writeln!(
         out,
-        "predicted_end={} (+{:.1}s)  actual_end={}  drift={}",
-        format_time(snap.predicted_volume_end),
-        predicted_dur,
-        snap.actual_volume_end
-            .map(|e| format!("{} (+{:.1}s)", format_time(e), e - snap.volume_start))
-            .unwrap_or_else(|| "—".into()),
-        snap.actual_volume_end
-            .map(|e| format!("{:+.1}s", e - snap.predicted_volume_end))
-            .unwrap_or_else(|| "—".into())
+        "duration: pred={:.1}s actual={} drift={}",
+        predicted_dur, actual_dur_str, drift_str
     );
     let _ = writeln!(
         out,
-        "inter_volume_gap={} (prev_end={})  predicted_gap={}",
+        "inter_volume_gap: obs={} pred={} delta={}",
         snap.inter_volume_gap_secs
             .map(|g| format!("{g:+.2}s"))
             .unwrap_or_else(|| "—".into()),
-        snap.previous_volume_end
-            .map(format_time)
-            .unwrap_or_else(|| "—".into()),
         snap.predicted_inter_volume_gap_secs
             .map(|g| format!("{g:+.2}s"))
-            .unwrap_or_else(|| "—".into())
-    );
-    let (m_a, m_b, m_lib) = rate_source_tally(snap);
-    let _ = writeln!(
-        out,
-        "projections_at_start={}  rates: vcp={}  fallback={}  library={}",
-        snap.chunk_projections_available_at_start, m_a, m_b, m_lib
+            .unwrap_or_else(|| "—".into()),
+        match (
+            snap.inter_volume_gap_secs,
+            snap.predicted_inter_volume_gap_secs,
+        ) {
+            (Some(o), Some(p)) => format!("{:+.2}s", o - p),
+            _ => "—".into(),
+        },
     );
     out.push('\n');
 
+    // ── Per-elevation table ─────────────────────────────────────────
     let _ = writeln!(
         out,
-        "legend: tag = SAILS/MRLE/BASE/— (standard);  src = LIB (projection) / VCP (msg rate) / FB (fallback);  Δ = actual − predicted"
+        "elv  ang    wf    used  src | pred_dur act_dur Δdur   | pred_ch act_ch Δch | timing status"
     );
-    let _ = writeln!(
-        out,
-        "elv  angle  wf    prf tag    vcp_r  fb_r  used  src | pred_dur act_dur  Δdur  | pred_ch act_ch Δch | Δstart  | timing     status"
-    );
-
     for s in &snap.sweeps {
         let _ = writeln!(
             out,
-            "{:>3}  {:>5.2}  {:<4} {:>3} {:<5}  {:>5}  {:>5.2} {:>5.2} {:<3} | {:>6.1}s {:>6}s {:>5} | {:>6} {:>6} {:>3} | {:>6}  | {:<10} {}",
+            "{:>3}  {:>5.2}  {:<4} {:>5.2} {:<3} | {:>6.1}s {:>6}s {:>5} | {:>6} {:>6} {:>3} | {:<6} {}",
             s.elev_number,
             s.elev_angle,
             trim_str(&s.waveform, 4),
-            s.prf_number,
-            cut_type_tag(s),
-            s.vcp_azimuth_rate
-                .map(|r| format!("{r:.2}"))
-                .unwrap_or_else(|| "—".into()),
-            s.fallback_azimuth_rate,
             s.azimuth_rate_used,
             s.rate_source.short(),
             s.predicted_duration,
@@ -878,13 +979,10 @@ pub fn serialize_forecast(snap: &VolumeForecastSnapshot, arrivals: &[ChunkArriva
                 (Some(a), Some(p)) => format!("{:+}", a as i32 - p as i32),
                 _ => "—".into(),
             },
-            s.actual_start
-                .map(|a| format!("{:+.2}s", a - s.predicted_start))
-                .unwrap_or_else(|| "—".into()),
             match s.timing_source {
-                Some(SweepTiming::Observed) => "Observed",
-                Some(SweepTiming::Anchored) => "Anchored",
-                Some(SweepTiming::Estimated) => "Estimated",
+                Some(SweepTiming::Observed) => "Obs",
+                Some(SweepTiming::Anchored) => "Anch",
+                Some(SweepTiming::Estimated) => "Est",
                 None => "—",
             },
             match s.status {
@@ -894,13 +992,13 @@ pub fn serialize_forecast(snap: &VolumeForecastSnapshot, arrivals: &[ChunkArriva
             },
         );
     }
-
     out.push('\n');
 
+    // ── Summary ─────────────────────────────────────────────────────
     let (complete, in_progress, future) = count_statuses(snap);
     let _ = writeln!(
         out,
-        "summary: complete={complete}  in_progress={in_progress}  future={future}"
+        "summary: complete={complete} in_progress={in_progress} future={future}"
     );
 
     let dur_errs: Vec<f64> = snap
@@ -911,10 +1009,8 @@ pub fn serialize_forecast(snap: &VolumeForecastSnapshot, arrivals: &[ChunkArriva
     if let Some((mean, median, max_abs)) = stats_on(&dur_errs) {
         let _ = writeln!(
             out,
-            "duration_err: mean={mean:+.2}s  median={median:+.2}s  max_abs={max_abs:.2}s"
+            "duration_err: mean={mean:+.2}s median={median:+.2}s max_abs={max_abs:.2}s"
         );
-    } else {
-        let _ = writeln!(out, "duration_err: —");
     }
 
     let chunk_errs: Vec<f64> = snap
@@ -926,37 +1022,9 @@ pub fn serialize_forecast(snap: &VolumeForecastSnapshot, arrivals: &[ChunkArriva
         })
         .collect();
     if let Some((mean, _median, max_abs)) = stats_on(&chunk_errs) {
-        let _ = writeln!(out, "chunk_err:    mean={mean:+.2}  max_abs={max_abs:.0}");
-    } else {
-        let _ = writeln!(out, "chunk_err: —");
+        let _ = writeln!(out, "chunk_err: mean={mean:+.2} max_abs={max_abs:.0}");
     }
 
-    if let Some(end) = snap.actual_volume_end {
-        let _ = writeln!(
-            out,
-            "volume_end_drift: {:+.2}s",
-            end - snap.predicted_volume_end
-        );
-    }
-    let _ = writeln!(
-        out,
-        "inter_volume_gap: observed={}  predicted={}  delta={}",
-        snap.inter_volume_gap_secs
-            .map(|g| format!("{g:+.2}s"))
-            .unwrap_or_else(|| "—".into()),
-        snap.predicted_inter_volume_gap_secs
-            .map(|g| format!("{g:+.2}s"))
-            .unwrap_or_else(|| "—".into()),
-        match (
-            snap.inter_volume_gap_secs,
-            snap.predicted_inter_volume_gap_secs,
-        ) {
-            (Some(o), Some(p)) => format!("{:+.2}s", o - p),
-            _ => "—".into(),
-        },
-    );
-
-    // ── Chunk arrivals ───────────────────────────────────────────────
     let total_empty = total_empty_polls(arrivals);
     let any_retry = arrivals.iter().filter(|a| a.empty_polls > 0).count();
     let total_requests = arrivals.len() as u32 + total_empty;
@@ -967,14 +1035,7 @@ pub fn serialize_forecast(snap: &VolumeForecastSnapshot, arrivals: &[ChunkArriva
     };
     let _ = writeln!(
         out,
-        "s3_requests: {total_requests} total ({} successes + {total_empty} empty polls) → {waste_pct:.1}% wasted",
-        arrivals.len()
-    );
-    let _ = writeln!(
-        out,
-        "chunk_arrivals: count={} chunks_with_retries={}/{}",
-        arrivals.len(),
-        any_retry,
+        "s3_requests: {total_requests} total → {total_empty} wasted ({waste_pct:.1}%)  retries_on={any_retry}/{} chunks",
         arrivals.len()
     );
     let pred_errs: Vec<f64> = arrivals
@@ -984,10 +1045,8 @@ pub fn serialize_forecast(snap: &VolumeForecastSnapshot, arrivals: &[ChunkArriva
     if let Some((mean, median, max_abs)) = stats_on(&pred_errs) {
         let _ = writeln!(
             out,
-            "chunk_pred_err: mean={mean:+.2}s  median={median:+.2}s  max_abs={max_abs:.2}s"
+            "chunk_pred_err: mean={mean:+.2}s median={median:+.2}s max_abs={max_abs:.2}s"
         );
-    } else {
-        let _ = writeln!(out, "chunk_pred_err: —");
     }
     let wait_after_empty_ms: Vec<f64> = arrivals
         .iter()
@@ -996,120 +1055,107 @@ pub fn serialize_forecast(snap: &VolumeForecastSnapshot, arrivals: &[ChunkArriva
     if let Some((mean, median, max_abs)) = stats_on(&wait_after_empty_ms) {
         let _ = writeln!(
             out,
-            "wait_after_last_empty_ms: mean={mean:.0}  median={median:.0}  max_abs={max_abs:.0}"
+            "wait_after_last_empty_ms: mean={mean:.0} median={median:.0} max_abs={max_abs:.0}"
         );
-    } else {
-        let _ = writeln!(out, "wait_after_last_empty_ms: —  (no retries)");
     }
-    let wait_after_s3_ms: Vec<f64> = arrivals
+    let lag_ms: Vec<f64> = arrivals
         .iter()
-        .filter_map(|a| a.wait_after_s3_publish_ms())
+        .filter_map(|a| a.availability_lag_ms.map(|m| m as f64))
         .collect();
-    let s3_coverage = arrivals
-        .iter()
-        .filter(|a| a.s3_last_modified_at.is_some())
-        .count();
-    if let Some((mean, median, max_abs)) = stats_on(&wait_after_s3_ms) {
+    if let Some((mean, median, max_abs)) = stats_on(&lag_ms) {
         let _ = writeln!(
             out,
-            "wait_after_s3_publish_ms: mean={mean:.0}  median={median:.0}  max_abs={max_abs:.0}  (coverage {}/{}; ±1s quantized — Last-Modified is second-precision)",
-            s3_coverage,
+            "availability_lag_ms: mean={mean:.0} median={median:.0} max_abs={max_abs:.0}  (n={}/{})",
+            lag_ms.len(),
             arrivals.len()
         );
-        // Filter to measurable waits only — |values| > 1000 ms are outside the
-        // quantization noise band and reflect real client-side wait.
-        let measurable: Vec<f64> = wait_after_s3_ms
-            .iter()
-            .copied()
-            .filter(|v| v.abs() > 1000.0)
-            .collect();
-        if let Some((mean_m, _median_m, max_m)) = stats_on(&measurable) {
+    }
+    let path_tally = scheduler_path_tally(arrivals);
+    if path_tally.iter().any(|(_, n)| *n > 0) {
+        let _ = writeln!(out, "path: {}", format_path_tally(&path_tally));
+    }
+    let anchor_tally = anchor_source_tally(arrivals);
+    if anchor_tally.iter().any(|(_, n)| *n > 0) {
+        let _ = writeln!(out, "anchor: {}", format_anchor_tally(&anchor_tally));
+    }
+    out.push('\n');
+
+    // ── Per-bucket table ────────────────────────────────────────────
+    let bucket_rows = compute_per_bucket_stats(arrivals);
+    if !bucket_rows.is_empty() {
+        let _ = writeln!(
+            out,
+            "per_bucket  (bucket = chunk_type|waveform|channel|first_in_sweep)"
+        );
+        let _ = writeln!(
+            out,
+            "  bucket           n   med_pred_err  med_lag    n_lag  med_wait_empty"
+        );
+        for row in &bucket_rows {
             let _ = writeln!(
                 out,
-                "wait_after_s3_measurable: {}/{} chunks outside ±1s band  mean={mean_m:.0}ms  max={max_m:.0}ms",
-                measurable.len(),
-                wait_after_s3_ms.len()
-            );
-        } else {
-            let _ = writeln!(
-                out,
-                "wait_after_s3_measurable: 0/{} — all chunks within ±1s quantization noise (no measurable client-side wait)",
-                wait_after_s3_ms.len()
+                "  {:<16} {:>3}  {:>11}  {:>8}  {:>5}  {:>13}",
+                row.bucket.short(),
+                row.n,
+                row.median_pred_err_ms
+                    .map(|m| format!("{m:+.0}ms"))
+                    .unwrap_or_else(|| "—".into()),
+                row.median_lag_ms
+                    .map(|m| format!("{m:+.0}ms"))
+                    .unwrap_or_else(|| "—".into()),
+                row.n_lag,
+                row.median_wait_after_empty_ms
+                    .map(|m| format!("{m:.0}ms"))
+                    .unwrap_or_else(|| "—".into()),
             );
         }
-    } else {
-        let _ = writeln!(
-            out,
-            "wait_after_s3_publish_ms: —  (Last-Modified unavailable for all chunks)"
-        );
-    }
-    let slop_ms: Vec<f64> = arrivals
-        .iter()
-        .filter_map(|a| a.scheduler_slop_ms())
-        .collect();
-    if let Some((mean, median, max_abs)) = stats_on(&slop_ms) {
-        let _ = writeln!(
-            out,
-            "scheduler_slop_ms: mean={mean:+.0}  median={median:+.0}  max_abs={max_abs:.0}  (scheduled - predicted; expected ≈ POLL_DELAY_AFTER_PREDICTED_MS)"
-        );
-    }
-    let fetch_ms: Vec<f64> = arrivals.iter().map(|a| a.fetch_latency_ms).collect();
-    if let Some((mean, median, max_abs)) = stats_on(&fetch_ms) {
-        let _ = writeln!(
-            out,
-            "fetch_latency_ms: mean={mean:.0}  median={median:.0}  max_abs={max_abs:.0}"
-        );
+        out.push('\n');
     }
 
+    // ── Per-chunk arrivals table ───────────────────────────────────
     if !arrivals.is_empty() {
-        out.push('\n');
         let _ = writeln!(
             out,
-            "legend: all times are offsets from volume_start;  elev shows elevation# (chunk-index-in-sweep / chunks-in-sweep)"
+            "chunk_arrivals  (path = hist|phys|legacy|start;  anchor = obs|median|default)"
         );
         let _ = writeln!(
             out,
-            "seq  type          elev        empty  predicted_at  success_at  pred_err  first_empty  last_empty  wait_after_empty  s3_last_mod  wait_after_s3  fetch_ms"
+            "  seq  type          elev        empty  bucket            stats_n  path    anchor   pred_err  wait_empty   lag_ms    physics"
         );
         let mut prev_elev: Option<u8> = None;
         for a in arrivals {
-            // Blank line on elevation transitions (but not before the first row).
             if prev_elev.is_some() && a.elevation_number != prev_elev {
                 out.push('\n');
             }
             prev_elev = a.elevation_number;
-
-            let fmt_off = |t: f64| format!("+{:.2}s", t - snap.volume_start);
             let _ = writeln!(
                 out,
-                "{:>3}  {:<12}  {:<10}  {:>5}  {:>12}  {:>10}  {:>8}  {:>11}  {:>10}  {:>15}  {:>11}  {:>13}  {:>8}",
+                "  {:>3}  {:<12}  {:<10}  {:>5}  {:<16}  {:>7}  {:<6}  {:<7}  {:>8}  {:>10}  {:>7}  {}",
                 a.sequence,
                 a.chunk_type,
                 fmt_elev(a),
                 a.empty_polls,
-                a.predicted_available_at
-                    .map(fmt_off)
+                a.bucket_key
+                    .as_ref()
+                    .map(BucketKey::short)
                     .unwrap_or_else(|| "—".into()),
-                fmt_off(a.success_at),
+                if a.stats_n_at_prediction == 0 {
+                    "—".into()
+                } else {
+                    format!("{}", a.stats_n_at_prediction)
+                },
+                a.scheduler_path.map(|p| p.short()).unwrap_or("—"),
+                a.anchor_source.map(|s| s.short()).unwrap_or("—"),
                 a.prediction_error_secs()
                     .map(|e| format!("{e:+.2}s"))
-                    .unwrap_or_else(|| "—".into()),
-                a.first_empty_poll_at
-                    .map(fmt_off)
-                    .unwrap_or_else(|| "—".into()),
-                a.last_empty_poll_at
-                    .map(fmt_off)
                     .unwrap_or_else(|| "—".into()),
                 a.wait_after_last_empty_ms()
                     .map(|ms| format!("{ms:.0}ms"))
                     .unwrap_or_else(|| "—".into()),
-                a.s3_last_modified_at
-                    .map(fmt_off)
+                a.availability_lag_ms
+                    .map(|ms| format!("{ms:+}ms"))
                     .unwrap_or_else(|| "—".into()),
-                a.wait_after_s3_publish_ms()
-                    .map(|ms| format!("{ms:.0}ms"))
-                    .unwrap_or_else(|| "—".into()),
-                format!("{:.0}ms", a.fetch_latency_ms),
+                fmt_physics(a.physics_breakdown.as_ref()),
             );
         }
     }


### PR DESCRIPTION
## Summary
This branch is a substantial overhaul of how the workbench predicts when the next NEXRAD chunk will arrive in real-time mode, plus a unified network retry policy and a handful of related UX/perf improvements.

### Real-time timing estimation (primary focus)
- New [src/nexrad/timing/](src/nexrad/timing/) module forked from the previous chunk-timing prediction code, with separate concerns:
  - [chunk_timing_model.rs](src/nexrad/timing/chunk_timing_model.rs) — per-chunk arrival model
  - [chunk_timing_stats.rs](src/nexrad/timing/chunk_timing_stats.rs) — `ChunkTimingStats` v2 with availability-lag stats, persisted across sessions via `localStorage`
  - [scan_timing_projection.rs](src/nexrad/timing/scan_timing_projection.rs) — projection split into collection vs availability times (fields renamed with `_available_at` suffix for clarity); anchored on current chunk collection time, not volume start
  - [elevation_chunk_mapper.rs](src/nexrad/timing/elevation_chunk_mapper.rs)
  - [estimate_next_chunk_time.rs](src/nexrad/timing/estimate_next_chunk_time.rs)
- `ChunkCharacteristics` now keyed on `is_first_in_sweep`; Start→first-chunk gap split from inter-volume gap; new waveform-transition penalty on `inter_sweep_gap`.
- Scheduler tuning from second-volume residuals: bumped `CS→CDW` / `B→CDWO` penalties, raised then rolled back pad to 400ms while tightening Start→first gap to 1.5s, and bumped streaming poll padding to 750ms to cover S3 availability lag.
- Streaming pipeline now plumbs the parsed volume header time into `StreamingState`, populates `chunk_projections` during mid-volume join, always emits the Start chunk first when transitioning volumes, and provisions `ScanKey.scan_start` from `upload − median lag`.
- VCP forecast diagnostics refocused on prediction-error attribution; collection-space interval error exposed in chunk diagnostics; timing-category invariants documented on key timestamp fields.
- New [docs/TIMING.md](docs/TIMING.md) documenting the timing model end-to-end.

### Unified retry policy
- New [src/net/retry.rs](src/net/retry.rs) with shared exponential-backoff/jitter logic.
- Applied to S3 archive and real-time chunk fetches, alerts API, ZIP lookup, and the national mosaic fetch path.

### Developer mode + diagnostics
- New developer-mode toggle gates diagnostic UI surfaces and timing-collection overhead.
- VCP forecast modal substantially reworked around prediction-error attribution.

### Render & UI polish
- Label layout deferred to camera-settle; per-frame render work cached via new [src/state/render_cache.rs](src/state/render_cache.rs).
- Alert overlay now draws on top of radar imagery, as outlines only with a halo, slightly thicker; geo/site labels also haloed and drawn over radar.
- Live-mode timeline keeps the playhead visible via minimal scroll, removes view pinning during playback/streaming.