### PR TITLE
Enable location layer when site picked via geolocation

### DIFF
--- a/src/app/geolocation.rs
+++ b/src/app/geolocation.rs
@@ -9,7 +9,7 @@
 //! modal's own channel for site selection. The UI never touches `web_sys` or
 //! spawns these futures itself.
 
-use crate::core::LocationResult;
+use crate::core::{LocationResult, LocationSource};
 use crate::net::retry::{with_retry, Verdict, DEFAULT_POLICY};
 use crate::WorkbenchApp;
 use eframe::egui;
@@ -81,7 +81,11 @@ pub(super) fn start_geolocation(
             .unwrap()
             .as_f64()
             .unwrap_or(0.0);
-        let _ = results_ok.unbounded_send(LocationResult::Success(lat, lon));
+        let _ = results_ok.unbounded_send(LocationResult::Success {
+            lat,
+            lon,
+            source: LocationSource::Geolocation,
+        });
         ctx_ok.request_repaint();
     });
 
@@ -128,7 +132,11 @@ fn start_zip_lookup(zip: &str, results: UnboundedSender<LocationResult>, ctx: eg
             });
 
         let payload = match result {
-            Ok((lat, lon)) => LocationResult::Success(lat, lon),
+            Ok((lat, lon)) => LocationResult::Success {
+                lat,
+                lon,
+                source: LocationSource::Zip,
+            },
             Err(e) => LocationResult::Error(e),
         };
         let _ = results.unbounded_send(payload);

--- a/src/core/effect.rs
+++ b/src/core/effect.rs
@@ -20,11 +20,33 @@
 use crate::core::UserPreferences;
 use crate::core::ViewState;
 
+/// How a lat/lon was obtained. Distinguishes browser geolocation from zip
+/// geocoding so site-pick can enable the My Location layer only for the
+/// former (issue #135).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LocationSource {
+    /// `navigator.geolocation` (site "Use My Location" or the GPS overlay).
+    Geolocation,
+    /// Zippopotam.us zip-code lookup.
+    Zip,
+}
+
+/// Whether a successful site-pick location fix should also turn on the
+/// My Location layer and seed it with the user's coordinates.
+pub(crate) fn enable_location_layer_on_site_pick(source: LocationSource) -> bool {
+    matches!(source, LocationSource::Geolocation)
+}
+
 /// Result of an async location operation (browser geolocation or zip-code
-/// geocoding) — the response vocabulary of [`Effect::StartGeolocation`].
+/// geocoding) — the response vocabulary of [`Effect::StartGeolocation`] /
+/// [`Effect::LocateForSite`] / [`Effect::GeocodeZip`].
 pub(crate) enum LocationResult {
     /// Successfully resolved to a lat/lon.
-    Success(f64, f64),
+    Success {
+        lat: f64,
+        lon: f64,
+        source: LocationSource,
+    },
     /// The operation failed with an error message.
     Error(String),
 }
@@ -67,4 +89,22 @@ pub(crate) enum Effect {
     /// and deliver the coordinates to the site modal's [`LocationResult`]
     /// channel.
     GeocodeZip(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    #[wasm_bindgen_test]
+    fn geolocation_site_pick_enables_location_layer() {
+        assert!(enable_location_layer_on_site_pick(
+            LocationSource::Geolocation
+        ));
+    }
+
+    #[wasm_bindgen_test]
+    fn zip_site_pick_leaves_location_layer_alone() {
+        assert!(!enable_location_layer_on_site_pick(LocationSource::Zip));
+    }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -94,7 +94,7 @@ pub(crate) use domain::worker::{
     CacheLoadResult, ChunkIngestContext, ChunkIngestResult, DecodeResult, IngestContext,
     IngestResult, RenderContext, VolumeData, VolumeSweepMeta, WorkerLoad,
 };
-pub(crate) use effect::{Effect, LocationResult};
+pub(crate) use effect::{Effect, LocationResult, LocationSource};
 pub(crate) use geo_layers::GeoLayer;
 pub(crate) use live_mode::{
     should_stop_for_detached_idle, LiveExitReason, LiveModeState, LivePhase, StreamActivity,

--- a/src/main.rs
+++ b/src/main.rs
@@ -923,7 +923,7 @@ impl eframe::App for WorkbenchApp {
         // inline — so the success/auto-off-on-failure rules stay testable.
         for r in self.diagnostics.gps.drain_results() {
             let intent = match r {
-                core::LocationResult::Success(lat, lon) => {
+                core::LocationResult::Success { lat, lon, .. } => {
                     core::diagnostics::DiagnosticsIntent::GpsResolved(lat, lon)
                 }
                 core::LocationResult::Error(msg) => {

--- a/src/ui/site_modal.rs
+++ b/src/ui/site_modal.rs
@@ -5,6 +5,7 @@
 //! visit (no preferred site saved), shows welcome verbiage; on subsequent
 //! visits, shows a shorter "change site" heading instead.
 
+use crate::core::effect::enable_location_layer_on_site_pick;
 use crate::core::LocationResult;
 use crate::data::{all_sites_sorted, get_site, nearest_site};
 use crate::state::AppState;
@@ -128,13 +129,24 @@ fn draw_site_modal(
     // Poll for async location results
     for result in modal_state.drain_location_results() {
         match result {
-            LocationResult::Success(lat, lon) => {
+            LocationResult::Success { lat, lon, source } => {
                 if let Some(site) = nearest_site(lat, lon) {
                     state.push_command(crate::core::Intent::SelectSite {
                         site_id: site.id.to_string(),
                         lat: site.lat,
                         lon: site.lon,
                     });
+                    // Physical geolocation: show the user's position on the map
+                    // using this same fix (issue #135). Zip picks leave the layer off.
+                    if enable_location_layer_on_site_pick(source) {
+                        state.push_command(crate::core::Intent::SetGeoLayer(
+                            crate::core::GeoLayer::GpsLocation,
+                            true,
+                        ));
+                        state.push_command(crate::core::Intent::Diagnostics(
+                            crate::core::diagnostics::DiagnosticsIntent::GpsResolved(lat, lon),
+                        ));
+                    }
                     modal_state.mode = SiteModalMode::Welcome;
                     modal_state.filter.clear();
                     modal_state.zip_input.clear();


### PR DESCRIPTION
## Summary
- When the user picks a site via browser geolocation, automatically enable the My Location layer
- Seed GPS coords from the same geolocation fix (no second permission prompt)
- Zip-code and manual site picks are unchanged

Closes #135

## Test plan
- [ ] Site modal → Use my location → site selected, location layer on, blue dot at user position
- [ ] Site modal → zip code → site selected, location layer stays off
- [ ] Site modal → browse list → site selected, location layer stays off
- [ ] Toggle location layer off manually still works
- [ ] `cargo test --bin nexrad-workbench` / clippy clean