### PR TITLE
Add timestamp stamp for national mosaic

### DIFF
--- a/src/nexrad/render/national_mosaic.rs
+++ b/src/nexrad/render/national_mosaic.rs
@@ -58,6 +58,9 @@ pub(crate) struct NationalMosaic {
     /// Timestamp (seconds) of the last attempt — successful or not. Used to
     /// gate the next attempt against `REFRESH_INTERVAL_SECS`.
     last_attempt_ts: Option<f64>,
+    /// Wall-clock seconds when the currently held texture was successfully
+    /// fetched. Cleared with the texture; never set on failed attempts.
+    image_time: Option<f64>,
     in_flight: Rc<RefCell<bool>>,
     sender: Sender<FetchOutcome>,
     receiver: Receiver<FetchOutcome>,
@@ -69,6 +72,7 @@ impl Default for NationalMosaic {
         Self {
             texture: None,
             last_attempt_ts: None,
+            image_time: None,
             in_flight: Rc::new(RefCell::new(false)),
             sender,
             receiver,
@@ -82,9 +86,10 @@ impl NationalMosaic {
     /// so no GPU memory is held while the layer is off.
     pub(crate) fn poll_tick(&mut self, ctx: &egui::Context, enabled: bool) {
         if !enabled {
-            if self.texture.is_some() || self.last_attempt_ts.is_some() {
+            if self.texture.is_some() || self.last_attempt_ts.is_some() || self.image_time.is_some()
+            {
                 self.texture = None;
-                self.last_attempt_ts = None;
+                clear_on_disable(&mut self.last_attempt_ts, &mut self.image_time);
             }
             while self.receiver.try_recv().is_ok() {}
             return;
@@ -96,10 +101,10 @@ impl NationalMosaic {
                     let handle =
                         ctx.load_texture("national_mosaic", image, egui::TextureOptions::LINEAR);
                     self.texture = Some(handle);
-                    self.last_attempt_ts = Some(fetched_at);
+                    record_loaded(&mut self.last_attempt_ts, &mut self.image_time, fetched_at);
                 }
                 FetchOutcome::Failed { attempted_at } => {
-                    self.last_attempt_ts = Some(attempted_at);
+                    record_failed(&mut self.last_attempt_ts, attempted_at);
                 }
             }
         }
@@ -159,10 +164,36 @@ impl NationalMosaic {
         self.texture.as_ref()
     }
 
+    /// Wall-clock seconds when the currently displayed mosaic image was
+    /// successfully fetched. `None` when no texture is held.
+    pub(crate) fn image_time(&self) -> Option<f64> {
+        self.image_time
+    }
+
     /// Mosaic geographic bounds as (min_lon, min_lat, max_lon, max_lat).
     pub(crate) fn bounds(&self) -> (f64, f64, f64, f64) {
         MOSAIC_BOUNDS
     }
+}
+
+/// Pure state transition for a successful mosaic load: stamp both the
+/// attempt clock and the image time. Kept free of I/O so unit tests can
+/// pin the contract without a GPU texture.
+fn record_loaded(last_attempt_ts: &mut Option<f64>, image_time: &mut Option<f64>, fetched_at: f64) {
+    *last_attempt_ts = Some(fetched_at);
+    *image_time = Some(fetched_at);
+}
+
+/// Pure state transition for a failed mosaic attempt: advance the attempt
+/// clock only — leave any previously loaded image time alone.
+fn record_failed(last_attempt_ts: &mut Option<f64>, attempted_at: f64) {
+    *last_attempt_ts = Some(attempted_at);
+}
+
+/// Pure disable path: drop texture-associated timestamps.
+fn clear_on_disable(last_attempt_ts: &mut Option<f64>, image_time: &mut Option<f64>) {
+    *last_attempt_ts = None;
+    *image_time = None;
 }
 
 /// Fetch a PNG via browser-native image decoding and convert to an
@@ -237,4 +268,49 @@ async fn fetch_and_decode(url: &str) -> Result<egui::ColorImage, String> {
         [w as usize, h as usize],
         &bytes,
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    #[wasm_bindgen_test]
+    fn loaded_sets_image_time() {
+        let mut last = None;
+        let mut image = None;
+        record_loaded(&mut last, &mut image, 1_700_000_000.0);
+        assert_eq!(last, Some(1_700_000_000.0));
+        assert_eq!(image, Some(1_700_000_000.0));
+    }
+
+    #[wasm_bindgen_test]
+    fn failed_does_not_touch_image_time() {
+        let mut last = Some(100.0);
+        let image = Some(100.0);
+        record_failed(&mut last, 200.0);
+        assert_eq!(last, Some(200.0));
+        assert_eq!(image, Some(100.0));
+    }
+
+    #[wasm_bindgen_test]
+    fn disable_clears_image_time() {
+        let mut last = Some(100.0);
+        let mut image = Some(100.0);
+        clear_on_disable(&mut last, &mut image);
+        assert_eq!(last, None);
+        assert_eq!(image, None);
+    }
+
+    #[wasm_bindgen_test]
+    fn failed_then_loaded_updates_image_time() {
+        let mut last = None;
+        let mut image = None;
+        record_failed(&mut last, 50.0);
+        assert_eq!(image, None);
+        record_loaded(&mut last, &mut image, 75.0);
+        assert_eq!(image, Some(75.0));
+        record_failed(&mut last, 90.0);
+        assert_eq!(image, Some(75.0));
+    }
 }

--- a/src/nexrad/render/national_mosaic.rs
+++ b/src/nexrad/render/national_mosaic.rs
@@ -7,7 +7,13 @@
 //! routes through `crate::net::retry::with_retry`, so transient failures get
 //! a short burst of exponential-backoff retries instead of waiting for the
 //! full refresh interval to roll around.
+//!
+//! Product valid time comes from the layer's WMS `time` dimension
+//! (`GetCapabilities` `Extent/@default`), not the client wall clock. The
+//! subsequent `GetMap` request pins `TIME=` to that same ISO8601 instant so
+//! the texture and canvas stamp describe one product.
 
+use crate::net::err_text;
 use crate::net::retry::{with_retry, Verdict, DEFAULT_POLICY};
 use eframe::egui;
 use futures_channel::oneshot;
@@ -16,23 +22,19 @@ use std::rc::Rc;
 use std::sync::mpsc::{channel, Receiver, Sender};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
+use wasm_bindgen_futures::JsFuture;
 
-/// NOAA NCEP GeoServer WMS endpoint serving the MRMS quality-controlled
-/// CONUS base reflectivity. Returns a single PNG rendered to whatever bbox
-/// and pixel size we request, with `Access-Control-Allow-Origin: *`.
-/// Updated by the upstream MRMS feed every ~2 min.
-const MOSAIC_URL: &str = concat!(
+/// Base OWS endpoint for the CONUS quality-controlled base reflectivity layer.
+const MOSAIC_OWS: &str = "https://opengeo.ncep.noaa.gov/geoserver/conus/conus_bref_qcd/ows";
+
+/// WMS GetCapabilities URL — advertises the layer's current `time` default.
+const CAPABILITIES_URL: &str = concat!(
     "https://opengeo.ncep.noaa.gov/geoserver/conus/conus_bref_qcd/ows",
-    "?service=WMS&version=1.1.1&request=GetMap",
-    "&layers=conus_bref_qcd",
-    "&bbox=-126,24,-66,50",
-    "&width=1200&height=520",
-    "&srs=EPSG:4326",
-    "&format=image/png&transparent=true&styles=",
+    "?service=WMS&version=1.1.1&request=GetCapabilities",
 );
 
 /// Bounds of the composite in degrees: (min_lon, min_lat, max_lon, max_lat).
-/// Must match the bbox in [`MOSAIC_URL`] above so the image registers
+/// Must match the bbox in [`mosaic_getmap_url`] so the image registers
 /// correctly under the map projection.
 const MOSAIC_BOUNDS: (f64, f64, f64, f64) = (-126.0, 24.0, -66.0, 50.0);
 
@@ -45,7 +47,10 @@ const REFRESH_INTERVAL_SECS: f64 = 120.0;
 enum FetchOutcome {
     Loaded {
         image: egui::ColorImage,
+        /// Wall-clock seconds when this attempt finished (refresh gating).
         fetched_at: f64,
+        /// MRMS product valid time (unix seconds) from WMS `time` default.
+        product_time: f64,
     },
     Failed {
         attempted_at: f64,
@@ -58,8 +63,8 @@ pub(crate) struct NationalMosaic {
     /// Timestamp (seconds) of the last attempt — successful or not. Used to
     /// gate the next attempt against `REFRESH_INTERVAL_SECS`.
     last_attempt_ts: Option<f64>,
-    /// Wall-clock seconds when the currently held texture was successfully
-    /// fetched. Cleared with the texture; never set on failed attempts.
+    /// MRMS product valid time (unix seconds) for the currently held texture.
+    /// Cleared with the texture; never set on failed attempts.
     image_time: Option<f64>,
     in_flight: Rc<RefCell<bool>>,
     sender: Sender<FetchOutcome>,
@@ -97,11 +102,20 @@ impl NationalMosaic {
 
         while let Ok(outcome) = self.receiver.try_recv() {
             match outcome {
-                FetchOutcome::Loaded { image, fetched_at } => {
+                FetchOutcome::Loaded {
+                    image,
+                    fetched_at,
+                    product_time,
+                } => {
                     let handle =
                         ctx.load_texture("national_mosaic", image, egui::TextureOptions::LINEAR);
                     self.texture = Some(handle);
-                    record_loaded(&mut self.last_attempt_ts, &mut self.image_time, fetched_at);
+                    record_loaded(
+                        &mut self.last_attempt_ts,
+                        &mut self.image_time,
+                        fetched_at,
+                        product_time,
+                    );
                 }
                 FetchOutcome::Failed { attempted_at } => {
                     record_failed(&mut self.last_attempt_ts, attempted_at);
@@ -128,13 +142,9 @@ impl NationalMosaic {
         let ctx_clone = ctx.clone();
         wasm_bindgen_futures::spawn_local(async move {
             let outcome = match with_retry(&DEFAULT_POLICY, "national_mosaic", |_attempt| async {
-                match fetch_and_decode(MOSAIC_URL).await {
-                    Ok(image) => Verdict::Ok(image),
+                match fetch_mosaic_product().await {
+                    Ok(loaded) => Verdict::Ok(loaded),
                     Err(e) => {
-                        // The HtmlImageElement load API doesn't surface HTTP
-                        // status codes, so we can't distinguish 4xx from 5xx
-                        // from network failure. Treat all errors as transient
-                        // and let the policy's attempt budget bound it.
                         log::debug!("National mosaic fetch attempt failed: {}", e);
                         Verdict::Retry { after: None }
                     }
@@ -142,9 +152,10 @@ impl NationalMosaic {
             })
             .await
             {
-                Ok(image) => FetchOutcome::Loaded {
+                Ok((image, product_time)) => FetchOutcome::Loaded {
                     image,
                     fetched_at: js_sys::Date::now() / 1000.0,
+                    product_time,
                 },
                 Err(msg) => {
                     log::warn!("National mosaic fetch failed: {}", msg);
@@ -164,8 +175,8 @@ impl NationalMosaic {
         self.texture.as_ref()
     }
 
-    /// Wall-clock seconds when the currently displayed mosaic image was
-    /// successfully fetched. `None` when no texture is held.
+    /// MRMS product valid time (unix seconds) for the currently displayed
+    /// mosaic. `None` when no texture is held.
     pub(crate) fn image_time(&self) -> Option<f64> {
         self.image_time
     }
@@ -176,12 +187,15 @@ impl NationalMosaic {
     }
 }
 
-/// Pure state transition for a successful mosaic load: stamp both the
-/// attempt clock and the image time. Kept free of I/O so unit tests can
-/// pin the contract without a GPU texture.
-fn record_loaded(last_attempt_ts: &mut Option<f64>, image_time: &mut Option<f64>, fetched_at: f64) {
+/// Pure state transition for a successful mosaic load.
+fn record_loaded(
+    last_attempt_ts: &mut Option<f64>,
+    image_time: &mut Option<f64>,
+    fetched_at: f64,
+    product_time: f64,
+) {
     *last_attempt_ts = Some(fetched_at);
-    *image_time = Some(fetched_at);
+    *image_time = Some(product_time);
 }
 
 /// Pure state transition for a failed mosaic attempt: advance the attempt
@@ -194,6 +208,100 @@ fn record_failed(last_attempt_ts: &mut Option<f64>, attempted_at: f64) {
 fn clear_on_disable(last_attempt_ts: &mut Option<f64>, image_time: &mut Option<f64>) {
     *last_attempt_ts = None;
     *image_time = None;
+}
+
+/// Build a timed GetMap URL so the PNG matches the advertised product time.
+fn mosaic_getmap_url(time_iso: &str) -> String {
+    // TIME is percent-encoded only for the separators that matter in a query;
+    // ISO8601 uses `:` and the server accepts them unencoded, matching other
+    // opengeo clients.
+    format!(
+        "{base}?service=WMS&version=1.1.1&request=GetMap\
+         &layers=conus_bref_qcd\
+         &bbox=-126,24,-66,50\
+         &width=1200&height=520\
+         &srs=EPSG:4326\
+         &format=image/png&transparent=true&styles=\
+         &time={time}",
+        base = MOSAIC_OWS,
+        time = time_iso,
+    )
+}
+
+/// Pull the default product time from a WMS 1.1.1 GetCapabilities body.
+///
+/// Looks for `Extent name="time" ... default="..."` (the opengeo MRMS layout).
+/// Returns the raw ISO8601 string from the attribute.
+fn parse_wms_time_default(xml: &str) -> Option<&str> {
+    // Prefer an Extent (or Dimension) whose name is time and that carries default=.
+    for marker in ["Extent name=\"time\"", "Dimension name=\"time\""] {
+        let mut rest = xml;
+        while let Some(idx) = rest.find(marker) {
+            let after = &rest[idx + marker.len()..];
+            let end = after.find('>').unwrap_or(after.len());
+            let attrs = &after[..end];
+            if let Some(v) = attr_value(attrs, "default") {
+                return Some(v);
+            }
+            rest = &after[end..];
+        }
+    }
+    None
+}
+
+/// Read `name="value"` (double-quoted) from a fragment of XML attributes.
+fn attr_value<'a>(attrs: &'a str, name: &str) -> Option<&'a str> {
+    let key = format!("{name}=\"");
+    let start = attrs.find(&key)? + key.len();
+    let tail = &attrs[start..];
+    let end = tail.find('"')?;
+    Some(&tail[..end])
+}
+
+/// Parse an ISO8601 / RFC3339 instant (e.g. `2026-08-11T19:52:12Z`) to unix
+/// seconds. Accepts optional fractional seconds.
+fn parse_iso8601_to_unix_secs(s: &str) -> Option<f64> {
+    chrono::DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|dt| dt.timestamp() as f64 + (dt.timestamp_subsec_millis() as f64) / 1000.0)
+}
+
+/// Fetch capabilities → product time, then the timed GetMap PNG.
+async fn fetch_mosaic_product() -> Result<(egui::ColorImage, f64), String> {
+    let caps = fetch_text(CAPABILITIES_URL).await?;
+    let time_iso = parse_wms_time_default(&caps)
+        .ok_or_else(|| "WMS capabilities missing time default".to_string())?
+        .to_string();
+    let product_time = parse_iso8601_to_unix_secs(&time_iso)
+        .ok_or_else(|| format!("unparseable WMS time default: {time_iso}"))?;
+    let image = fetch_and_decode(&mosaic_getmap_url(&time_iso)).await?;
+    Ok((image, product_time))
+}
+
+/// GET a text body (GetCapabilities XML) via `window.fetch`.
+async fn fetch_text(url: &str) -> Result<String, String> {
+    let window = web_sys::window().ok_or("no window")?;
+    let init = web_sys::RequestInit::new();
+    init.set_method("GET");
+    init.set_mode(web_sys::RequestMode::Cors);
+    let request = web_sys::Request::new_with_str_and_init(url, &init)
+        .map_err(|e| format!("request init failed: {:?}", e))?;
+    let resp_value = JsFuture::from(window.fetch_with_request(&request))
+        .await
+        .map_err(err_text)?;
+    let resp: web_sys::Response = resp_value
+        .dyn_into()
+        .map_err(|_| "invalid response object".to_string())?;
+    if !resp.ok() {
+        return Err(format!("HTTP {}", resp.status()));
+    }
+    let text_promise = resp
+        .text()
+        .map_err(|e| format!("failed to read body: {}", err_text(e)))?;
+    let text_value = JsFuture::from(text_promise).await.map_err(err_text)?;
+    text_value
+        .as_string()
+        .ok_or_else(|| "body not a string".to_string())
 }
 
 /// Fetch a PNG via browser-native image decoding and convert to an
@@ -276,11 +384,11 @@ mod tests {
     use wasm_bindgen_test::wasm_bindgen_test;
 
     #[wasm_bindgen_test]
-    fn loaded_sets_image_time() {
+    fn loaded_sets_product_time_not_fetch_clock() {
         let mut last = None;
         let mut image = None;
-        record_loaded(&mut last, &mut image, 1_700_000_000.0);
-        assert_eq!(last, Some(1_700_000_000.0));
+        record_loaded(&mut last, &mut image, 1_700_000_100.0, 1_700_000_000.0);
+        assert_eq!(last, Some(1_700_000_100.0));
         assert_eq!(image, Some(1_700_000_000.0));
     }
 
@@ -308,9 +416,57 @@ mod tests {
         let mut image = None;
         record_failed(&mut last, 50.0);
         assert_eq!(image, None);
-        record_loaded(&mut last, &mut image, 75.0);
-        assert_eq!(image, Some(75.0));
+        record_loaded(&mut last, &mut image, 75.0, 70.0);
+        assert_eq!(image, Some(70.0));
         record_failed(&mut last, 90.0);
-        assert_eq!(image, Some(75.0));
+        assert_eq!(image, Some(70.0));
+    }
+
+    #[wasm_bindgen_test]
+    fn parse_wms_time_default_reads_extent_attribute() {
+        let xml = r#"
+            <Layer>
+              <Name>conus_bref_qcd</Name>
+              <Dimension name="time" units="ISO8601"/>
+              <Extent name="time" default="2026-08-11T19:52:12Z" nearestValue="1">
+                2026-08-11T19:50:09.000Z,2026-08-11T19:52:12.000Z
+              </Extent>
+            </Layer>
+        "#;
+        assert_eq!(parse_wms_time_default(xml), Some("2026-08-11T19:52:12Z"));
+    }
+
+    #[wasm_bindgen_test]
+    fn parse_wms_time_default_missing_returns_none() {
+        assert_eq!(parse_wms_time_default("<Layer/>"), None);
+        assert_eq!(
+            parse_wms_time_default(r#"<Extent name="elevation" default="0"/>"#),
+            None
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn parse_iso8601_z_and_fractional() {
+        assert_eq!(
+            parse_iso8601_to_unix_secs("2026-08-11T19:52:12Z"),
+            Some(1_786_477_932.0)
+        );
+        let frac = parse_iso8601_to_unix_secs("2026-08-11T19:52:12.500Z").unwrap();
+        assert!((frac - 1_786_477_932.5).abs() < 1e-9);
+    }
+
+    #[wasm_bindgen_test]
+    fn parse_iso8601_rejects_garbage() {
+        assert_eq!(parse_iso8601_to_unix_secs("not-a-time"), None);
+        assert_eq!(parse_iso8601_to_unix_secs(""), None);
+    }
+
+    #[wasm_bindgen_test]
+    fn getmap_url_embeds_time_and_bbox() {
+        let url = mosaic_getmap_url("2026-08-11T19:52:12Z");
+        assert!(url.contains("request=GetMap"));
+        assert!(url.contains("time=2026-08-11T19:52:12Z"));
+        assert!(url.contains("bbox=-126,24,-66,50"));
+        assert!(url.starts_with(MOSAIC_OWS));
     }
 }

--- a/src/ui/canvas_overlays/mod.rs
+++ b/src/ui/canvas_overlays/mod.rs
@@ -26,6 +26,7 @@ mod compass;
 mod globe;
 mod gps_location;
 mod info;
+mod mosaic_time;
 mod mping;
 mod national_mosaic;
 mod scale_bar;
@@ -59,12 +60,7 @@ pub(crate) struct OverlayContext<'a> {
     /// Live streaming subsystem (for the in-progress chunk indicator
     /// that the overlay info panel shows).
     pub live: &'a Live,
-    /// Per-frame derived snapshot. Currently unused by the chrome
-    /// overlays themselves, but available so future predicates (e.g.
-    /// hide the color scale while data is stale) can gate on it
-    /// without changing the signature.
-    #[allow(dead_code)]
-    // Doc above: kept so future overlay predicates don't change the signature.
+    /// Per-frame derived snapshot (e.g. `data_is_live` for mosaic stamp).
     pub derived: &'a Derived,
 }
 
@@ -100,6 +96,7 @@ pub(crate) fn render_chrome_overlays(ui: &mut egui::Ui, ctx: &OverlayContext) {
         &color_scale::ColorScaleOverlay, // z=20
         &compass::CompassOverlay,        // z=30
         &scale_bar::ScaleBarOverlay,     // z=40
+        &mosaic_time::MosaicTimeOverlay, // z=50
     ];
 
     debug_assert!(

--- a/src/ui/canvas_overlays/mosaic_time.rs
+++ b/src/ui/canvas_overlays/mosaic_time.rs
@@ -1,0 +1,49 @@
+//! National mosaic image-time stamp in the bottom-right canvas corner.
+//!
+//! Shown only while the mosaic layer is on, data is live, and a texture has
+//! been successfully loaded. Formats through the shared clock helpers so a
+//! local/UTC flip reformats this stamp in the same frame as every other
+//! readout.
+
+use crate::ui::time_format::format_mosaic_stamp;
+use eframe::egui::{self, Align2, Color32, FontId, Vec2};
+
+/// Trait wrapper for the registry. Z-order sits above the scale bar so the
+/// stamp stays readable over map chrome.
+pub(super) struct MosaicTimeOverlay;
+
+impl super::Overlay for MosaicTimeOverlay {
+    fn z_order(&self) -> i32 {
+        50
+    }
+
+    fn visible(&self, ctx: &super::OverlayContext) -> bool {
+        ctx.state.layer_state.geo.national_mosaic
+            && ctx.derived.data_is_live
+            && ctx.state.national_mosaic.image_time().is_some()
+    }
+
+    fn draw(&self, ui: &mut egui::Ui, ctx: &super::OverlayContext) {
+        let Some(label) = format_mosaic_stamp(
+            ctx.state.national_mosaic.image_time(),
+            ctx.state.use_local_time,
+        ) else {
+            return;
+        };
+
+        let painter = ui.painter();
+        let pos = ctx.rect.right_bottom() - Vec2::new(12.0, 12.0);
+        let font = FontId::monospace(11.0);
+        let color = Color32::from_rgba_unmultiplied(200, 200, 220, 220);
+
+        // Soft shadow so the stamp stays legible over bright mosaic cells.
+        painter.text(
+            pos + Vec2::new(1.0, 1.0),
+            Align2::RIGHT_BOTTOM,
+            &label,
+            font.clone(),
+            Color32::from_rgba_unmultiplied(0, 0, 0, 140),
+        );
+        painter.text(pos, Align2::RIGHT_BOTTOM, label, font, color);
+    }
+}

--- a/src/ui/canvas_overlays/mosaic_time.rs
+++ b/src/ui/canvas_overlays/mosaic_time.rs
@@ -1,9 +1,10 @@
-//! National mosaic image-time stamp in the bottom-right canvas corner.
+//! National mosaic product-valid-time stamp in the bottom-right canvas corner.
 //!
 //! Shown only while the mosaic layer is on, data is live, and a texture has
-//! been successfully loaded. Formats through the shared clock helpers so a
-//! local/UTC flip reformats this stamp in the same frame as every other
-//! readout.
+//! been successfully loaded. The time is the MRMS product valid time from the
+//! WMS `time` dimension (not client fetch time). Formats through the shared
+//! clock helpers so a local/UTC flip reformats this stamp in the same frame as
+//! every other readout.
 
 use crate::ui::time_format::format_mosaic_stamp;
 use eframe::egui::{self, Align2, Color32, FontId, Vec2};

--- a/src/ui/time_format.rs
+++ b/src/ui/time_format.rs
@@ -169,6 +169,17 @@ fn to_12h(hour24: u32) -> (u32, &'static str) {
     (hour12, meridiem)
 }
 
+/// Canvas stamp for the national mosaic image time.
+///
+/// `ts` is the wall-clock seconds when the currently held mosaic PNG was
+/// fetched. Returns `None` when there is no image yet so the caller can skip
+/// painting. Honors `use_local` the same way as other canvas clocks.
+pub(crate) fn format_mosaic_stamp(ts: Option<f64>, use_local: bool) -> Option<String> {
+    let ts = ts?;
+    let clock = format_clock_12h(ts, use_local, Compaction::Full);
+    Some(format!("Mosaic \u{00B7} {clock}"))
+}
+
 /// Plain-language data-age phrasing for the live edge (spec §5/§11.3):
 /// "updated just now", "updated 1m ago", "updated 2h ago". `age_secs` is
 /// wall-clock now minus the displayed frame's collection time. Negative ages
@@ -293,5 +304,18 @@ mod tests {
     #[wasm_bindgen_test]
     fn updated_ago_negative_reads_as_just_now() {
         assert_eq!(format_updated_ago(-5.0), "updated just now");
+    }
+
+    #[wasm_bindgen_test]
+    fn mosaic_stamp_none_when_no_image() {
+        assert_eq!(format_mosaic_stamp(None, false), None);
+    }
+
+    #[wasm_bindgen_test]
+    fn mosaic_stamp_utc_includes_label_and_clock() {
+        assert_eq!(
+            format_mosaic_stamp(Some(TS), false).as_deref(),
+            Some("Mosaic \u{00B7} 7:41:07 PM UTC")
+        );
     }
 }

--- a/src/ui/time_format.rs
+++ b/src/ui/time_format.rs
@@ -169,11 +169,12 @@ fn to_12h(hour24: u32) -> (u32, &'static str) {
     (hour12, meridiem)
 }
 
-/// Canvas stamp for the national mosaic image time.
+/// Canvas stamp for the national mosaic product valid time.
 ///
-/// `ts` is the wall-clock seconds when the currently held mosaic PNG was
-/// fetched. Returns `None` when there is no image yet so the caller can skip
-/// painting. Honors `use_local` the same way as other canvas clocks.
+/// `ts` is the MRMS product valid time (unix seconds) from the WMS `time`
+/// dimension, not the client fetch clock. Returns `None` when there is no
+/// image yet so the caller can skip painting. Honors `use_local` the same way
+/// as other canvas clocks.
 pub(crate) fn format_mosaic_stamp(ts: Option<f64>, use_local: bool) -> Option<String> {
     let ts = ts?;
     let clock = format_clock_12h(ts, use_local, Compaction::Full);


### PR DESCRIPTION
## Summary
- Stamp the canvas with the national mosaic's **MRMS product valid time** (WMS `time` dimension), not client fetch time
- On each refresh: `GetCapabilities` → parse `Extent name="time" default="…"` → timed `GetMap&TIME=` so texture and stamp share one product instant
- Bottom-right chrome overlay while the mosaic layer is on and live

Closes #112

## Test plan
- [ ] Enable national mosaic; stamp shows product valid time (should track ~2 min MRMS steps, not exact fetch clock)
- [ ] Confirm stamp updates after mosaic refresh
- [ ] Toggle local/UTC; stamp reformats
- [ ] Disable mosaic layer; stamp disappears
- [ ] `cargo test --bin nexrad-workbench` / clippy clean