### PR TITLE
Bump aws-lc-rs to fix aws-lc-sys security alerts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -241,14 +241,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.1"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -2895,7 +2896,7 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rand_chacha",
  "simd_helpers",
  "thiserror 2.0.18",


### PR DESCRIPTION
## Summary
- Bumps transitive `aws-lc-rs` 1.16.0 → 1.18.0, which pulls `aws-lc-sys` 0.37.1 → 0.44.0
- Closes open Dependabot alerts on `aws-lc-sys`:
  - #15 high — CRL Distribution Point Scope Check Logic Error
  - #14 high — X.509 Name Constraints Bypass via Wildcard/Unicode CN
  - #12 high — PKCS7_verify Signature Validation Bypass
  - #11 high — Timing Side-Channel in AES-CCM Tag Verification
  - #10 high — PKCS7_verify Certificate Chain Validation Bypass
- Also normalizes a leftover `rand 0.9.2` lock reference to `0.9.5` (already patched via #131)

`aws-lc-sys` is pulled in via `nexrad-data → reqwest → rustls → aws-lc-rs` (native/HTTP path; not on the WASM default target).

## Test plan
- [x] `cargo check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --bin nexrad-workbench` (pre-commit)
- [ ] Confirm Dependabot alerts #10–#12, #14, #15 auto-close after merge