### PR TITLE
Gate data-age desaturation on effective sweep animation

### DIFF
--- a/docs/RENDERING.md
+++ b/docs/RENDERING.md
@@ -150,8 +150,9 @@ progressively against transparent background.
 
 ### Data-age desaturation
 
-When `data_age_desaturation` is on and the chunk boundary is known,
-three angular zones get different treatments:
+When `data_age_desaturation` is on, sweep animation is effectively
+active, and the chunk boundary is known, three angular zones get
+different treatments:
 
 ```
    [fresh data] ← received edge ← [gap] ← now line ← [fade 90°] ← [no desat]

--- a/docs/RENDERING.md
+++ b/docs/RENDERING.md
@@ -151,8 +151,11 @@ progressively against transparent background.
 ### Data-age desaturation
 
 When `data_age_desaturation` is on, sweep animation is effectively
-active, and the chunk boundary is known, three angular zones get
-different treatments:
+active for the current view, and the chunk boundary is known, three
+angular zones get different treatments. Effective animation requires
+the usual live/mode gates **and** — with a fixed elevation filter —
+that the antenna is currently collecting that cut (so age fades stop
+between visits while other tilts collect).
 
 ```
    [fresh data] ← received edge ← [gap] ← now line ← [fade 90°] ← [no desat]

--- a/src/app/render_loop.rs
+++ b/src/app/render_loop.rs
@@ -118,10 +118,11 @@ impl WorkbenchApp {
             return;
         }
 
-        if !self
-            .state
-            .effective_sweep_animation(&self.playback.state, self.live.mode_state.is_active())
-        {
+        if !self.state.effective_sweep_animation(
+            &self.playback.state,
+            self.live.mode_state.is_active(),
+            self.live.radar_model.collecting_elevation(),
+        ) {
             self.state.viz_state.previous_displayed = None;
             self.state.viz_state.last_sweep_line_cache = None;
             return;

--- a/src/app/worker_results.rs
+++ b/src/app/worker_results.rs
@@ -330,6 +330,7 @@ impl WorkbenchApp {
                 sweep_animation: self.state.effective_sweep_animation(
                     &self.playback.state,
                     self.live.mode_state.is_active(),
+                    self.live.radar_model.collecting_elevation(),
                 ),
                 storm_cells_visible: self.state.viz_state.storm_cells_visible,
                 in_flight_scans: &self.state.download_progress.in_flight_scans,

--- a/src/core/canvas.rs
+++ b/src/core/canvas.rs
@@ -38,6 +38,17 @@ pub(crate) fn sweep_animation_effective(
     pref && mode == crate::core::PlaybackMode::Micro && advanced && streaming && playhead_attached
 }
 
+/// Whether data-age desaturation should run this frame.
+///
+/// Desaturation only makes sense while the sweep animation is effectively
+/// active (beam collecting / oldest-data wedge). Live mode still enables the
+/// GPU sweep path for partial-chunk compositing when animation is off, so the
+/// preference alone is not enough — gate on both the stored toggle and
+/// [`sweep_animation_effective`].
+pub(crate) fn data_age_desaturation_effective(pref: bool, effective_sweep_animation: bool) -> bool {
+    pref && effective_sweep_animation
+}
+
 /// Interpolate the rotating sweep-line azimuth within `sweep` at playback time
 /// `ts`, returning `(current_az, start_az)` in degrees, or `None` if the sweep
 /// has no positive duration.
@@ -733,6 +744,19 @@ mod coverage_tests {
         assert!(!sweep_animation_effective(false, Micro, true, true, true));
         assert!(!sweep_animation_effective(true, Macro, true, true, true));
         assert!(!sweep_animation_effective(true, Micro, false, true, true));
+    }
+
+    // --- data_age_desaturation_effective ---------------------------------------
+
+    #[wasm_bindgen_test]
+    fn data_age_desaturation_requires_effective_sweep_animation() {
+        // Preference on + animation effectively on → desaturate.
+        assert!(data_age_desaturation_effective(true, true));
+        // Preference on but animation inactive (toggle/mode/filter) → no desat.
+        assert!(!data_age_desaturation_effective(true, false));
+        // Animation on but preference off → no desat.
+        assert!(!data_age_desaturation_effective(false, true));
+        assert!(!data_age_desaturation_effective(false, false));
     }
 
     // --- sweep_line_azimuth: uncovered branches -------------------------------

--- a/src/core/canvas.rs
+++ b/src/core/canvas.rs
@@ -38,15 +38,54 @@ pub(crate) fn sweep_animation_effective(
     pref && mode == crate::core::PlaybackMode::Micro && advanced && streaming && playhead_attached
 }
 
+/// Whether the beam is currently collecting the elevation the user is viewing.
+///
+/// - `selected_elevation = None` (Latest / all tilts): any collecting cut counts.
+/// - `selected_elevation = Some(n)` (fixed cut / filter): only while the antenna
+///   is on elevation `n`. Between visits the beam is on other tilts, so sweep
+///   animation and age desaturation must stay off.
+pub(crate) fn displayed_elevation_is_collecting(
+    selected_elevation: Option<u8>,
+    collecting_elevation: Option<u8>,
+) -> bool {
+    match selected_elevation {
+        None => true,
+        Some(want) => collecting_elevation == Some(want),
+    }
+}
+
+/// Sweep animation as shown for the current view: base live/mode gates plus
+/// the elevation-filter gate from [`displayed_elevation_is_collecting`].
+pub(crate) fn sweep_animation_for_view(
+    base_effective: bool,
+    selected_elevation: Option<u8>,
+    collecting_elevation: Option<u8>,
+) -> bool {
+    base_effective && displayed_elevation_is_collecting(selected_elevation, collecting_elevation)
+}
+
 /// Whether data-age desaturation should run this frame.
 ///
 /// Desaturation only makes sense while the sweep animation is effectively
 /// active (beam collecting / oldest-data wedge). Live mode still enables the
 /// GPU sweep path for partial-chunk compositing when animation is off, so the
 /// preference alone is not enough — gate on both the stored toggle and
-/// [`sweep_animation_effective`].
+/// [`sweep_animation_effective`] (via the view-level effective flag).
 pub(crate) fn data_age_desaturation_effective(pref: bool, effective_sweep_animation: bool) -> bool {
     pref && effective_sweep_animation
+}
+
+/// Live partial azimuth range for GPU compositing, or `None` when the in-progress
+/// elevation is not the one on screen (fixed elevation filter between visits).
+pub(crate) fn live_compositing_azimuth_range(
+    selected_elevation: Option<u8>,
+    active_elevation: Option<u8>,
+    data_azimuth_range: Option<(f32, f32)>,
+) -> Option<(f32, f32)> {
+    if !displayed_elevation_is_collecting(selected_elevation, active_elevation) {
+        return None;
+    }
+    data_azimuth_range
 }
 
 /// Interpolate the rotating sweep-line azimuth within `sweep` at playback time
@@ -757,6 +796,37 @@ mod coverage_tests {
         // Animation on but preference off → no desat.
         assert!(!data_age_desaturation_effective(false, true));
         assert!(!data_age_desaturation_effective(false, false));
+    }
+
+    #[wasm_bindgen_test]
+    fn displayed_elevation_filter_gates_animation_between_visits() {
+        // Latest (no fixed cut): always collecting for animation purposes.
+        assert!(displayed_elevation_is_collecting(None, None));
+        assert!(displayed_elevation_is_collecting(None, Some(3)));
+        // Fixed cut: only while the antenna is on that elevation.
+        assert!(displayed_elevation_is_collecting(Some(1), Some(1)));
+        assert!(!displayed_elevation_is_collecting(Some(1), Some(2)));
+        assert!(!displayed_elevation_is_collecting(Some(1), None));
+
+        assert!(sweep_animation_for_view(true, Some(1), Some(1)));
+        assert!(!sweep_animation_for_view(true, Some(1), Some(4)));
+        assert!(!sweep_animation_for_view(false, Some(1), Some(1)));
+        assert!(sweep_animation_for_view(true, None, Some(4)));
+
+        // Live compositing range suppressed off-elevation so other tilts
+        // don't drive the GPU sweep boundary for the filtered product.
+        assert_eq!(
+            live_compositing_azimuth_range(Some(1), Some(1), Some((10.0, 40.0))),
+            Some((10.0, 40.0))
+        );
+        assert_eq!(
+            live_compositing_azimuth_range(Some(1), Some(2), Some((10.0, 40.0))),
+            None
+        );
+        assert_eq!(
+            live_compositing_azimuth_range(None, Some(2), Some((10.0, 40.0))),
+            Some((10.0, 40.0))
+        );
     }
 
     // --- sweep_line_azimuth: uncovered branches -------------------------------

--- a/src/core/live_radar_model.rs
+++ b/src/core/live_radar_model.rs
@@ -40,6 +40,13 @@ pub(crate) struct LiveRadarModel {
     pub frame_now: FrameDerivedPosition,
 }
 
+impl LiveRadarModel {
+    /// Elevation number currently being collected, if any.
+    pub(crate) fn collecting_elevation(&self) -> Option<u8> {
+        self.active_sweep.as_ref().map(|s| s.elevation_number)
+    }
+}
+
 /// Derived values that need to be evaluated at "now" for live mode but
 /// must agree with the frame's canonical timestamp. Populated only when
 /// `position` is `Some` and live mode is active; otherwise all fields

--- a/src/core/worker_decoded.rs
+++ b/src/core/worker_decoded.rs
@@ -57,7 +57,7 @@ pub(crate) struct DecodedEnv<'a> {
     /// `self.live_render_sources()` — the live collecting cut + anchor
     /// feeding [`resolve_desired_display`].
     pub live_cut: Option<(u8, i64)>,
-    /// `state.effective_sweep_animation(&playback.state)`.
+    /// `state.effective_sweep_animation(&playback.state, streaming, collecting)`.
     pub sweep_animation: bool,
     /// `viz_state.storm_cells_visible`.
     pub storm_cells_visible: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -832,6 +832,7 @@ impl eframe::App for WorkbenchApp {
             &self.state,
             &self.playback,
             self.live.mode_state.is_active(),
+            self.live.radar_model.collecting_elevation(),
         );
         self.state.national_mosaic.poll_tick(
             ctx,
@@ -949,6 +950,7 @@ impl eframe::App for WorkbenchApp {
             &self.state,
             &self.playback,
             self.live.mode_state.is_active(),
+            self.live.radar_model.collecting_elevation(),
         );
 
         // 19. Consume any deferred geolocation request raised by the

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -458,17 +458,27 @@ impl AppState {
     /// edge. Macro mode, Basic UI, and historical viewing all suppress the
     /// animation regardless of the stored preference, which is preserved
     /// across mode toggles.
+    ///
+    /// `collecting_elevation` is the live in-progress cut (`None` when not
+    /// streaming or between elevations). A fixed elevation filter further
+    /// suppresses animation while the antenna is on any other tilt.
     pub(crate) fn effective_sweep_animation(
         &self,
         playback: &PlaybackState,
         streaming: bool,
+        collecting_elevation: Option<u8>,
     ) -> bool {
-        crate::core::canvas::sweep_animation_effective(
+        let base = crate::core::canvas::sweep_animation_effective(
             self.render_processing.sweep_animation,
             playback.playback_mode(),
             self.advanced_mode,
             streaming,
             playback.time_model.is_pinned() || playback.time_model.is_lookback(),
+        );
+        crate::core::canvas::sweep_animation_for_view(
+            base,
+            self.viz_state.elevation_selection.elevation_number(),
+            collecting_elevation,
         )
     }
 

--- a/src/subsystem/derived.rs
+++ b/src/subsystem/derived.rs
@@ -43,7 +43,8 @@ pub(crate) struct Derived {
     pub data_is_live: bool,
     /// Whether sweep animation is effectively enabled this frame
     /// (`render_processing.sweep_animation && micro mode && advanced
-    /// && streaming && playhead attached to the live edge`).
+    /// && streaming && playhead attached to the live edge`, and — when a
+    /// fixed elevation filter is set — the antenna is on that cut).
     pub effective_sweep_animation: bool,
 }
 
@@ -52,12 +53,22 @@ impl Derived {
     /// before any subsystem tick or panel render, so every consumer
     /// downstream reads the same values. `streaming` is the live
     /// subsystem's `mode_state.is_active()` — an active stream session.
-    pub(crate) fn for_frame(state: &AppState, playback: &Playback, streaming: bool) -> Self {
+    /// `collecting_elevation` is the live in-progress cut when known.
+    pub(crate) fn for_frame(
+        state: &AppState,
+        playback: &Playback,
+        streaming: bool,
+        collecting_elevation: Option<u8>,
+    ) -> Self {
         Self {
             frame_now_secs: state.frame_now.secs(),
             visible_bounds: state.viz_state.last_visible_bounds,
             data_is_live: crate::state::recency::data_is_live(&playback.state),
-            effective_sweep_animation: state.effective_sweep_animation(&playback.state, streaming),
+            effective_sweep_animation: state.effective_sweep_animation(
+                &playback.state,
+                streaming,
+                collecting_elevation,
+            ),
         }
     }
 }

--- a/src/ui/canvas.rs
+++ b/src/ui/canvas.rs
@@ -211,6 +211,15 @@ pub(crate) fn render_canvas_with_geo(
                 let chunk_boundary = live.radar_model.estimated_azimuth;
 
                 if let Some(renderer) = gpu_renderer {
+                    // Live compositing keeps `gpu_sweep` set even when animation
+                    // is off; force desaturation off in that case so age fades
+                    // only accompany an active sweep animation (#134).
+                    let mut processing = state.render_processing.clone();
+                    processing.data_age_desaturation =
+                        crate::core::canvas::data_age_desaturation_effective(
+                            processing.data_age_desaturation,
+                            derived.effective_sweep_animation,
+                        );
                     draw_radar_gpu(
                         ui,
                         &projection,
@@ -218,7 +227,7 @@ pub(crate) fn render_canvas_with_geo(
                         &rect,
                         state.viz_state.center_lat,
                         state.viz_state.center_lon,
-                        &state.render_processing,
+                        &processing,
                         gpu_sweep,
                         chunk_boundary,
                     );

--- a/src/ui/canvas.rs
+++ b/src/ui/canvas.rs
@@ -208,7 +208,13 @@ pub(crate) fn render_canvas_with_geo(
                 let (gpu_sweep, between_sweeps) =
                     compute_gpu_sweep_state(state, timeline, live, playback, derived, sweep_info);
 
-                let chunk_boundary = live.radar_model.estimated_azimuth;
+                // Age desaturation needs the estimated antenna azimuth; only
+                // supply it while the view's sweep animation is active so a
+                // fixed elevation filter doesn't keep fading between visits.
+                let chunk_boundary = derived
+                    .effective_sweep_animation
+                    .then_some(live.radar_model.estimated_azimuth)
+                    .flatten();
 
                 if let Some(renderer) = gpu_renderer {
                     // Live compositing keeps `gpu_sweep` set even when animation
@@ -580,20 +586,19 @@ fn compute_gpu_sweep_state(
     derived: &crate::subsystem::Derived,
     sweep_info: Option<(f32, f32)>,
 ) -> (Option<(f32, f32)>, bool) {
-    // In live mode the GPU needs the partial-data azimuth range to
-    // composite incoming chunks (and the overlay needs it to colour the
-    // donut wedges), so the live branch always emits sweep boundaries
-    // regardless of the user's sweep_animation preference. The overlay
-    // suppresses the rotating lines separately when the toggle is off.
-    // The archive branch still respects effective_sweep_animation().
-    // The live partial's azimuth range is the GPU's sweep boundary; otherwise,
-    // when animating, resolve the archive sweep the playhead sits in. The
-    // before/within/after classification + sentinel handling is pure core.
-    let live_range = live
-        .radar_model
-        .active_sweep
-        .as_ref()
-        .and_then(|s| s.data_azimuth_range);
+    // Live partial compositing only when the in-progress elevation matches
+    // the user's filter (Latest accepts any cut). Otherwise other tilts would
+    // keep driving the GPU sweep boundary and age desaturation between visits
+    // of a fixed elevation. Archive animation still uses effective_sweep_animation.
+    let selected_elev = state.viz_state.elevation_selection.elevation_number();
+    let live_range = crate::core::canvas::live_compositing_azimuth_range(
+        selected_elev,
+        live.radar_model.collecting_elevation(),
+        live.radar_model
+            .active_sweep
+            .as_ref()
+            .and_then(|s| s.data_azimuth_range),
+    );
     let playback_ts = playback.state.playback_position();
     let sweep_bounds = if live_range.is_none() && derived.effective_sweep_animation {
         timeline


### PR DESCRIPTION
## Summary
- Fixes #134: do not desaturate radar data for age/staleness when sweep animation is inactive (toggled off, macro mode, filters, or otherwise not effectively on).
- Live mode still enables the GPU sweep path for partial-chunk compositing when the viewed elevation is collecting; desaturation is gated on both the preference and view-level `effective_sweep_animation`.
- Fixed elevation filter: sweep animation, age desaturation, and live compositing azimuth are suppressed while the antenna is on other tilts (between visits of the selected cut).
- Pure core helpers + unit tests; docs updated in `docs/RENDERING.md`.

## Test plan
- [x] `cargo fmt`
- [x] `cargo check` / clippy via pre-commit
- [x] unit tests for elevation gate + desaturation gate
- [x] Manually: stream live with sweep animation on + data age desaturation on → age fade visible while collecting
- [x] Manually: toggle sweep animation off while streaming → full-saturation image
- [x] Manually: fixed single elevation filter → no rotating line / no desat between visits; both resume when that tilt collects again
- [x] Manually: Latest (all tilts) → animation continues across elevations as before