### PR TITLE
Improve geographic label placement

### DIFF
--- a/src/core/geo_labels.rs
+++ b/src/core/geo_labels.rs
@@ -1,0 +1,281 @@
+//! Pure screen-space selection for geographic labels.
+
+use crate::geo::{GeoLabelClass, GeoLayerVisibility, ProjectionFingerprint, ScreenBounds};
+
+/// One retained label per this many logical square points at most.
+pub(crate) const LABEL_AREA_PER_ENTRY: f32 = 12_000.0;
+
+/// Padding around measured text bounds, covering the halo plus visual separation.
+pub(crate) const LABEL_COLLISION_PADDING: f32 = 2.0;
+
+/// Layer-toggle inputs that affect the global candidate set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct GeoLabelVisibilityKey {
+    pub states: bool,
+    pub counties: bool,
+    pub cities: bool,
+    pub highways: bool,
+    pub lakes: bool,
+    pub labels: bool,
+}
+
+impl From<&GeoLayerVisibility> for GeoLabelVisibilityKey {
+    fn from(visibility: &GeoLayerVisibility) -> Self {
+        Self {
+            states: visibility.states,
+            counties: visibility.counties,
+            cities: visibility.cities,
+            highways: visibility.highways,
+            lakes: visibility.lakes,
+            labels: visibility.labels,
+        }
+    }
+}
+
+/// Complete identity of a settled geographic-label placement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct GeoLabelPlacementKey {
+    pub projection: ProjectionFingerprint,
+    pub visibility: GeoLabelVisibilityKey,
+    pub dark: bool,
+}
+
+/// Paint-independent metadata consumed by the pure selector.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct GeoLabelSelectionCandidate {
+    pub class: GeoLabelClass,
+    pub bounds: ScreenBounds,
+    pub source_order: usize,
+}
+
+/// Whether the retained placement should be replaced this frame.
+pub(crate) fn should_rebuild_labels(
+    cached: Option<GeoLabelPlacementKey>,
+    requested: GeoLabelPlacementKey,
+    camera_settled: bool,
+) -> bool {
+    cached.is_none() || (cached != Some(requested) && camera_settled)
+}
+
+/// Select globally non-overlapping candidates under an area-derived count cap.
+///
+/// Returned indices address `candidates`. Priority is explicit; source order and
+/// finally input order make every repeated selection deterministic.
+pub(crate) fn select_geo_labels(
+    candidates: &[GeoLabelSelectionCandidate],
+    viewport: ScreenBounds,
+) -> Vec<usize> {
+    let Some(area) = viewport.area() else {
+        return Vec::new();
+    };
+    let budget = ((area / LABEL_AREA_PER_ENTRY).floor() as usize).max(1);
+
+    let mut ordered: Vec<usize> = (0..candidates.len()).collect();
+    ordered.sort_by_key(|&index| {
+        let candidate = &candidates[index];
+        (
+            priority_rank(candidate.class),
+            candidate.source_order,
+            index,
+        )
+    });
+
+    let mut selected = Vec::with_capacity(budget.min(candidates.len()));
+    let mut occupied = Vec::with_capacity(budget.min(candidates.len()));
+
+    for index in ordered {
+        let bounds = candidates[index].bounds;
+        if !bounds.is_valid() || !viewport.contains(bounds) {
+            continue;
+        }
+
+        let padded = bounds.expanded(LABEL_COLLISION_PADDING);
+        if occupied
+            .iter()
+            .any(|existing: &ScreenBounds| padded.intersects(*existing))
+        {
+            continue;
+        }
+
+        selected.push(index);
+        occupied.push(padded);
+        if selected.len() == budget {
+            break;
+        }
+    }
+
+    selected
+}
+
+fn priority_rank(class: GeoLabelClass) -> u8 {
+    match class {
+        GeoLabelClass::State => 0,
+        GeoLabelClass::CityMajor => 1,
+        GeoLabelClass::CityMedium => 2,
+        GeoLabelClass::CitySmall => 3,
+        GeoLabelClass::Highway => 4,
+        GeoLabelClass::Lake => 5,
+        GeoLabelClass::County => 6,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    fn bounds(min_x: f32, min_y: f32, max_x: f32, max_y: f32) -> ScreenBounds {
+        ScreenBounds {
+            min_x,
+            min_y,
+            max_x,
+            max_y,
+        }
+    }
+
+    fn candidate(
+        class: GeoLabelClass,
+        source_order: usize,
+        bounds: ScreenBounds,
+    ) -> GeoLabelSelectionCandidate {
+        GeoLabelSelectionCandidate {
+            class,
+            bounds,
+            source_order,
+        }
+    }
+
+    fn visibility() -> GeoLabelVisibilityKey {
+        GeoLabelVisibilityKey {
+            states: true,
+            counties: true,
+            cities: true,
+            highways: false,
+            lakes: false,
+            labels: true,
+        }
+    }
+
+    fn placement_key(
+        projection: ProjectionFingerprint,
+        visibility: GeoLabelVisibilityKey,
+        dark: bool,
+    ) -> GeoLabelPlacementKey {
+        GeoLabelPlacementKey {
+            projection,
+            visibility,
+            dark,
+        }
+    }
+
+    #[wasm_bindgen_test]
+    fn empty_candidates_and_zero_viewport_select_nothing() {
+        assert!(select_geo_labels(&[], bounds(0.0, 0.0, 100.0, 100.0)).is_empty());
+        let candidates = vec![candidate(
+            GeoLabelClass::State,
+            0,
+            bounds(0.0, 0.0, 10.0, 10.0),
+        )];
+        assert!(select_geo_labels(&candidates, bounds(0.0, 0.0, 0.0, 100.0)).is_empty());
+    }
+
+    #[wasm_bindgen_test]
+    fn conflicts_resolve_in_required_priority_order() {
+        let overlap = bounds(10.0, 10.0, 30.0, 20.0);
+        let candidates = vec![
+            candidate(GeoLabelClass::County, 0, overlap),
+            candidate(GeoLabelClass::Lake, 0, overlap),
+            candidate(GeoLabelClass::Highway, 0, overlap),
+            candidate(GeoLabelClass::CitySmall, 0, overlap),
+            candidate(GeoLabelClass::CityMedium, 0, overlap),
+            candidate(GeoLabelClass::CityMajor, 0, overlap),
+            candidate(GeoLabelClass::State, 0, overlap),
+        ];
+
+        assert_eq!(
+            select_geo_labels(&candidates, bounds(0.0, 0.0, 400.0, 400.0)),
+            vec![6]
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn equal_priority_uses_stable_source_order() {
+        let overlap = bounds(10.0, 10.0, 30.0, 20.0);
+        let candidates = vec![
+            candidate(GeoLabelClass::CityMajor, 9, overlap),
+            candidate(GeoLabelClass::CityMajor, 2, overlap),
+        ];
+        let viewport = bounds(0.0, 0.0, 400.0, 400.0);
+
+        assert_eq!(select_geo_labels(&candidates, viewport), vec![1]);
+        assert_eq!(select_geo_labels(&candidates, viewport), vec![1]);
+    }
+
+    #[wasm_bindgen_test]
+    fn collision_padding_separates_nearby_labels() {
+        let candidates = vec![
+            candidate(GeoLabelClass::State, 0, bounds(0.0, 0.0, 10.0, 10.0)),
+            candidate(GeoLabelClass::State, 1, bounds(13.0, 0.0, 23.0, 10.0)),
+            candidate(GeoLabelClass::State, 2, bounds(15.0, 0.0, 25.0, 10.0)),
+        ];
+
+        assert_eq!(
+            select_geo_labels(&candidates, bounds(0.0, 0.0, 400.0, 400.0)),
+            vec![0, 2]
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn area_budget_caps_non_overlapping_labels() {
+        let candidates: Vec<_> = (0..10)
+            .map(|i| {
+                candidate(
+                    GeoLabelClass::State,
+                    i,
+                    bounds(i as f32 * 20.0, 0.0, i as f32 * 20.0 + 10.0, 10.0),
+                )
+            })
+            .collect();
+        let viewport = bounds(0.0, 0.0, 390.0, LABEL_AREA_PER_ENTRY * 3.9 / 390.0);
+
+        assert_eq!(select_geo_labels(&candidates, viewport).len(), 3);
+    }
+
+    #[wasm_bindgen_test]
+    fn invalid_and_offscreen_candidates_are_rejected() {
+        let candidates = vec![
+            candidate(GeoLabelClass::State, 0, bounds(f32::NAN, 0.0, 1.0, 1.0)),
+            candidate(GeoLabelClass::State, 1, bounds(200.0, 200.0, 210.0, 210.0)),
+            candidate(GeoLabelClass::State, 2, bounds(95.0, 10.0, 105.0, 20.0)),
+        ];
+
+        assert!(select_geo_labels(&candidates, bounds(0.0, 0.0, 100.0, 100.0)).is_empty());
+    }
+
+    #[wasm_bindgen_test]
+    fn rebuild_waits_for_a_changed_placement_to_settle() {
+        let original = placement_key(ProjectionFingerprint::test_value(1), visibility(), true);
+        let changed = placement_key(ProjectionFingerprint::test_value(2), visibility(), true);
+
+        assert!(should_rebuild_labels(None, original, false));
+        assert!(!should_rebuild_labels(Some(original), original, true));
+        assert!(!should_rebuild_labels(Some(original), changed, false));
+        assert!(should_rebuild_labels(Some(original), changed, true));
+    }
+
+    #[wasm_bindgen_test]
+    fn viewport_theme_and_visibility_invalidate_placement() {
+        let base_fingerprint = ProjectionFingerprint::test_value(1);
+        let base = placement_key(base_fingerprint, visibility(), true);
+        let changed_viewport =
+            placement_key(ProjectionFingerprint::test_value(2), visibility(), true);
+        let theme = placement_key(base_fingerprint, visibility(), false);
+        let mut toggled_visibility = visibility();
+        toggled_visibility.counties = false;
+        let toggled = placement_key(base_fingerprint, toggled_visibility, true);
+
+        assert_ne!(base, changed_viewport);
+        assert_ne!(base, theme);
+        assert_ne!(base, toggled);
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -28,6 +28,7 @@ pub(crate) mod canvas;
 pub(crate) mod diagnostics;
 pub(crate) mod domain;
 pub(crate) mod effect;
+pub(crate) mod geo_labels;
 pub(crate) mod geo_layers;
 pub(crate) mod geocode;
 pub(crate) mod intent;

--- a/src/geo/cities.rs
+++ b/src/geo/cities.rs
@@ -8,26 +8,14 @@
 //! should pick a citable source (e.g. the Census Bureau gazetteer) and note it
 //! here — ideally alongside a regeneration script, matching the zones pipeline.
 
-use super::layer::{GeoFeature, GeoLayer, GeoLayerType};
+use super::layer::{CityTier as Tier, GeoFeature, GeoLayer, GeoLayerType};
 use geo_types::Coord;
 
 /// Population tier for controlling visibility at different zoom levels.
-#[derive(Clone, Copy)]
-enum Tier {
-    /// Major metro (pop > 500k) — visible at all zoom levels
-    Major,
-    /// Medium city (pop 200k-500k) — visible at zoom >= 1.5
-    Medium,
-    /// Smaller city (pop 100k-200k) — visible at zoom >= 3.0
-    Small,
-}
-
 struct CityEntry {
     name: &'static str,
     lat: f64,
     lon: f64,
-    #[allow(dead_code)]
-    // Curated zoom-visibility tier (doc on `Tier`); city-layer LOD not wired yet.
     tier: Tier,
 }
 
@@ -853,13 +841,14 @@ pub(crate) fn build_cities_layer() -> GeoLayer {
     let mut layer = GeoLayer::new(GeoLayerType::Cities);
 
     for city in CITIES {
-        layer.features.push(GeoFeature::Point(
-            Coord {
+        layer.features.push(GeoFeature::Point {
+            coord: Coord {
                 x: city.lon,
                 y: city.lat,
             },
-            Some(city.name.to_string()),
-        ));
+            label: Some(city.name.to_string()),
+            city_tier: Some(city.tier),
+        });
     }
 
     layer
@@ -894,15 +883,35 @@ mod coverage_tests {
         assert_eq!(layer.features.len(), 135);
     }
 
+    #[wasm_bindgen_test]
+    fn build_cities_layer_preserves_tier_counts_and_source_order() {
+        let layer = build_cities_layer();
+        let tiers: Vec<_> = layer
+            .features
+            .iter()
+            .map(|feature| match feature {
+                GeoFeature::Point { city_tier, .. } => city_tier.expect("city tier"),
+                other => panic!("expected Point feature, got {other:?}"),
+            })
+            .collect();
+
+        assert_eq!(tiers[..42], [Tier::Major; 42]);
+        assert_eq!(tiers[42..73], [Tier::Medium; 31]);
+        assert_eq!(tiers[73..], [Tier::Small; 62]);
+    }
+
     /// Every feature is a Point carrying a non-empty label (the city name).
     #[wasm_bindgen_test]
     fn all_features_are_labeled_points() {
         let layer = build_cities_layer();
         for feature in &layer.features {
             match feature {
-                GeoFeature::Point(_coord, label) => {
+                GeoFeature::Point {
+                    label, city_tier, ..
+                } => {
                     let name = label.as_ref().expect("city point must have a name");
                     assert!(!name.is_empty(), "city name must be non-empty");
+                    assert!(city_tier.is_some(), "city point must retain its tier");
                 }
                 other => panic!("expected Point feature, got {:?}", other),
             }
@@ -915,8 +924,13 @@ mod coverage_tests {
     fn first_city_is_new_york_with_lon_x_lat_y() {
         let layer = build_cities_layer();
         match &layer.features[0] {
-            GeoFeature::Point(coord, label) => {
+            GeoFeature::Point {
+                coord,
+                label,
+                city_tier,
+            } => {
                 assert_eq!(label.as_deref(), Some("New York"));
+                assert_eq!(*city_tier, Some(Tier::Major));
                 assert!(
                     (coord.x - (-74.0060)).abs() < 1e-9,
                     "lon→x, got {}",
@@ -949,7 +963,12 @@ mod coverage_tests {
 
         let find = |name: &str| -> Coord<f64> {
             for f in &layer.features {
-                if let GeoFeature::Point(coord, Some(label)) = f {
+                if let GeoFeature::Point {
+                    coord,
+                    label: Some(label),
+                    ..
+                } = f
+                {
                     if label == name {
                         return *coord;
                     }
@@ -981,7 +1000,12 @@ mod coverage_tests {
     fn all_coords_in_us_bounds() {
         let layer = build_cities_layer();
         for f in &layer.features {
-            if let GeoFeature::Point(coord, Some(name)) = f {
+            if let GeoFeature::Point {
+                coord,
+                label: Some(name),
+                ..
+            } = f
+            {
                 // Longitude (x): western hemisphere, roughly -180..-60.
                 assert!(
                     coord.x < -60.0 && coord.x > -180.0,

--- a/src/geo/geo_line_renderer.rs
+++ b/src/geo/geo_line_renderer.rs
@@ -223,7 +223,7 @@ fn emit_feature_lines(feature: &GeoFeature, verts: &mut Vec<f32>) {
                 emit_linestring(ext, verts);
             }
         }
-        GeoFeature::Point(..) => {} // handled by egui text
+        GeoFeature::Point { .. } => {} // handled by egui text
     }
 }
 

--- a/src/geo/layer.rs
+++ b/src/geo/layer.rs
@@ -66,6 +66,26 @@ pub enum GeoLayerType {
     Lakes,
 }
 
+/// Curated population tier retained for city-label placement priority.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CityTier {
+    Major,
+    Medium,
+    Small,
+}
+
+/// Global geographic-label priority class.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GeoLabelClass {
+    State,
+    CityMajor,
+    CityMedium,
+    CitySmall,
+    Highway,
+    Lake,
+    County,
+}
+
 impl GeoLayerType {
     /// Returns the default color for this layer type.
     pub fn default_color(&self) -> Color32 {
@@ -141,8 +161,12 @@ pub enum GeoFeature {
         label: Option<String>,
         label_anchor: Coord<f64>,
     },
-    /// A single point (for cities, landmarks)
-    Point(Coord<f64>, Option<String>),
+    /// A single point (for cities, landmarks).
+    Point {
+        coord: Coord<f64>,
+        label: Option<String>,
+        city_tier: Option<CityTier>,
+    },
 }
 
 /// Computes the true geometric centroid of a polygon using the shoelace formula.
@@ -223,12 +247,6 @@ pub struct GeoLayer {
     /// Invisible (idle) views hit the cache every frame and skip all
     /// trig on feature coords.
     cache: RefCell<LayerProjectionCache>,
-    /// Cache of laid-out label galleys + their lat/lon anchors. Rebuilt
-    /// only when the camera has settled and the label-cache token (zoom
-    /// bucket, theme) has changed. Per-frame label rendering reprojects
-    /// the cached anchors and reuses the cached galleys with halo offsets,
-    /// avoiding text layout on every frame.
-    label_cache: RefCell<LayerLabelCache>,
 }
 
 /// Single retained label, ready to paint at the projected position of its
@@ -256,26 +274,64 @@ pub(crate) struct LabelEntry {
     pub font_size: f32,
     /// Foreground text color (halo offsets paint in black).
     pub color: Color32,
+    /// Source class, retained so disabled layers can be filtered immediately.
+    pub class: GeoLabelClass,
 }
 
-/// Inputs that, when changed, force a label-cache rebuild on next settle:
-/// font sizes scale with zoom, and label colors flip with theme. The
-/// projection fingerprint is *not* part of the token because pan/zoom
-/// within a bucket should reuse the same galleys.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub(crate) struct LabelCacheToken {
-    /// `(zoom * 4.0).round() as u16` — quarter-zoom resolution. Coarse
-    /// enough to absorb tiny floating-point jitter, fine enough that font
-    /// sizes update visibly during sustained zoom.
-    pub zoom_bucket: u16,
-    pub dark: bool,
-    pub show_labels: bool,
+/// Primitive screen-space rectangle used by the headless selector.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct ScreenBounds {
+    pub min_x: f32,
+    pub min_y: f32,
+    pub max_x: f32,
+    pub max_y: f32,
 }
 
-#[derive(Debug, Clone, Default)]
-pub(crate) struct LayerLabelCache {
-    pub token: Option<LabelCacheToken>,
-    pub entries: Vec<LabelEntry>,
+impl ScreenBounds {
+    pub(crate) fn is_valid(self) -> bool {
+        self.min_x.is_finite()
+            && self.min_y.is_finite()
+            && self.max_x.is_finite()
+            && self.max_y.is_finite()
+            && self.max_x > self.min_x
+            && self.max_y > self.min_y
+    }
+
+    pub(crate) fn area(self) -> Option<f32> {
+        self.is_valid()
+            .then_some((self.max_x - self.min_x) * (self.max_y - self.min_y))
+    }
+
+    pub(crate) fn expanded(self, amount: f32) -> Self {
+        Self {
+            min_x: self.min_x - amount,
+            min_y: self.min_y - amount,
+            max_x: self.max_x + amount,
+            max_y: self.max_y + amount,
+        }
+    }
+
+    pub(crate) fn intersects(self, other: Self) -> bool {
+        self.min_x < other.max_x
+            && self.max_x > other.min_x
+            && self.min_y < other.max_y
+            && self.max_y > other.min_y
+    }
+
+    pub(crate) fn contains(self, other: Self) -> bool {
+        self.min_x <= other.min_x
+            && self.min_y <= other.min_y
+            && self.max_x >= other.max_x
+            && self.max_y >= other.max_y
+    }
+}
+
+/// Measured label candidate presented to the pure global selector.
+#[derive(Debug, Clone)]
+pub(crate) struct GeoLabelCandidate {
+    pub entry: LabelEntry,
+    pub bounds: ScreenBounds,
+    pub source_order: usize,
 }
 
 /// Cached screen-space projection of a single feature's line/ring
@@ -309,7 +365,7 @@ fn project_line(coords: &[Coord<f64>], projection: &MapProjection) -> Vec<Pos2> 
 
 fn project_feature(feature: &GeoFeature, projection: &MapProjection) -> FeatureProjection {
     match feature {
-        GeoFeature::Point(_, _) => FeatureProjection::Empty,
+        GeoFeature::Point { .. } => FeatureProjection::Empty,
         GeoFeature::LineString(coords) => {
             FeatureProjection::Single(project_line(coords, projection))
         }
@@ -344,7 +400,11 @@ impl GeoFeature {
                 label_anchor,
                 ..
             } => Some(*label_anchor),
-            GeoFeature::Point(coord, Some(_)) => Some(*coord),
+            GeoFeature::Point {
+                coord,
+                label: Some(_),
+                ..
+            } => Some(*coord),
             _ => None,
         }
     }
@@ -354,7 +414,7 @@ impl GeoFeature {
         match self {
             GeoFeature::Polygon { label: Some(s), .. }
             | GeoFeature::MultiPolygon { label: Some(s), .. }
-            | GeoFeature::Point(_, Some(s)) => Some(s.as_str()),
+            | GeoFeature::Point { label: Some(s), .. } => Some(s.as_str()),
             _ => None,
         }
     }
@@ -370,18 +430,7 @@ impl GeoLayer {
             line_width: None,
             visible: true,
             cache: RefCell::new(LayerProjectionCache::default()),
-            label_cache: RefCell::new(LayerLabelCache::default()),
         }
-    }
-
-    /// Borrow the label cache mutably for rebuild.
-    pub(crate) fn label_cache_mut(&self) -> std::cell::RefMut<'_, LayerLabelCache> {
-        self.label_cache.borrow_mut()
-    }
-
-    /// Borrow the label cache for paint.
-    pub(crate) fn label_cache(&self) -> std::cell::Ref<'_, LayerLabelCache> {
-        self.label_cache.borrow()
     }
 
     /// Ensures the cache of projected screen points matches the current
@@ -471,7 +520,11 @@ fn convert_shapefile_shape(shape: &shapefile::Shape, label: Option<String>) -> O
     match shape {
         shapefile::Shape::Point(p) => {
             let coord = Coord { x: p.x, y: p.y };
-            Some(GeoFeature::Point(coord, label))
+            Some(GeoFeature::Point {
+                coord,
+                label,
+                city_tier: None,
+            })
         }
         shapefile::Shape::Polyline(pl) => {
             let parts = pl.parts();
@@ -826,7 +879,11 @@ mod coverage_tests {
 
     #[wasm_bindgen_test]
     fn label_anchor_point_with_label_returns_point() {
-        let f = GeoFeature::Point(c(-98.0, 39.0), Some("City".to_string()));
+        let f = GeoFeature::Point {
+            coord: c(-98.0, 39.0),
+            label: Some("City".to_string()),
+            city_tier: Some(CityTier::Major),
+        };
         let anchor = f.label_anchor().expect("labeled point has anchor");
         assert!((anchor.x + 98.0).abs() < 1e-9);
         assert!((anchor.y - 39.0).abs() < 1e-9);
@@ -834,7 +891,11 @@ mod coverage_tests {
 
     #[wasm_bindgen_test]
     fn label_anchor_point_without_label_is_none() {
-        let f = GeoFeature::Point(c(1.0, 2.0), None);
+        let f = GeoFeature::Point {
+            coord: c(1.0, 2.0),
+            label: None,
+            city_tier: None,
+        };
         assert!(f.label_anchor().is_none());
     }
 
@@ -856,7 +917,11 @@ mod coverage_tests {
         };
         assert_eq!(poly.label_text(), Some("Poly"));
 
-        let point = GeoFeature::Point(c(0.0, 0.0), Some("Pt".to_string()));
+        let point = GeoFeature::Point {
+            coord: c(0.0, 0.0),
+            label: Some("Pt".to_string()),
+            city_tier: None,
+        };
         assert_eq!(point.label_text(), Some("Pt"));
 
         let multi = GeoFeature::MultiPolygon {
@@ -866,7 +931,11 @@ mod coverage_tests {
         };
         assert_eq!(multi.label_text(), Some("M"));
 
-        let unlabeled = GeoFeature::Point(c(0.0, 0.0), None);
+        let unlabeled = GeoFeature::Point {
+            coord: c(0.0, 0.0),
+            label: None,
+            city_tier: None,
+        };
         assert_eq!(unlabeled.label_text(), None);
 
         let line = GeoFeature::MultiLineString(vec![vec![c(0.0, 0.0)]]);
@@ -912,7 +981,14 @@ mod coverage_tests {
     #[wasm_bindgen_test]
     fn point_feature_projects_to_empty() {
         let proj = test_proj();
-        let pf = project_feature(&GeoFeature::Point(c(-98.0, 39.0), None), &proj);
+        let pf = project_feature(
+            &GeoFeature::Point {
+                coord: c(-98.0, 39.0),
+                label: None,
+                city_tier: None,
+            },
+            &proj,
+        );
         assert!(matches!(pf, FeatureProjection::Empty));
     }
 
@@ -981,7 +1057,11 @@ mod coverage_tests {
     fn refresh_projection_cache_builds_parallel_entries() {
         let proj = test_proj();
         let mut layer = GeoLayer::new(GeoLayerType::States);
-        layer.features.push(GeoFeature::Point(c(-98.0, 39.0), None));
+        layer.features.push(GeoFeature::Point {
+            coord: c(-98.0, 39.0),
+            label: None,
+            city_tier: None,
+        });
         layer
             .features
             .push(GeoFeature::LineString(vec![c(-98.0, 39.0), c(-97.0, 39.0)]));
@@ -1021,30 +1101,6 @@ mod coverage_tests {
         );
     }
 
-    // ----- LabelCacheToken default / equality -----
-
-    #[wasm_bindgen_test]
-    fn label_cache_token_default_and_eq() {
-        let a = LabelCacheToken::default();
-        assert_eq!(a.zoom_bucket, 0);
-        assert!(!a.dark);
-        assert!(!a.show_labels);
-
-        let b = LabelCacheToken {
-            zoom_bucket: 0,
-            dark: false,
-            show_labels: false,
-        };
-        assert_eq!(a, b);
-
-        let c_tok = LabelCacheToken {
-            zoom_bucket: 4,
-            dark: true,
-            show_labels: true,
-        };
-        assert_ne!(a, c_tok);
-    }
-
     // ----- LabelEntry construction sanity (pure struct) -----
 
     #[wasm_bindgen_test]
@@ -1056,6 +1112,7 @@ mod coverage_tests {
             text: "Topeka".to_string(),
             font_size: 12.0,
             color: Color32::WHITE,
+            class: GeoLabelClass::CityMajor,
         };
         assert_eq!(e.text, "Topeka");
         assert!((e.font_size - 12.0).abs() < 1e-6);

--- a/src/geo/mod.rs
+++ b/src/geo/mod.rs
@@ -16,6 +16,11 @@ pub(crate) use camera::GlobeProjection;
 pub(crate) use camera::{Camera, Flat2DState, UrlOrbitFields, ViewMode, DEFAULT_FLAT_ZOOM};
 pub(crate) use geo_line_renderer::GeoLineRenderer;
 pub(crate) use globe_renderer::GlobeRenderer;
-pub(crate) use layer::{GeoFeature, GeoLayer, GeoLayerSet, GeoLayerType, GeoLayerVisibility};
+pub(crate) use layer::{
+    GeoFeature, GeoLabelCandidate, GeoLabelClass, GeoLayer, GeoLayerSet, GeoLayerType,
+    GeoLayerVisibility, LabelEntry, ScreenBounds,
+};
 pub(crate) use projection::{MapProjection, Projection, ProjectionFingerprint};
-pub(crate) use renderer::{render_geo_layers, text_with_halo, GeoPass};
+pub(crate) use renderer::{
+    build_geo_label_candidates, paint_geo_labels, render_geo_layers, text_with_halo, GeoPass,
+};

--- a/src/geo/projection.rs
+++ b/src/geo/projection.rs
@@ -236,6 +236,24 @@ pub(crate) struct ProjectionFingerprint {
 }
 
 #[cfg(test)]
+impl ProjectionFingerprint {
+    pub(crate) fn test_value(value: u64) -> Self {
+        Self {
+            center_lat: value,
+            center_lon: value,
+            range_deg: value,
+            zoom: value as u32,
+            pan_x: value as u32,
+            pan_y: value as u32,
+            rect_min_x: value as u32,
+            rect_min_y: value as u32,
+            rect_max_x: value as u32,
+            rect_max_y: value as u32,
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use wasm_bindgen_test::wasm_bindgen_test;

--- a/src/geo/renderer.rs
+++ b/src/geo/renderer.rs
@@ -1,11 +1,13 @@
 //! Geographic layer rendering.
 //!
 //! Renders geographic features to the egui canvas. Lines and point markers
-//! repaint every frame using the projection cache; labels follow a tiered
-//! invalidation strategy — galleys are laid out once per camera-settle
-//! event and reprojected to screen positions every frame thereafter.
+//! repaint every frame using the projection cache; labels are measured and
+//! globally selected once per settled viewport, then reprojected each frame.
 
-use super::layer::{FeatureProjection, GeoLayerType, LabelCacheToken, LabelEntry, LayerLabelCache};
+use super::layer::{
+    CityTier, FeatureProjection, GeoLabelCandidate, GeoLabelClass, GeoLayerType, LabelEntry,
+    ScreenBounds,
+};
 use super::{GeoFeature, GeoLayer, GeoLayerSet, MapProjection};
 use crate::geo::GeoLayerVisibility;
 use eframe::egui::{Align2, Color32, FontId, Painter, Pos2, Stroke, Vec2};
@@ -13,8 +15,7 @@ use eframe::epaint::Galley;
 use geo_types::Coord;
 use std::sync::Arc;
 
-/// Which geo rendering pass to execute. Split so lines/markers can draw
-/// below the radar texture while labels draw on top of it for legibility.
+/// Which NEXRAD-site rendering pass to execute.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub(crate) enum GeoPass {
     Lines,
@@ -88,37 +89,21 @@ fn aligned_galley_pos(pos: Pos2, galley_size: Vec2, align: Align2) -> Pos2 {
     Pos2::new(x, y)
 }
 
-/// Renders all visible geographic layers to the canvas.
+/// Renders lines and markers for all visible geographic layers.
 ///
 /// Visibility is passed in separately (rather than via a cloned
 /// [`GeoLayerSet`]) so the large coord data never gets cloned per
-/// frame. Each layer holds a projection-keyed cache of screen points
-/// (refreshed on the Lines pass) and a settle-debounced label cache
-/// (refreshed on the Labels pass when camera motion has stopped).
-#[allow(clippy::too_many_arguments)]
+/// frame. Each layer holds a projection-keyed cache of screen points.
 pub(crate) fn render_geo_layers(
     painter: &Painter,
     layers: &GeoLayerSet,
     visibility: &GeoLayerVisibility,
     projection: &MapProjection,
     zoom: f32,
-    show_labels: bool,
-    pass: GeoPass,
-    dark: bool,
-    camera_settled: bool,
 ) {
     for (layer, visible) in layers_with_visibility(layers, visibility) {
         if visible && layer.visible && zoom >= layer.layer_type.min_zoom() {
-            render_layer(
-                painter,
-                layer,
-                projection,
-                show_labels,
-                zoom,
-                pass,
-                dark,
-                camera_settled,
-            );
+            render_lines_pass(painter, layer, projection, zoom);
         }
     }
 }
@@ -138,32 +123,6 @@ fn layers_with_visibility<'a>(
     .filter_map(|(layer, vis)| layer.map(|l| (l, vis)))
 }
 
-/// Renders a single geographic layer.
-#[allow(clippy::too_many_arguments)]
-fn render_layer(
-    painter: &Painter,
-    layer: &GeoLayer,
-    projection: &MapProjection,
-    show_labels: bool,
-    zoom: f32,
-    pass: GeoPass,
-    dark: bool,
-    camera_settled: bool,
-) {
-    match pass {
-        GeoPass::Lines => render_lines_pass(painter, layer, projection, zoom),
-        GeoPass::Labels => render_labels_pass(
-            painter,
-            layer,
-            projection,
-            show_labels,
-            zoom,
-            dark,
-            camera_settled,
-        ),
-    }
-}
-
 /// Lines pass: draw line geometry and point markers using the projection
 /// cache. Repaints every frame; per-feature visibility is rejected by
 /// bounding-box checks.
@@ -177,7 +136,7 @@ fn render_lines_pass(painter: &Painter, layer: &GeoLayer, projection: &MapProjec
 
     for (feature, entry) in layer.features.iter().zip(entries.iter()) {
         match (feature, entry) {
-            (GeoFeature::Point(coord, _), _) => {
+            (GeoFeature::Point { coord, .. }, _) => {
                 render_point_marker(painter, coord, projection, color, zoom);
             }
             (GeoFeature::LineString(coords), FeatureProjection::Single(points)) => {
@@ -201,88 +160,99 @@ fn render_lines_pass(painter: &Painter, layer: &GeoLayer, projection: &MapProjec
     }
 }
 
-/// Labels pass: project cached anchors and paint cached galleys. Rebuilds
-/// the cache when the camera has settled and the cache token has changed.
-fn render_labels_pass(
+/// Collect and measure all eligible labels for one global placement decision.
+pub(crate) fn build_geo_label_candidates(
     painter: &Painter,
-    layer: &GeoLayer,
+    layers: &GeoLayerSet,
+    visibility: &GeoLayerVisibility,
     projection: &MapProjection,
-    show_labels: bool,
     zoom: f32,
     dark: bool,
-    camera_settled: bool,
-) {
-    if !show_labels {
-        return;
+) -> Vec<GeoLabelCandidate> {
+    if !visibility.labels {
+        return Vec::new();
     }
 
-    let token = LabelCacheToken {
-        zoom_bucket: (zoom * 4.0).round().clamp(0.0, u16::MAX as f32) as u16,
-        dark,
-        show_labels,
-    };
+    let mut candidates = Vec::new();
+    let mut source_order = 0;
+    for (layer, visible) in layers_with_visibility(layers, visibility) {
+        if !visible
+            || !layer.visible
+            || zoom < layer.layer_type.min_zoom()
+            || zoom < layer.layer_type.min_label_zoom()
+        {
+            source_order += layer.features.len();
+            continue;
+        }
 
-    {
-        let mut cache = layer.label_cache_mut();
-        let needs_rebuild = match cache.token {
-            None => true,
-            Some(t) if t != token && camera_settled => true,
-            _ => false,
-        };
-        if needs_rebuild {
-            rebuild_label_cache(layer, projection, zoom, dark, &mut cache);
-            cache.token = Some(token);
+        for feature in &layer.features {
+            let current_source_order = source_order;
+            source_order += 1;
+
+            let Some(text) = feature.label_text() else {
+                continue;
+            };
+            let Some(anchor) = feature.label_anchor() else {
+                continue;
+            };
+            if !projection.is_visible(anchor, 0.5) {
+                continue;
+            }
+
+            let class = label_class(layer.layer_type, feature);
+            let entry = match feature {
+                GeoFeature::Polygon { .. } | GeoFeature::MultiPolygon { .. } => {
+                    build_polygon_label_entry(anchor, text, zoom, layer.layer_type, class, dark)
+                }
+                GeoFeature::Point { .. } => {
+                    Some(build_point_label_entry(anchor, text, zoom, class, dark))
+                }
+                _ => None,
+            };
+            let Some(entry) = entry else {
+                continue;
+            };
+
+            let galley = painter.layout_no_wrap(
+                entry.text.clone(),
+                FontId::proportional(entry.font_size),
+                entry.color,
+            );
+            let anchor_screen = projection.geo_to_screen(entry.anchor) + entry.pixel_offset;
+            let pos = aligned_galley_pos(anchor_screen, galley.size(), entry.align);
+            candidates.push(GeoLabelCandidate {
+                entry,
+                bounds: ScreenBounds {
+                    min_x: pos.x,
+                    min_y: pos.y,
+                    max_x: pos.x + galley.size().x,
+                    max_y: pos.y + galley.size().y,
+                },
+                source_order: current_source_order,
+            });
         }
     }
 
-    let cache = layer.label_cache();
-    paint_label_cache(painter, projection, &cache);
+    candidates
 }
 
-/// Build the per-layer label cache: one [`LabelEntry`] per visible
-/// labelable feature, recording its text and font size (the galley is laid
-/// out per-frame at paint time). Skips features whose `min_label_zoom`
-/// threshold isn't met or whose anchor isn't within the visible bounds at
-/// build time.
-fn rebuild_label_cache(
-    layer: &GeoLayer,
-    projection: &MapProjection,
-    zoom: f32,
-    dark: bool,
-    cache: &mut LayerLabelCache,
-) {
-    cache.entries.clear();
-
-    if zoom < layer.layer_type.min_label_zoom() {
-        return;
-    }
-
-    let layer_type = layer.layer_type;
-
-    for feature in &layer.features {
-        let Some(text) = feature.label_text() else {
-            continue;
-        };
-        let Some(anchor) = feature.label_anchor() else {
-            continue;
-        };
-        // Visibility check at build time uses generous margin so labels
-        // near the edge stay cached and stay positioned correctly during
-        // small pans before the next settle.
-        if !projection.is_visible(anchor, 0.5) {
-            continue;
-        }
-
-        let entry = match feature {
-            GeoFeature::Polygon { .. } | GeoFeature::MultiPolygon { .. } => {
-                build_polygon_label_entry(anchor, text, zoom, layer_type, dark)
-            }
-            GeoFeature::Point(_, _) => build_point_label_entry(anchor, text, zoom, dark),
-            _ => None,
-        };
-        if let Some(entry) = entry {
-            cache.entries.push(entry);
-        }
+fn label_class(layer_type: GeoLayerType, feature: &GeoFeature) -> GeoLabelClass {
+    match layer_type {
+        GeoLayerType::States => GeoLabelClass::State,
+        GeoLayerType::Counties => GeoLabelClass::County,
+        GeoLayerType::Highways => GeoLabelClass::Highway,
+        GeoLayerType::Lakes => GeoLabelClass::Lake,
+        GeoLayerType::Cities => match feature {
+            GeoFeature::Point {
+                city_tier: Some(CityTier::Major),
+                ..
+            } => GeoLabelClass::CityMajor,
+            GeoFeature::Point {
+                city_tier: Some(CityTier::Medium),
+                ..
+            } => GeoLabelClass::CityMedium,
+            _ => GeoLabelClass::CitySmall,
+        },
     }
 }
 
@@ -291,6 +261,7 @@ fn build_polygon_label_entry(
     text: &str,
     zoom: f32,
     layer_type: GeoLayerType,
+    class: GeoLabelClass,
     _dark: bool,
 ) -> Option<LabelEntry> {
     let (base_size, color) = polygon_label_style(layer_type);
@@ -302,6 +273,7 @@ fn build_polygon_label_entry(
         text: text.to_string(),
         font_size,
         color,
+        class,
     })
 }
 
@@ -309,19 +281,21 @@ fn build_point_label_entry(
     anchor: Coord<f64>,
     text: &str,
     zoom: f32,
+    class: GeoLabelClass,
     _dark: bool,
-) -> Option<LabelEntry> {
+) -> LabelEntry {
     let radius = (2.5 * zoom.sqrt()).clamp(2.0, 5.0);
     let font_size = (9.0 * zoom.sqrt()).clamp(8.0, 13.0);
     let color = Color32::from_rgb(180, 180, 200);
-    Some(LabelEntry {
+    LabelEntry {
         anchor,
         align: Align2::LEFT_CENTER,
         pixel_offset: Vec2::new(radius + 2.0, -2.0),
         text: text.to_string(),
         font_size,
         color,
-    })
+        class,
+    }
 }
 
 fn polygon_label_style(layer_type: GeoLayerType) -> (f32, Color32) {
@@ -338,8 +312,20 @@ fn polygon_label_style(layer_type: GeoLayerType) -> (f32, Color32) {
 /// egui's internal galley cache, which self-invalidates on font-atlas
 /// recreate) and project its anchor through the current projection before
 /// emitting one halo'd galley.
-fn paint_label_cache(painter: &Painter, projection: &MapProjection, cache: &LayerLabelCache) {
-    for entry in &cache.entries {
+pub(crate) fn paint_geo_labels(
+    painter: &Painter,
+    projection: &MapProjection,
+    visibility: &GeoLayerVisibility,
+    entries: &[LabelEntry],
+) {
+    if !visibility.labels {
+        return;
+    }
+
+    for entry in entries {
+        if !label_class_enabled(entry.class, visibility) {
+            continue;
+        }
         let galley = painter.layout_no_wrap(
             entry.text.clone(),
             FontId::proportional(entry.font_size),
@@ -352,8 +338,19 @@ fn paint_label_cache(painter: &Painter, projection: &MapProjection, cache: &Laye
     }
 }
 
-/// Renders a point feature's marker dot. Labels for points are emitted via
-/// the layer label cache during the Labels pass.
+fn label_class_enabled(class: GeoLabelClass, visibility: &GeoLayerVisibility) -> bool {
+    match class {
+        GeoLabelClass::State => visibility.states,
+        GeoLabelClass::CityMajor | GeoLabelClass::CityMedium | GeoLabelClass::CitySmall => {
+            visibility.cities
+        }
+        GeoLabelClass::Highway => visibility.highways,
+        GeoLabelClass::Lake => visibility.lakes,
+        GeoLabelClass::County => visibility.counties,
+    }
+}
+
+/// Renders a point feature's marker dot. Point labels use the global label pass.
 fn render_point_marker(
     painter: &Painter,
     coord: &Coord<f64>,

--- a/src/state/render_cache.rs
+++ b/src/state/render_cache.rs
@@ -4,15 +4,56 @@
 //! math) can be deferred until the user has stopped panning/zooming, plus a
 //! handful of small caches that smooth over per-frame recomputation.
 
-use crate::geo::ProjectionFingerprint;
+use crate::core::geo_labels::{
+    select_geo_labels, should_rebuild_labels, GeoLabelPlacementKey, GeoLabelSelectionCandidate,
+};
+use crate::geo::{GeoLabelCandidate, LabelEntry, ProjectionFingerprint, ScreenBounds};
 
 /// Default settle window: how long the camera must be stable before the
-/// label tier rebuilds its cache. 180 ms feels responsive without thrashing
+/// label selector rebuilds its cache. 180 ms feels responsive without thrashing
 /// the cache during a continuous pan/zoom gesture.
 pub(crate) const SETTLE_WINDOW_SECS: f64 = 0.18;
 
+/// One global retained placement for all 2D geographic feature labels.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct GeoLabelCache {
+    pub key: Option<GeoLabelPlacementKey>,
+    pub entries: Vec<LabelEntry>,
+}
+
+impl GeoLabelCache {
+    pub(crate) fn needs_rebuild(
+        &self,
+        requested: GeoLabelPlacementKey,
+        camera_settled: bool,
+    ) -> bool {
+        should_rebuild_labels(self.key, requested, camera_settled)
+    }
+
+    pub(crate) fn replace(
+        &mut self,
+        key: GeoLabelPlacementKey,
+        candidates: &[GeoLabelCandidate],
+        viewport: ScreenBounds,
+    ) {
+        let selection_candidates: Vec<_> = candidates
+            .iter()
+            .map(|candidate| GeoLabelSelectionCandidate {
+                class: candidate.entry.class,
+                bounds: candidate.bounds,
+                source_order: candidate.source_order,
+            })
+            .collect();
+        self.entries = select_geo_labels(&selection_candidates, viewport)
+            .into_iter()
+            .map(|index| candidates[index].entry.clone())
+            .collect();
+        self.key = Some(key);
+    }
+}
+
 /// Tracks whether the map camera (projection) has come to rest. Consumers
-/// (e.g. the label tier in the geo renderer) check `is_settled()` to decide
+/// (e.g. the geographic label selector) check `is_settled()` to decide
 /// whether to do expensive recomputation this frame.
 #[derive(Debug, Clone)]
 pub(crate) struct CameraMotion {
@@ -74,6 +115,9 @@ pub(crate) struct PrevSweepCacheKey {
 #[derive(Debug, Default, Clone)]
 pub(crate) struct RenderCache {
     pub camera_motion: CameraMotion,
+
+    /// Settled, globally selected geographic labels for the flat map.
+    pub geo_labels: GeoLabelCache,
 
     /// Last value of `is_dark` pushed to `egui::Context::set_visuals`. Used
     /// to skip the per-frame `Visuals` reconstruction unless the theme

--- a/src/ui/canvas.rs
+++ b/src/ui/canvas.rs
@@ -10,9 +10,9 @@ use super::canvas_overlays::{
     AlertRenderPhase, OverlayContext, RadarCutout,
 };
 use super::colors::canvas as canvas_colors;
+use crate::core::geo_labels::{GeoLabelPlacementKey, GeoLabelVisibilityKey};
 use crate::core::RenderProcessing;
-use crate::geo::ViewMode;
-use crate::geo::{GeoLayerSet, MapProjection};
+use crate::geo::{GeoLayerSet, MapProjection, ScreenBounds, ViewMode};
 use crate::nexrad::RadarGpuRenderer;
 use crate::state::AppState;
 use eframe::egui::{self, Color32, Rect, Sense, Stroke};
@@ -120,7 +120,7 @@ pub(crate) fn render_canvas_with_geo(
                     .observe(projection.fingerprint(), now_secs);
                 let camera_settled = state.render_cache.camera_motion.is_settled(now_secs);
                 // Schedule exactly one wake-up at the settle moment so the
-                // label tier rebuilds on time even when nothing else is
+                // label placement rebuilds on time even when nothing else is
                 // animating. No-op if already settled.
                 if let Some(remaining) =
                     state.render_cache.camera_motion.time_until_settle(now_secs)
@@ -174,10 +174,6 @@ pub(crate) fn render_canvas_with_geo(
                         &state.layer_state.geo,
                         &projection,
                         state.viz_state.zoom(),
-                        state.layer_state.geo.labels,
-                        crate::geo::GeoPass::Lines,
-                        dark,
-                        camera_settled,
                     );
                 }
 
@@ -302,16 +298,43 @@ pub(crate) fn render_canvas_with_geo(
                 // legible over bright reflectivity fills. Halo-stroked inside
                 // the renderer for contrast.
                 if let Some(layers) = geo_layers {
-                    crate::geo::render_geo_layers(
-                        &painter,
-                        layers,
-                        &state.layer_state.geo,
-                        &projection,
-                        state.viz_state.zoom(),
-                        state.layer_state.geo.labels,
-                        crate::geo::GeoPass::Labels,
+                    let visibility = &state.layer_state.geo;
+                    let placement_key = GeoLabelPlacementKey {
+                        projection: projection.fingerprint(),
+                        visibility: GeoLabelVisibilityKey::from(visibility),
                         dark,
-                        camera_settled,
+                    };
+
+                    if state
+                        .render_cache
+                        .geo_labels
+                        .needs_rebuild(placement_key, camera_settled)
+                    {
+                        let candidates = crate::geo::build_geo_label_candidates(
+                            &painter,
+                            layers,
+                            visibility,
+                            &projection,
+                            state.viz_state.zoom(),
+                            dark,
+                        );
+                        state.render_cache.geo_labels.replace(
+                            placement_key,
+                            &candidates,
+                            ScreenBounds {
+                                min_x: rect.min.x,
+                                min_y: rect.min.y,
+                                max_x: rect.max.x,
+                                max_y: rect.max.y,
+                            },
+                        );
+                    }
+
+                    crate::geo::paint_geo_labels(
+                        &painter,
+                        &projection,
+                        visibility,
+                        &state.render_cache.geo_labels.entries,
                     );
                 }
 


### PR DESCRIPTION
Closes #138

## Summary
- replace per-layer label caches with one deterministic screen-space placement pass
- prioritize states, city population tiers, highways, lakes, and counties while enforcing collision and area-based density limits
- invalidate settled placements for viewport, resize, zoom, theme, and layer visibility changes
- preserve city tiers and add pure coverage for priority, stable ties, collisions, density, edge cases, and invalidation

NEXRAD radar-site labels remain outside the selector, matching the agreed issue scope.

## Testing
- `cargo fmt -- --check`
- `cargo check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --bin nexrad-workbench` (2,186 passed)