### PR TITLE
Tighten default map zoom level

### DIFF
--- a/src/geo/camera.rs
+++ b/src/geo/camera.rs
@@ -89,10 +89,16 @@ pub struct Flat2DState {
     pub pan_offset: Vec2,
 }
 
+/// Default 2D map zoom (1.0 = historical 100% / ~500 km radius).
+///
+/// 2.0 halves the visible radius to ~250 km so a typical NEXRAD site's
+/// ~230–460 km coverage fills more of the canvas on first load (issue #140).
+pub(crate) const DEFAULT_FLAT_ZOOM: f32 = 2.0;
+
 impl Default for Flat2DState {
     fn default() -> Self {
         Self {
-            zoom: 1.0,
+            zoom: DEFAULT_FLAT_ZOOM,
             pan_offset: Vec2::ZERO,
         }
     }
@@ -1003,6 +1009,15 @@ mod tests {
         assert!((f.saved.common.site_lon - -98.0).abs() < 1e-4);
         assert!((f.saved.pivot_lat - 39.0).abs() < 1e-4);
         assert!((f.saved.distance - 0.10).abs() < 1e-6);
+        assert!((f.view.zoom - DEFAULT_FLAT_ZOOM).abs() < 1e-6);
+    }
+
+    #[wasm_bindgen_test]
+    fn default_flat_zoom_is_tighter_than_historical_1x() {
+        // Historical default was 1.0 (~500 km radius). 2.0 halves that so the
+        // site's coverage fills more of the canvas on first load (#140).
+        assert!((DEFAULT_FLAT_ZOOM - 2.0).abs() < 1e-6);
+        assert!((Flat2DState::default().zoom - DEFAULT_FLAT_ZOOM).abs() < 1e-6);
     }
 
     #[wasm_bindgen_test]

--- a/src/geo/mod.rs
+++ b/src/geo/mod.rs
@@ -13,7 +13,7 @@ mod renderer;
 
 #[allow(unused_imports)] // GlobeProjection is the 3D Projection adapter.
 pub(crate) use camera::GlobeProjection;
-pub(crate) use camera::{Camera, Flat2DState, UrlOrbitFields, ViewMode};
+pub(crate) use camera::{Camera, Flat2DState, UrlOrbitFields, ViewMode, DEFAULT_FLAT_ZOOM};
 pub(crate) use geo_line_renderer::GeoLineRenderer;
 pub(crate) use globe_renderer::GlobeRenderer;
 pub(crate) use layer::{GeoFeature, GeoLayer, GeoLayerSet, GeoLayerType, GeoLayerVisibility};

--- a/src/state/viz.rs
+++ b/src/state/viz.rs
@@ -155,7 +155,10 @@ impl VizState {
     /// Current 2D zoom level (1.0 = 100%). Falls back to the default zoom in
     /// 3D modes (the 2D pan/zoom is only meaningful in the Flat2D variant).
     pub(crate) fn zoom(&self) -> f32 {
-        self.camera.flat_2d().map(|s| s.zoom).unwrap_or(1.0)
+        self.camera
+            .flat_2d()
+            .map(|s| s.zoom)
+            .unwrap_or(crate::geo::DEFAULT_FLAT_ZOOM)
     }
 
     /// Current 2D pan offset. `ZERO` in 3D modes.
@@ -261,7 +264,7 @@ mod tests {
         viz.switch_to_3d_view();
         assert_eq!(viz.view_mode(), ViewMode::Globe3D);
         assert!(!viz.is_2d());
-        assert!((viz.zoom() - 1.0).abs() < 1e-6);
+        assert!((viz.zoom() - crate::geo::DEFAULT_FLAT_ZOOM).abs() < 1e-6);
         assert_eq!(viz.pan_offset(), Vec2::ZERO);
     }
 
@@ -353,7 +356,7 @@ mod coverage_tests {
         // No flat-2D state to write -> setters are no-ops, getters fall back.
         viz.set_zoom(5.0);
         viz.set_pan_offset(Vec2::new(9.0, 9.0));
-        assert!((viz.zoom() - 1.0).abs() < 1e-6);
+        assert!((viz.zoom() - crate::geo::DEFAULT_FLAT_ZOOM).abs() < 1e-6);
         assert_eq!(viz.pan_offset(), Vec2::ZERO);
         // flat_pan_mut yields None in 3D.
         assert!(viz.flat_pan_mut().is_none());

--- a/src/ui/canvas_interaction.rs
+++ b/src/ui/canvas_interaction.rs
@@ -242,7 +242,7 @@ pub(crate) fn handle_canvas_interaction(
     }
 
     if response.double_clicked() {
-        state.viz_state.set_zoom(1.0);
+        state.viz_state.set_zoom(crate::geo::DEFAULT_FLAT_ZOOM);
         state.viz_state.set_pan_offset(Vec2::ZERO);
     }
 }

--- a/src/ui/shortcuts.rs
+++ b/src/ui/shortcuts.rs
@@ -802,7 +802,7 @@ fn handle_reset_camera(
     _: &egui::Context,
 ) {
     if state.viz_state.is_2d() {
-        state.viz_state.set_zoom(1.0);
+        state.viz_state.set_zoom(crate::geo::DEFAULT_FLAT_ZOOM);
         state.viz_state.set_pan_offset(egui::Vec2::ZERO);
     } else {
         state.viz_state.camera.reset();


### PR DESCRIPTION
## Summary
- Raise default 2D map zoom from 1.0 (~500 km radius) to 2.0 (~250 km)
- Share `DEFAULT_FLAT_ZOOM` across first load, double-click reset, and keyboard camera reset

Closes #140

## Test plan
- [ ] Fresh load (no URL `mz`) centers on site with tighter framing than before
- [ ] Double-click canvas resets to the new default zoom
- [ ] Camera reset shortcut matches the new default in 2D
- [ ] URL/`mz` restore and manual zoom still work
- [ ] `cargo test --bin nexrad-workbench` / clippy clean