### PR TITLE
Show NWS alert check time on canvas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,8 +63,8 @@ dependencies = [
  "bitflags 2.13.1",
  "cc",
  "cesu8",
- "jni",
- "jni-sys",
+ "jni 0.21.1",
+ "jni-sys 0.3.0",
  "libc",
  "log",
  "ndk",
@@ -962,7 +962,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1834,7 +1834,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.0",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -1842,10 +1842,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"
@@ -2084,7 +2133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
  "bitflags 2.13.1",
- "jni-sys",
+ "jni-sys 0.3.0",
  "log",
  "ndk-sys",
  "num_enum",
@@ -2104,7 +2153,7 @@ version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
- "jni-sys",
+ "jni-sys 0.3.0",
 ]
 
 [[package]]
@@ -2260,7 +2309,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3204,6 +3253,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3226,7 +3284,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3273,7 +3331,7 @@ checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
  "log",
  "once_cell",
  "rustls",
@@ -3283,7 +3341,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3368,6 +3426,12 @@ name = "self_cell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -3457,6 +3521,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simd_helpers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3464,6 +3538,12 @@ checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "skrifa"
@@ -4221,15 +4301,15 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.1.0"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f00bb839c1cf1e3036066614cbdcd035ecf215206691ea646aa3c60a24f68f2"
+checksum = "62c35be770821a214dbc362fc26908c853e776c0004294d0b10b8a6bad582f94"
 dependencies = [
- "core-foundation 0.10.1",
- "jni",
+ "jni 0.22.4",
  "log",
  "ndk-context",
  "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
  "url",
  "web-sys",
@@ -4256,7 +4336,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/src/core/diagnostics.rs
+++ b/src/core/diagnostics.rs
@@ -232,12 +232,18 @@ pub(crate) struct DiagnosticsVm {
     /// Alerts whose bbox intersects the current view, severity-sorted. Empty in
     /// 3D / before the first canvas frame (no bounds), or when none match.
     pub visible_alerts: Vec<VisibleAlert>,
+    /// Unix seconds when this browser last successfully checked the NWS feed.
+    /// Independent of map bounds so canvas provenance remains available even
+    /// when no alert intersects the current view.
+    pub alerts_last_checked_secs: Option<f64>,
 }
 
 impl DiagnosticsVm {
     /// Build the view-model from the diagnostics state and this frame's visible
     /// bounds (`None` in 3D globe mode / before the canvas has rendered).
     pub(crate) fn build(alerts: &AlertsState, bounds: Option<(f64, f64, f64, f64)>) -> Self {
+        let alerts_last_checked_secs =
+            (alerts.last_success_ms > 0.0).then_some(alerts.last_success_ms / 1000.0);
         let visible_alerts = match bounds {
             Some(b) => alerts
                 .visible_in(b)
@@ -253,7 +259,10 @@ impl DiagnosticsVm {
                 .collect(),
             None => Vec::new(),
         };
-        Self { visible_alerts }
+        Self {
+            visible_alerts,
+            alerts_last_checked_secs,
+        }
     }
 }
 
@@ -993,6 +1002,25 @@ mod coverage_tests {
     fn vm_default_is_empty() {
         let vm = DiagnosticsVm::default();
         assert!(vm.visible_alerts.is_empty());
+        assert_eq!(vm.alerts_last_checked_secs, None);
+    }
+
+    #[wasm_bindgen_test]
+    fn vm_projects_last_success_independent_of_bounds() {
+        let mut alerts = AlertsState {
+            last_success_ms: 123_456.0,
+            ..AlertsState::default()
+        };
+        alerts.alerts.push(warning(
+            "a",
+            AlertSeverity::Extreme,
+            vec![vec![square(0.0, 10.0)]],
+        ));
+
+        let vm = DiagnosticsVm::build(&alerts, None);
+
+        assert!(vm.visible_alerts.is_empty());
+        assert_eq!(vm.alerts_last_checked_secs, Some(123.456));
     }
 
     #[wasm_bindgen_test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1027,6 +1027,7 @@ impl eframe::App for WorkbenchApp {
             &mut self.playback,
             &mut self.chrome,
             &mut self.diagnostics,
+            &diagnostics_vm,
             &derived,
             Some(&self.geo_layers),
             &self.gpu,

--- a/src/ui/canvas.rs
+++ b/src/ui/canvas.rs
@@ -29,6 +29,7 @@ pub(crate) fn render_canvas_with_geo(
     playback: &mut crate::subsystem::Playback,
     chrome: &mut crate::subsystem::Chrome,
     diagnostics: &mut crate::subsystem::Diagnostics,
+    diagnostics_vm: &crate::core::diagnostics::DiagnosticsVm,
     derived: &crate::subsystem::Derived,
     geo_layers: Option<&GeoLayerSet>,
     gpu: &crate::GpuResources,
@@ -89,6 +90,7 @@ pub(crate) fn render_canvas_with_geo(
                         state,
                         live,
                         derived,
+                        diagnostics_vm,
                     },
                 );
 
@@ -418,6 +420,7 @@ pub(crate) fn render_canvas_with_geo(
                         state,
                         live,
                         derived,
+                        diagnostics_vm,
                     },
                 );
 

--- a/src/ui/canvas_overlays/alerts_time.rs
+++ b/src/ui/canvas_overlays/alerts_time.rs
@@ -1,0 +1,47 @@
+//! Last-successful-check stamp for NWS alert layers.
+
+use crate::ui::time_format::{format_clock_12h, Compaction};
+use eframe::egui::{self, Align2, Color32, FontId, Vec2};
+
+pub(super) struct AlertsTimeOverlay;
+
+impl super::Overlay for AlertsTimeOverlay {
+    fn z_order(&self) -> i32 {
+        60
+    }
+
+    fn visible(&self, ctx: &super::OverlayContext) -> bool {
+        let layers = &ctx.state.layer_state.geo;
+        ctx.state.viz_state.view_mode() == crate::geo::ViewMode::Flat2D
+            && ctx.derived.data_is_live
+            && (layers.alerts_warnings || layers.alerts_other)
+            && ctx.diagnostics_vm.alerts_last_checked_secs.is_some()
+    }
+
+    fn draw(&self, ui: &mut egui::Ui, ctx: &super::OverlayContext) {
+        let Some(checked_secs) = ctx.diagnostics_vm.alerts_last_checked_secs else {
+            return;
+        };
+        let clock = format_clock_12h(
+            checked_secs,
+            ctx.state.use_local_time,
+            Compaction::NoSeconds,
+        );
+        let label = format!("Alerts checked {clock}");
+        // Keep one line above the national mosaic stamp, which owns the
+        // bottom-most right-corner position when that layer is visible.
+        let pos = ctx.rect.right_bottom() - Vec2::new(12.0, 28.0);
+        let font = FontId::monospace(11.0);
+        let color = Color32::from_rgba_unmultiplied(200, 200, 220, 220);
+        let painter = ui.painter();
+
+        painter.text(
+            pos + Vec2::new(1.0, 1.0),
+            Align2::RIGHT_BOTTOM,
+            &label,
+            font.clone(),
+            Color32::from_rgba_unmultiplied(0, 0, 0, 140),
+        );
+        painter.text(pos, Align2::RIGHT_BOTTOM, label, font, color);
+    }
+}

--- a/src/ui/canvas_overlays/mod.rs
+++ b/src/ui/canvas_overlays/mod.rs
@@ -21,6 +21,7 @@
 //!    reading the canvas top-to-bottom.
 
 mod alerts;
+mod alerts_time;
 mod color_scale;
 mod compass;
 mod globe;
@@ -62,6 +63,8 @@ pub(crate) struct OverlayContext<'a> {
     pub live: &'a Live,
     /// Per-frame derived snapshot (e.g. `data_is_live` for mosaic stamp).
     pub derived: &'a Derived,
+    /// Pure diagnostics projection used by canvas provenance overlays.
+    pub diagnostics_vm: &'a crate::core::diagnostics::DiagnosticsVm,
 }
 
 /// A corner-chrome overlay: one of the small self-contained surfaces
@@ -97,6 +100,7 @@ pub(crate) fn render_chrome_overlays(ui: &mut egui::Ui, ctx: &OverlayContext) {
         &compass::CompassOverlay,        // z=30
         &scale_bar::ScaleBarOverlay,     // z=40
         &mosaic_time::MosaicTimeOverlay, // z=50
+        &alerts_time::AlertsTimeOverlay, // z=60
     ];
 
     debug_assert!(


### PR DESCRIPTION
## Summary
- project the latest successful NWS alerts check through the diagnostics view model
- show the check time on the live 2D canvas whenever an alert layer is enabled
- honor the existing local/UTC preference and avoid overlapping the mosaic timestamp

## Tests
- `cargo fmt -- --check`
- `cargo check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --bin nexrad-workbench`

Closes #113