### PR TITLE
Make IndexedDB scan mutations atomic

### DIFF
--- a/docs/ARCHITECTURE_DIAGRAMS.md
+++ b/docs/ARCHITECTURE_DIAGRAMS.md
@@ -643,18 +643,17 @@ In WASM, an IDB transaction **auto-commits when the event loop yields** — so a
 ```mermaid
 sequenceDiagram
     participant App
-    participant RO as readonly tx
     participant RW as readwrite tx
-    App->>RO: read (decide create vs merge)
-    RO-->>App: scan_availability
-    Note over App,RW: closure is synchronous — NO await inside
-    App->>RW: write blobs + index (+ seed touch) synchronously
+    App->>RW: queue manifest/blob reads
+    RW-->>App: request callback
+    Note over App,RW: callback synchronously queues merge writes — NO await inside
+    App->>RW: write blobs + index (+ seed/repair touch)
     App->>RW: wait_for_transaction().await  ← await is OUTSIDE
     RW-->>App: committed
 ```
 
-Concurrent same-scan upserts are rejected at runtime by an `UpsertScanGuard` RAII
-token (`DataError::ConcurrentUpsert`).
+Overlapping same-scan mutations serialize through IndexedDB's shared readwrite
+transaction scope, including calls from separate workers and tabs.
 
 ### Cache eviction (LRU)
 

--- a/docs/INDEXEDDB.md
+++ b/docs/INDEXEDDB.md
@@ -16,7 +16,7 @@ so the same code compiles and runs in both contexts.
 
 ## 1. Schema
 
-Database `nexrad-workbench`, version `5`. Three object stores; all keyed
+Database `nexrad-workbench`, version `6`. Three object stores; all keyed
 by string.
 
 | Store          | Key format                          | Value                                                            |
@@ -113,7 +113,7 @@ Derived (accessor methods, not stored):
 | ----------------------------------- | ----------------------------------------------------------------------- |
 | `has_vcp() -> bool`                 | `vcp.is_some()`                                                         |
 | `planned_sweep_count() -> Option<u32>` | `vcp.as_ref().map(|v| v.elevations.len() as u32)`                       |
-| `cached_sweep_count() -> u32`       | `cached_sweeps.len() as u32`                                            |
+| `cached_sweep_count() -> u32`       | Count of unique `elevation_number` values                               |
 | `end_timestamp_secs() -> Option<i64>` | `cached_sweeps.iter().map(|s| s.end as i64).max()`                      |
 | `completeness() -> ScanCompleteness` | `from_counts(has_vcp(), cached_sweep_count(), planned_sweep_count())`   |
 
@@ -199,23 +199,20 @@ moves across await points in non-WASM contexts.
 The actual transaction-completion wait (`wait_for_transaction`) happens
 *after* the closure returns, which is the only safe place to await.
 
-### 3c. Read-modify-write is not atomic — the `UpsertScanGuard`
+### 3c. Atomic scan mutations
 
-Because of (3b), no single transaction can read a value, mutate it,
-and write it back — the `await` between read and write would commit
-the read transaction. The one RMW in the store is `upsert_scan`
-(§6), which does a readonly `scan_availability` lookup, merges in
-memory, then writes in a separate readwrite transaction.
+`upsert_scan`, deletion, and access touches perform scan mutations in a
+single readwrite transaction spanning all three stores. Initial reads are
+queued synchronously; their request callbacks synchronously queue dependent
+writes before the transaction is allowed to complete. There is still no
+`await` inside the transaction.
 
-That split is racy in principle, so `upsert_scan` acquires an
-**`UpsertScanGuard`** at entry — a per-scan-key RAII lock in a
-thread-local `HashSet` (WASM is single-threaded; the only contention
-is between concurrently-running async futures on the same worker). A
-second task upserting the same scan while one is in flight gets
-`DataError::ConcurrentUpsert` instead of silently racing. The ingest
-pipeline already serializes per-scan via the per-worker `CHUNK_ACCUM`
-thread-local (`decode/worker_api/ingest.rs`); the guard is the
-type-system backstop.
+IndexedDB serializes overlapping readwrite transactions across database
+connections, so this is correct across workers and tabs. The merge key is
+`(scan, elevation_number, product)`: product membership is unique and sorted,
+retries with identical bytes are no-ops, and replacement accounting uses the
+actual old blob length. Concurrent differing bytes or timing are unexpected;
+the later serialized transaction wins and logs a warning.
 
 ## 5. Key-range queries
 
@@ -282,8 +279,9 @@ types live in [`src/data/keys.rs`](../src/data/keys.rs).
   transaction. The initial touch is what gives the scan its place in
   the LRU order.
 - **Merge** (entry exists): fill in `vcp` / `file_name` only if
-  currently `None`, append the derived `CachedSweep`s to
-  `existing.cached_sweeps`, add the batch size to `total_size_bytes`.
+  currently `None`, update the one manifest row for each supplied elevation,
+  union its durable product keys, and apply actual blob replacement deltas to
+  `total_size_bytes`.
   **`scan_touches` is preserved** — a chunk-ingest flush doesn't
   refresh the access timestamp (which would conflate writes with
   reads and break LRU).
@@ -299,9 +297,8 @@ Contract details:
 - An empty `elevations` slice is permitted — the entry is written (or
   its header fields merged) without any blob writes (used by
   chunk-ingest flushes that don't produce new blobs).
-- The read-then-write split is guarded per scan key by
-  `UpsertScanGuard` (§3c); a concurrent upsert for the same scan gets
-  `DataError::ConcurrentUpsert`.
+- Concurrent upserts serialize at the database. They retain independent
+  elevations and never publish blobs without the corresponding manifest.
 
 ### Sweep blobs
 
@@ -366,7 +363,6 @@ letting IDB fail mid-transaction. The decision itself is the pure
 | `RequestFailed`      | Single-request failure inside a transaction         |
 | `QuotaExceeded`      | Browser storage estimate insufficient for the batch |
 | `SerdeError`         | `serde-wasm-bindgen` round-trip failed              |
-| `ConcurrentUpsert`   | A second task tried to `upsert_scan` a scan mid-upsert (§3c) |
 
 Errors from `JsValue` are formatted via the `js_err` helper, which
 extracts `name`/`message` when the value looks like a `DOMException`,
@@ -374,7 +370,7 @@ and falls back to `{:?}` otherwise. This gives readable strings like
 `"QuotaExceededError: ..."` instead of opaque `JsValue(...)` blobs.
 
 `DataError::kind()` classifies every error as `Transient` (retry may
-succeed: `NotOpen`, `ConcurrentUpsert`, aborted/timed-out
+succeed: `NotOpen`, aborted/timed-out
 transactions), `Quota` (succeeds only after eviction), or `Permanent`
 — so callers pick retry/give-up/evict behavior without matching every
 variant. IDB failures are classified by the DOMException name `js_err`
@@ -480,9 +476,8 @@ Not part of pre-commit.
   `IndexedDbStore::evict_to_size` only knows "evict until this
   size"; whether to evict (and to what target) is `DataFacade`'s job.
 
-- Cross-tab coordination — none. Multiple tabs of the same site share
-  the database but do not coordinate writes; ingest is idempotent at
-  the scan-key level so concurrent tabs at worst duplicate work.
+- Cross-tab scan mutations rely on IndexedDB transaction serialization; no
+  process-local lock or worker affinity is required.
 
 ## 11. Access-time tracking
 

--- a/src/data/indexeddb/helpers.rs
+++ b/src/data/indexeddb/helpers.rs
@@ -209,16 +209,33 @@ pub(super) async fn wait_for_transaction(tx: &IdbTransaction) -> Result<(), Data
         }
     }) as Box<dyn FnMut(_)>);
 
-    let tx_error = sender;
+    let tx_error = sender.clone();
+    let tx_for_error = tx.clone();
     let onerror = Closure::wrap(Box::new(move |_event: web_sys::Event| {
-        let error_msg = "Transaction error".to_string();
+        let error_msg = tx_for_error
+            .error()
+            .map(|error| format!("{}: {}", error.name(), error.message()))
+            .unwrap_or_else(|| "Transaction error".to_string());
         if let Some(tx) = tx_error.borrow_mut().take() {
+            let _ = tx.send(Err(error_msg));
+        }
+    }) as Box<dyn FnMut(_)>);
+
+    let tx_abort = sender;
+    let tx_for_abort = tx.clone();
+    let onabort = Closure::wrap(Box::new(move |_event: web_sys::Event| {
+        let error_msg = tx_for_abort
+            .error()
+            .map(|error| format!("{}: {}", error.name(), error.message()))
+            .unwrap_or_else(|| "Transaction aborted".to_string());
+        if let Some(tx) = tx_abort.borrow_mut().take() {
             let _ = tx.send(Err(error_msg));
         }
     }) as Box<dyn FnMut(_)>);
 
     tx.set_oncomplete(Some(oncomplete.as_ref().unchecked_ref()));
     tx.set_onerror(Some(onerror.as_ref().unchecked_ref()));
+    tx.set_onabort(Some(onabort.as_ref().unchecked_ref()));
 
     let result = rx
         .await
@@ -226,9 +243,11 @@ pub(super) async fn wait_for_transaction(tx: &IdbTransaction) -> Result<(), Data
 
     tx.set_oncomplete(None);
     tx.set_onerror(None);
+    tx.set_onabort(None);
 
     drop(oncomplete);
     drop(onerror);
+    drop(onabort);
 
     result.map_err(DataError::TransactionFailed)
 }

--- a/src/data/indexeddb/logic.rs
+++ b/src/data/indexeddb/logic.rs
@@ -4,8 +4,8 @@
 //! IDB. Every function here is `pub(super)` and stateless.
 
 use super::{DataError, StorageQuotaEstimate};
-use crate::data::keys::{ScanIndexEntry, ScanKey, UnixMillis};
-use std::collections::HashMap;
+use crate::data::keys::{ElevationUpload, ScanHeader, ScanIndexEntry, ScanKey, UnixMillis};
+use std::collections::{BTreeSet, HashMap};
 
 /// Decides whether a `touch_scan` call should be deduplicated against
 /// an in-memory record of the previous touch.
@@ -64,6 +64,63 @@ pub(super) fn eviction_order(
     let mut sorted: Vec<&ScanIndexEntry> = entries.iter().collect();
     sorted.sort_by_key(|e| touches.get(&e.scan).copied().unwrap_or(UnixMillis(0)).0);
     sorted.into_iter().map(|e| e.scan.clone()).collect()
+}
+
+/// Merges an upsert into the transaction-visible scan manifest. Blob identity
+/// is `(scan, elevation_number, product)`; an upload adds product keys to its
+/// elevation and replaces that elevation's measured timing. Callers provide
+/// the actual old and new blob sizes so replacement accounting stays exact.
+pub(super) fn merge_scan_entry(
+    existing: Option<ScanIndexEntry>,
+    header: &ScanHeader,
+    elevations: &[ElevationUpload],
+    old_blob_sizes: &HashMap<String, u64>,
+    new_blob_sizes: &HashMap<String, u64>,
+) -> ScanIndexEntry {
+    let mut entry = existing.unwrap_or_else(|| ScanIndexEntry {
+        scan: header.scan.clone(),
+        vcp: header.vcp.clone(),
+        file_name: header.file_name.clone(),
+        cached_sweeps: Vec::new(),
+        total_size_bytes: 0,
+    });
+
+    if entry.vcp.is_none() {
+        entry.vcp = header.vcp.clone();
+    }
+    if entry.file_name.is_none() {
+        entry.file_name = header.file_name.clone();
+    }
+
+    for upload in elevations {
+        let incoming = upload.to_cached_sweep();
+        if let Some(current) = entry
+            .cached_sweeps
+            .iter_mut()
+            .find(|sweep| sweep.elevation_number == upload.elevation_number)
+        {
+            let mut products: BTreeSet<String> = current.cached_products.drain(..).collect();
+            products.extend(incoming.cached_products);
+            current.start = incoming.start;
+            current.end = incoming.end;
+            current.elevation = incoming.elevation;
+            current.start_azimuth = incoming.start_azimuth;
+            current.cached_products = products.into_iter().collect();
+        } else {
+            entry.cached_sweeps.push(incoming);
+        }
+    }
+    entry
+        .cached_sweeps
+        .sort_by_key(|sweep| sweep.elevation_number);
+
+    let replaced_bytes: u64 = old_blob_sizes.values().sum();
+    let incoming_bytes: u64 = new_blob_sizes.values().sum();
+    entry.total_size_bytes = entry
+        .total_size_bytes
+        .saturating_sub(replaced_bytes)
+        .saturating_add(incoming_bytes);
+    entry
 }
 
 /// Filters a list of scan-index entries to those within the inclusive
@@ -376,6 +433,15 @@ mod tests {
         assert_eq!(e.cached_sweep_count(), 0);
         e.cached_sweeps = vec![cached_sweep(1, 100.0), cached_sweep(2, 130.0)];
         assert_eq!(e.cached_sweep_count(), 2);
+    }
+
+    #[wasm_bindgen_test]
+    fn entry_cached_sweep_count_ignores_duplicate_elevations() {
+        let mut e = entry("KDMX", 0, 0);
+        e.vcp = Some(vcp_with(2));
+        e.cached_sweeps = vec![cached_sweep(1, 100.0), cached_sweep(1, 130.0)];
+        assert_eq!(e.cached_sweep_count(), 1);
+        assert_eq!(e.completeness(), ScanCompleteness::PartialWithVcp);
     }
 
     #[wasm_bindgen_test]

--- a/src/data/indexeddb/mod.rs
+++ b/src/data/indexeddb/mod.rs
@@ -22,23 +22,18 @@
 //!   compiler rejects `.await` inside it — enforcing the WASM IDB rule that
 //!   readwrite transactions auto-commit when the event loop yields.
 //! - Cross-store transactions are supported by passing a multi-store slice.
-//! - `upsert_scan` does a readonly `scan_availability` lookup before its
-//!   readwrite transaction to decide create-vs-merge. The split is *not*
-//!   atomic across async awaits, so the function acquires an
-//!   [`UpsertScanGuard`] at entry and returns
-//!   [`DataError::ConcurrentUpsert`] when a second task tries to upsert
-//!   the same scan in parallel. The ingest pipeline already serializes
-//!   via the per-worker `CHUNK_ACCUM` thread-local; the guard is the
-//!   type-system backstop.
+//! - `upsert_scan` chains transaction-visible reads and dependent writes from
+//!   IDB request callbacks, so IndexedDB serializes same-scan mutations across
+//!   workers and tabs without awaiting inside the readwrite transaction.
 
 use crate::data::keys::*;
 use js_sys::{Array, ArrayBuffer, Uint8Array};
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::rc::Rc;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
-use web_sys::{IdbDatabase, IdbObjectStore, IdbRequest, IdbTransactionMode};
+use web_sys::{IdbDatabase, IdbObjectStore, IdbRequest, IdbTransaction, IdbTransactionMode};
 
 /// Structured error type for IndexedDB operations.
 #[derive(Debug)]
@@ -53,11 +48,6 @@ pub enum DataError {
     QuotaExceeded { available_mb: f64, required_mb: f64 },
     /// (De)serialization of stored data failed.
     SerdeError(String),
-    /// Another async task is already performing an upsert for this scan.
-    /// The non-atomic read-then-write split in `upsert_scan` requires
-    /// per-scan serialization; this is raised when that contract is
-    /// violated rather than letting the writes silently race.
-    ConcurrentUpsert { scan_key: String },
 }
 
 impl std::fmt::Display for DataError {
@@ -75,9 +65,6 @@ impl std::fmt::Display for DataError {
                 available_mb, required_mb
             ),
             DataError::SerdeError(msg) => write!(f, "Serde error: {}", msg),
-            DataError::ConcurrentUpsert { scan_key } => {
-                write!(f, "Concurrent upsert in flight for scan {}", scan_key)
-            }
         }
     }
 }
@@ -102,7 +89,7 @@ impl DataError {
     /// formatted message.
     pub fn kind(&self) -> ErrorKind {
         match self {
-            DataError::NotOpen | DataError::ConcurrentUpsert { .. } => ErrorKind::Transient,
+            DataError::NotOpen => ErrorKind::Transient,
             DataError::QuotaExceeded { .. } => ErrorKind::Quota,
             DataError::SerdeError(_) => ErrorKind::Permanent,
             DataError::TransactionFailed(msg) | DataError::RequestFailed(msg) => {
@@ -125,50 +112,6 @@ fn classify_js_error(msg: &str) -> ErrorKind {
         }
         _ => ErrorKind::Permanent,
     }
-}
-
-/// RAII token enforcing the single-writer invariant on
-/// [`IndexedDbStore::upsert_scan`]. The store's read-then-write split is
-/// not atomic across its two IDB transactions, so two concurrent async
-/// tasks writing the same scan would race; this token rejects the second
-/// caller via [`DataError::ConcurrentUpsert`] instead of corrupting
-/// `scan_availability`.
-///
-/// Acquire via [`UpsertScanGuard::try_acquire`]; drop releases the lock.
-/// The lock is per-scan-key and lives in a thread-local (WASM is
-/// single-threaded; the only contention is between concurrently-running
-/// async futures on the same worker).
-pub struct UpsertScanGuard {
-    key: String,
-}
-
-impl UpsertScanGuard {
-    /// Try to acquire the lock for `scan`. Returns `None` if another
-    /// task is mid-upsert for the same scan; the caller should propagate
-    /// [`DataError::ConcurrentUpsert`] in that case.
-    pub fn try_acquire(scan: &crate::data::ScanKey) -> Option<Self> {
-        let key = scan.to_storage_key();
-        UPSERT_LOCKS.with(|locks| {
-            if !locks.borrow_mut().insert(key.clone()) {
-                None
-            } else {
-                Some(Self { key })
-            }
-        })
-    }
-}
-
-impl Drop for UpsertScanGuard {
-    fn drop(&mut self) {
-        UPSERT_LOCKS.with(|locks| {
-            locks.borrow_mut().remove(&self.key);
-        });
-    }
-}
-
-thread_local! {
-    static UPSERT_LOCKS: std::cell::RefCell<std::collections::HashSet<String>> =
-        std::cell::RefCell::new(std::collections::HashSet::new());
 }
 
 /// Format a `JsValue` error into a string. Tries to extract `name`/`message`
@@ -208,7 +151,7 @@ impl StorageQuotaEstimate {
 }
 
 /// Current database schema version.
-pub(super) const DATABASE_VERSION: u32 = 5;
+pub(super) const DATABASE_VERSION: u32 = 6;
 
 /// Database name.
 const DATABASE_NAME: &str = "nexrad-workbench";
@@ -224,6 +167,64 @@ pub(super) const STORE_SCAN_TOUCHES: &str = "scan_touches";
 /// Minimum interval between in-memory touch deduplications. Limits how often
 /// a single scan's `last_accessed_at` is rewritten to IDB during fast scrub.
 const TOUCH_THROTTLE_MS: i64 = 60_000;
+
+type EventCallbacks = Rc<RefCell<Vec<Closure<dyn FnMut(web_sys::Event)>>>>;
+
+/// Results collected by the callback chain of one atomic scan upsert.
+struct UpsertReadState {
+    existing: Option<ScanIndexEntry>,
+    index_read: bool,
+    touch_exists: Option<bool>,
+    pending_blobs: usize,
+    old_blob_sizes: HashMap<String, u64>,
+    old_blob_bytes: HashMap<String, Vec<u8>>,
+    writes_enqueued: bool,
+}
+
+fn canonical_uploads(elevations: &[ElevationUpload]) -> Vec<ElevationUpload> {
+    let mut canonical: BTreeMap<u8, ElevationUpload> = BTreeMap::new();
+    for upload in elevations.iter().filter(|upload| !upload.blobs.is_empty()) {
+        let target = canonical
+            .entry(upload.elevation_number)
+            .or_insert_with(|| ElevationUpload {
+                elevation_number: upload.elevation_number,
+                timing: upload.timing.clone(),
+                blobs: Vec::new(),
+            });
+        if target.timing != upload.timing {
+            log::warn!(
+                "Duplicate upload timing for elevation {} is inconsistent; later input wins",
+                upload.elevation_number
+            );
+            target.timing = upload.timing.clone();
+        }
+        for blob in &upload.blobs {
+            if let Some(existing) = target
+                .blobs
+                .iter_mut()
+                .find(|current| current.product == blob.product)
+            {
+                if existing.bytes != blob.bytes {
+                    log::warn!(
+                        "Duplicate upload for elevation {} product {} differs; later input wins",
+                        upload.elevation_number,
+                        blob.product
+                    );
+                }
+                existing.bytes = blob.bytes.clone();
+            } else {
+                target.blobs.push(blob.clone());
+            }
+        }
+        target.blobs.sort_by_key(|blob| blob.product);
+    }
+    canonical.into_values().collect()
+}
+
+fn abort_with(tx: &IdbTransaction, failure: &Rc<RefCell<Option<DataError>>>, error: DataError) {
+    *failure.borrow_mut() = Some(error);
+    let _ = tx.abort();
+}
 
 /// Open-state machine that coalesces concurrent `open()` calls into a single
 /// underlying `indexedDB.open(...)`. Without this, multiple `spawn_local`
@@ -424,15 +425,16 @@ impl IndexedDbStore {
     /// Atomically writes blobs + scan-index entry for a scan, creating the
     /// entry on first call and merging on subsequent calls.
     ///
-    /// Dispatches internally on `scan_availability`:
+    /// The transaction reads the current manifest and replaced blob keys, then
+    /// synchronously queues its merge writes from IDB request callbacks:
     ///
     /// - **First write** (no existing entry): derive a fresh `ScanIndexEntry`
     ///   from `header` and the uploads, then write blobs + index + an initial
     ///   `scan_touches=now` in one cross-store readwrite transaction. The
     ///   initial touch is what gives the scan its place in the LRU order.
     /// - **Merge** (entry exists): fill in `header.vcp` / `header.file_name`
-    ///   only if currently `None`, append derived `CachedSweep`s to
-    ///   `existing.cached_sweeps`, and add to `existing.total_size_bytes`.
+    ///   only if currently `None`, update the canonical elevation row, union
+    ///   its product keys, and apply actual replacement byte deltas.
     ///   `scan_touches` is preserved so a chunk-ingest flush doesn't refresh
     ///   the access timestamp on every partial write.
     ///
@@ -443,34 +445,14 @@ impl IndexedDbStore {
     /// Empty `elevations` is permitted: the entry is written (or its header
     /// fields merged) without any blob writes.
     ///
-    /// Read-modify-write is *not* atomic across the readonly and readwrite
-    /// transactions, so callers must serialize on the per-scan key. This
-    /// is enforced at runtime by an [`UpsertScanGuard`] acquired here:
-    /// two concurrent async tasks targeting the same scan are rejected
-    /// with [`DataError::ConcurrentUpsert`] rather than allowed to race.
-    /// (The ingest pipeline naturally serializes already via the
-    /// per-worker `CHUNK_ACCUM` thread-local; the guard is the
-    /// type-system backstop.)
+    /// Same-scan calls from independent workers or tabs serialize through the
+    /// common three-store IndexedDB transaction scope.
     pub async fn upsert_scan(
         &self,
         header: &ScanHeader,
         elevations: &[ElevationUpload],
     ) -> Result<(), DataError> {
-        let _guard = UpsertScanGuard::try_acquire(&header.scan).ok_or_else(|| {
-            DataError::ConcurrentUpsert {
-                scan_key: header.scan.to_storage_key(),
-            }
-        })?;
-
-        // Drop phantom elevations at the boundary. Everything downstream
-        // (manifest derivation, blob writes, size accounting) operates on
-        // the filtered list, so the manifest can never claim a sweep that
-        // wasn't written.
-        let kept: Vec<&ElevationUpload> =
-            elevations.iter().filter(|e| !e.blobs.is_empty()).collect();
-
-        // Materialize the blob (key, bytes) pairs once so we can both
-        // size-check and write them without redundant key formatting.
+        let kept = canonical_uploads(elevations);
         let sweep_blobs: Vec<(String, Vec<u8>)> = kept
             .iter()
             .flat_map(|elev| {
@@ -485,70 +467,209 @@ impl IndexedDbStore {
         Self::check_quota(&sweep_blobs).await?;
         self.ensure_open().await?;
 
+        // IndexedDB keeps a readwrite transaction active while a request
+        // callback runs. Chaining the merge and writes from these callbacks
+        // gives every worker/tab one database-scoped serialized mutation.
+        let db = self.get_db()?;
+        let names = Array::of3(
+            &JsValue::from_str(STORE_SWEEPS),
+            &JsValue::from_str(STORE_SCAN_INDEX),
+            &JsValue::from_str(STORE_SCAN_TOUCHES),
+        );
+        let tx = db
+            .transaction_with_str_sequence_and_mode(&names, IdbTransactionMode::Readwrite)
+            .map_err(|e| DataError::TransactionFailed(js_err(e)))?;
+        let sweeps = tx
+            .object_store(STORE_SWEEPS)
+            .map_err(|e| DataError::TransactionFailed(js_err(e)))?;
+        let index = tx
+            .object_store(STORE_SCAN_INDEX)
+            .map_err(|e| DataError::TransactionFailed(js_err(e)))?;
+        let touches = tx
+            .object_store(STORE_SCAN_TOUCHES)
+            .map_err(|e| DataError::TransactionFailed(js_err(e)))?;
         let entry_key = header.scan.to_storage_key();
-        let existing = self.scan_availability(&header.scan).await?;
-        let batch_bytes: u64 = sweep_blobs.iter().map(|(_, b)| b.len() as u64).sum();
+        let state = Rc::new(RefCell::new(UpsertReadState {
+            existing: None,
+            index_read: false,
+            touch_exists: None,
+            pending_blobs: 0,
+            old_blob_sizes: HashMap::new(),
+            old_blob_bytes: HashMap::new(),
+            writes_enqueued: false,
+        }));
+        let failure = Rc::new(RefCell::new(None));
+        let callbacks: EventCallbacks = Rc::new(RefCell::new(Vec::new()));
 
-        let (entry, seed_touch) = match existing {
-            Some(mut existing) => {
-                if existing.vcp.is_none() {
-                    existing.vcp = header.vcp.clone();
+        let enqueue_writes: Rc<dyn Fn()> = Rc::new({
+            let state = state.clone();
+            let failure = failure.clone();
+            let header = header.clone();
+            let kept = kept.clone();
+            let sweep_blobs = sweep_blobs.clone();
+            let entry_key = entry_key.clone();
+            let sweeps = sweeps.clone();
+            let index = index.clone();
+            let touches = touches.clone();
+            let tx = tx.clone();
+            move || {
+                let mut state = state.borrow_mut();
+                if state.writes_enqueued
+                    || !state.index_read
+                    || state.touch_exists.is_none()
+                    || state.pending_blobs != 0
+                {
+                    return;
                 }
-                if existing.file_name.is_none() {
-                    existing.file_name = header.file_name.clone();
-                }
-                existing
-                    .cached_sweeps
-                    .extend(kept.iter().map(|e| e.to_cached_sweep()));
-                existing.total_size_bytes += batch_bytes;
-                (existing, false)
-            }
-            None => {
-                let cached_sweeps = kept.iter().map(|e| e.to_cached_sweep()).collect();
-                let entry = ScanIndexEntry {
-                    scan: header.scan.clone(),
-                    vcp: header.vcp.clone(),
-                    file_name: header.file_name.clone(),
-                    cached_sweeps,
-                    total_size_bytes: batch_bytes,
+                let was_new = state.existing.is_none();
+                let new_sizes: HashMap<String, u64> = sweep_blobs
+                    .iter()
+                    .map(|(key, bytes)| (key.clone(), bytes.len() as u64))
+                    .collect();
+                let entry = logic::merge_scan_entry(
+                    state.existing.clone(),
+                    &header,
+                    &kept,
+                    &state.old_blob_sizes,
+                    &new_sizes,
+                );
+                let entry_value = match to_js_value(&entry) {
+                    Ok(value) => value,
+                    Err(error) => {
+                        abort_with(&tx, &failure, error);
+                        return;
+                    }
                 };
-                (entry, true)
+                for (key, bytes) in &sweep_blobs {
+                    if let Some(old) = state.old_blob_bytes.get(key) {
+                        if old == bytes {
+                            continue;
+                        }
+                        log::warn!(
+                            "Conflicting cached blob {}: later serialized transaction wins",
+                            key
+                        );
+                    }
+                    let buffer = Uint8Array::from(bytes.as_slice()).buffer();
+                    if let Err(error) = sweeps.put_with_key(&buffer, &JsValue::from_str(key)) {
+                        abort_with(&tx, &failure, DataError::RequestFailed(js_err(error)));
+                        return;
+                    }
+                }
+                if let Err(error) = index.put_with_key(&entry_value, &JsValue::from_str(&entry_key))
+                {
+                    abort_with(&tx, &failure, DataError::RequestFailed(js_err(error)));
+                    return;
+                }
+                if was_new || state.touch_exists == Some(false) {
+                    let now = JsValue::from_f64(UnixMillis::now().0 as f64);
+                    if let Err(error) = touches.put_with_key(&now, &JsValue::from_str(&entry_key)) {
+                        abort_with(&tx, &failure, DataError::RequestFailed(js_err(error)));
+                        return;
+                    }
+                }
+                state.writes_enqueued = true;
             }
-        };
+        });
 
-        let entry_value = to_js_value(&entry)?;
-        let touch_value = if seed_touch {
-            Some(JsValue::from_f64(UnixMillis::now().0 as f64))
-        } else {
-            None
+        let touch_request = touches
+            .get(&JsValue::from_str(&entry_key))
+            .map_err(|e| DataError::RequestFailed(js_err(e)))?;
+        let touch_callback = {
+            let state = state.clone();
+            let enqueue_writes = enqueue_writes.clone();
+            Closure::wrap(Box::new(move |event: web_sys::Event| {
+                let request: IdbRequest = event.target().unwrap().dyn_into().unwrap();
+                let result = request.result().unwrap_or(JsValue::UNDEFINED);
+                state.borrow_mut().touch_exists = Some(!result.is_null() && !result.is_undefined());
+                enqueue_writes();
+            }) as Box<dyn FnMut(_)>)
         };
+        touch_request.set_onsuccess(Some(touch_callback.as_ref().unchecked_ref()));
+        callbacks.borrow_mut().push(touch_callback);
 
-        let stores: &[&str] = if seed_touch {
-            &[STORE_SWEEPS, STORE_SCAN_INDEX, STORE_SCAN_TOUCHES]
-        } else {
-            &[STORE_SWEEPS, STORE_SCAN_INDEX]
+        let index_request = index
+            .get(&JsValue::from_str(&entry_key))
+            .map_err(|e| DataError::RequestFailed(js_err(e)))?;
+        let index_callback = {
+            let state = state.clone();
+            let failure = failure.clone();
+            let callbacks = callbacks.clone();
+            let enqueue_writes = enqueue_writes.clone();
+            let sweep_blobs = sweep_blobs.clone();
+            let sweeps = sweeps.clone();
+            let tx = tx.clone();
+            Closure::wrap(Box::new(move |event: web_sys::Event| {
+                let request: IdbRequest = event.target().unwrap().dyn_into().unwrap();
+                let value = request.result().unwrap_or(JsValue::UNDEFINED);
+                match from_js_value_opt(&value) {
+                    Ok(existing) => {
+                        let mut read = state.borrow_mut();
+                        read.existing = existing;
+                        read.index_read = true;
+                        read.pending_blobs = sweep_blobs.len();
+                    }
+                    Err(error) => {
+                        abort_with(&tx, &failure, error);
+                        return;
+                    }
+                }
+                for (key, _) in &sweep_blobs {
+                    let request = match sweeps.get(&JsValue::from_str(key)) {
+                        Ok(request) => request,
+                        Err(error) => {
+                            abort_with(&tx, &failure, DataError::RequestFailed(js_err(error)));
+                            return;
+                        }
+                    };
+                    let state = state.clone();
+                    let failure = failure.clone();
+                    let enqueue_writes = enqueue_writes.clone();
+                    let key = key.clone();
+                    let tx = tx.clone();
+                    let callback = Closure::wrap(Box::new(move |event: web_sys::Event| {
+                        let request: IdbRequest = event.target().unwrap().dyn_into().unwrap();
+                        let value = request.result().unwrap_or(JsValue::UNDEFINED);
+                        let mut read = state.borrow_mut();
+                        if !value.is_null() && !value.is_undefined() {
+                            let buffer: Result<ArrayBuffer, _> = value.dyn_into();
+                            match buffer {
+                                Ok(buffer) => {
+                                    read.old_blob_sizes
+                                        .insert(key.clone(), buffer.byte_length() as u64);
+                                    read.old_blob_bytes
+                                        .insert(key.clone(), Uint8Array::new(&buffer).to_vec());
+                                }
+                                Err(_) => {
+                                    drop(read);
+                                    abort_with(
+                                        &tx,
+                                        &failure,
+                                        DataError::SerdeError("Expected ArrayBuffer".to_string()),
+                                    );
+                                    return;
+                                }
+                            }
+                        }
+                        read.pending_blobs -= 1;
+                        drop(read);
+                        enqueue_writes();
+                    }) as Box<dyn FnMut(_)>);
+                    request.set_onsuccess(Some(callback.as_ref().unchecked_ref()));
+                    callbacks.borrow_mut().push(callback);
+                }
+                enqueue_writes();
+            }) as Box<dyn FnMut(_)>)
         };
+        index_request.set_onsuccess(Some(index_callback.as_ref().unchecked_ref()));
+        callbacks.borrow_mut().push(index_callback);
 
-        self.write_tx(stores, |wtx| {
-            let sweeps = wtx.object_store(STORE_SWEEPS)?;
-            for (key, data) in &sweep_blobs {
-                let array = Uint8Array::from(data.as_slice());
-                let buffer = array.buffer();
-                sweeps
-                    .put_with_key(&buffer, &JsValue::from_str(key))
-                    .map_err(|e| DataError::RequestFailed(js_err(e)))?;
-            }
-            wtx.object_store(STORE_SCAN_INDEX)?
-                .put_with_key(&entry_value, &JsValue::from_str(&entry_key))
-                .map_err(|e| DataError::RequestFailed(js_err(e)))?;
-            if let Some(ref touch) = touch_value {
-                wtx.object_store(STORE_SCAN_TOUCHES)?
-                    .put_with_key(touch, &JsValue::from_str(&entry_key))
-                    .map_err(|e| DataError::RequestFailed(js_err(e)))?;
-            }
-            Ok(())
-        })
-        .await
+        let transaction_result = wait_for_transaction(&tx).await;
+        callbacks.borrow_mut().clear();
+        if let Some(error) = failure.borrow_mut().take() {
+            return Err(error);
+        }
+        transaction_result
     }
 
     /// Gets a pre-computed sweep blob, returning the raw JS ArrayBuffer.
@@ -635,14 +756,63 @@ impl IndexedDbStore {
     async fn write_touch(&self, scan: &ScanKey, time: UnixMillis) -> Result<(), DataError> {
         self.ensure_open().await?;
         let key = scan.to_storage_key();
-        let value = JsValue::from_f64(time.0 as f64);
-        self.write_tx(&[STORE_SCAN_TOUCHES], |wtx| {
-            wtx.object_store(STORE_SCAN_TOUCHES)?
-                .put_with_key(&value, &JsValue::from_str(&key))
-                .map_err(|e| DataError::RequestFailed(js_err(e)))?;
-            Ok(())
-        })
-        .await
+        let db = self.get_db()?;
+        let names = Array::of2(
+            &JsValue::from_str(STORE_SCAN_INDEX),
+            &JsValue::from_str(STORE_SCAN_TOUCHES),
+        );
+        let tx = db
+            .transaction_with_str_sequence_and_mode(&names, IdbTransactionMode::Readwrite)
+            .map_err(|e| DataError::TransactionFailed(js_err(e)))?;
+        let index = tx
+            .object_store(STORE_SCAN_INDEX)
+            .map_err(|e| DataError::TransactionFailed(js_err(e)))?;
+        let touches = tx
+            .object_store(STORE_SCAN_TOUCHES)
+            .map_err(|e| DataError::TransactionFailed(js_err(e)))?;
+        let callbacks: EventCallbacks = Rc::new(RefCell::new(Vec::new()));
+        let index_request = index
+            .get(&JsValue::from_str(&key))
+            .map_err(|e| DataError::RequestFailed(js_err(e)))?;
+        let index_callback = {
+            let callbacks = callbacks.clone();
+            let key = key.clone();
+            let touches = touches.clone();
+            Closure::wrap(Box::new(move |event: web_sys::Event| {
+                let request: IdbRequest = event.target().unwrap().dyn_into().unwrap();
+                let index = request.result().unwrap_or(JsValue::UNDEFINED);
+                if index.is_null() || index.is_undefined() {
+                    let _ = touches.delete(&JsValue::from_str(&key));
+                    return;
+                }
+                let request = match touches.get(&JsValue::from_str(&key)) {
+                    Ok(request) => request,
+                    Err(error) => {
+                        log::debug!("Failed to read touch for {}: {}", key, js_err(error));
+                        return;
+                    }
+                };
+                let key = key.clone();
+                let touches = touches.clone();
+                let callback = Closure::wrap(Box::new(move |event: web_sys::Event| {
+                    let request: IdbRequest = event.target().unwrap().dyn_into().unwrap();
+                    let existing = request.result().ok().and_then(|value| value.as_f64());
+                    let next = existing.unwrap_or(time.0 as f64).max(time.0 as f64);
+                    if let Err(error) =
+                        touches.put_with_key(&JsValue::from_f64(next), &JsValue::from_str(&key))
+                    {
+                        log::debug!("Failed to write touch for {}: {}", key, js_err(error));
+                    }
+                }) as Box<dyn FnMut(_)>);
+                request.set_onsuccess(Some(callback.as_ref().unchecked_ref()));
+                callbacks.borrow_mut().push(callback);
+            }) as Box<dyn FnMut(_)>)
+        };
+        index_request.set_onsuccess(Some(index_callback.as_ref().unchecked_ref()));
+        callbacks.borrow_mut().push(index_callback);
+        let result = wait_for_transaction(&tx).await;
+        callbacks.borrow_mut().clear();
+        result
     }
 
     /// Reads every entry in the `scan_touches` store as a map. Used by
@@ -785,32 +955,69 @@ impl IndexedDbStore {
     /// per-scan deletion semantics directly.
     pub async fn delete_scan(&self, scan: &ScanKey) -> Result<u64, DataError> {
         self.ensure_open().await?;
-
         let scan_storage_key = scan.to_storage_key();
-        let bytes_freed = self
-            .scan_availability(scan)
-            .await?
-            .map(|e| e.total_size_bytes)
-            .unwrap_or(0);
-
         let sweeps_range = scan_prefix_range(scan)?;
-
-        self.write_tx(
-            &[STORE_SWEEPS, STORE_SCAN_INDEX, STORE_SCAN_TOUCHES],
-            |wtx| {
-                wtx.object_store(STORE_SWEEPS)?
-                    .delete(&sweeps_range.into())
-                    .map_err(|e| DataError::RequestFailed(js_err(e)))?;
-                wtx.object_store(STORE_SCAN_INDEX)?
-                    .delete(&JsValue::from_str(&scan_storage_key))
-                    .map_err(|e| DataError::RequestFailed(js_err(e)))?;
-                wtx.object_store(STORE_SCAN_TOUCHES)?
-                    .delete(&JsValue::from_str(&scan_storage_key))
-                    .map_err(|e| DataError::RequestFailed(js_err(e)))?;
-                Ok(())
-            },
-        )
-        .await?;
+        let db = self.get_db()?;
+        let names = Array::of3(
+            &JsValue::from_str(STORE_SWEEPS),
+            &JsValue::from_str(STORE_SCAN_INDEX),
+            &JsValue::from_str(STORE_SCAN_TOUCHES),
+        );
+        let tx = db
+            .transaction_with_str_sequence_and_mode(&names, IdbTransactionMode::Readwrite)
+            .map_err(|e| DataError::TransactionFailed(js_err(e)))?;
+        let sweeps = tx
+            .object_store(STORE_SWEEPS)
+            .map_err(|e| DataError::TransactionFailed(js_err(e)))?;
+        let index = tx
+            .object_store(STORE_SCAN_INDEX)
+            .map_err(|e| DataError::TransactionFailed(js_err(e)))?;
+        let touches = tx
+            .object_store(STORE_SCAN_TOUCHES)
+            .map_err(|e| DataError::TransactionFailed(js_err(e)))?;
+        let bytes_freed = Rc::new(RefCell::new(0u64));
+        let failure = Rc::new(RefCell::new(None));
+        let request = index
+            .get(&JsValue::from_str(&scan_storage_key))
+            .map_err(|e| DataError::RequestFailed(js_err(e)))?;
+        let callback = {
+            let bytes_freed = bytes_freed.clone();
+            let failure = failure.clone();
+            let tx = tx.clone();
+            let scan_storage_key = scan_storage_key.clone();
+            Closure::wrap(Box::new(move |event: web_sys::Event| {
+                let request: IdbRequest = event.target().unwrap().dyn_into().unwrap();
+                let value = request.result().unwrap_or(JsValue::UNDEFINED);
+                match from_js_value_opt::<ScanIndexEntry>(&value) {
+                    Ok(entry) => {
+                        *bytes_freed.borrow_mut() =
+                            entry.map(|entry| entry.total_size_bytes).unwrap_or(0)
+                    }
+                    Err(error) => {
+                        abort_with(&tx, &failure, error);
+                        return;
+                    }
+                }
+                for result in [
+                    sweeps.delete(&sweeps_range.clone().into()),
+                    index.delete(&JsValue::from_str(&scan_storage_key)),
+                    touches.delete(&JsValue::from_str(&scan_storage_key)),
+                ] {
+                    if let Err(error) = result {
+                        abort_with(&tx, &failure, DataError::RequestFailed(js_err(error)));
+                        return;
+                    }
+                }
+            }) as Box<dyn FnMut(_)>)
+        };
+        request.set_onsuccess(Some(callback.as_ref().unchecked_ref()));
+        let result = wait_for_transaction(&tx).await;
+        drop(callback);
+        if let Some(error) = failure.borrow_mut().take() {
+            return Err(error);
+        }
+        result?;
+        let bytes_freed = *bytes_freed.borrow();
 
         // Drop the in-memory throttle entry so a subsequent re-ingest of the
         // same scan key isn't suppressed.
@@ -919,46 +1126,11 @@ use helpers::*;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::data::{ScanKey, SiteId, UnixMillis};
     use wasm_bindgen_test::wasm_bindgen_test;
-
-    fn key(site: &str, ms: i64) -> ScanKey {
-        ScanKey::new(SiteId::new(site), UnixMillis(ms))
-    }
-
-    #[wasm_bindgen_test]
-    fn upsert_guard_blocks_concurrent_acquisition_for_same_scan() {
-        let scan = key("KDMX", 1_700_000_000_000);
-        let g1 = UpsertScanGuard::try_acquire(&scan).expect("first acquire succeeds");
-        assert!(
-            UpsertScanGuard::try_acquire(&scan).is_none(),
-            "second concurrent acquire must fail"
-        );
-        drop(g1);
-        // Once the first guard is dropped, the lock is released and a
-        // fresh acquire is allowed again.
-        assert!(UpsertScanGuard::try_acquire(&scan).is_some());
-    }
-
-    #[wasm_bindgen_test]
-    fn upsert_guard_independent_per_scan() {
-        let scan_a = key("KDMX", 1_700_000_000_000);
-        let scan_b = key("KFTG", 1_700_000_000_000);
-        let _ga = UpsertScanGuard::try_acquire(&scan_a).expect("acquire A");
-        let _gb =
-            UpsertScanGuard::try_acquire(&scan_b).expect("acquire B independent of A succeeds");
-    }
 
     #[wasm_bindgen_test]
     fn error_kind_classifies_structured_variants() {
         assert_eq!(DataError::NotOpen.kind(), ErrorKind::Transient);
-        assert_eq!(
-            DataError::ConcurrentUpsert {
-                scan_key: "KDMX|0".into()
-            }
-            .kind(),
-            ErrorKind::Transient
-        );
         assert_eq!(
             DataError::QuotaExceeded {
                 available_mb: 1.0,

--- a/src/data/keys.rs
+++ b/src/data/keys.rs
@@ -338,7 +338,7 @@ pub struct CachedSweep {
 /// Timing metadata for a single elevation cut. Used as input to
 /// `IndexedDbStore::upsert_scan`, which derives the persisted
 /// [`CachedSweep`] from it.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct SweepTiming {
     /// Sweep start time (Unix seconds, sub-second precision).
     pub start_secs: f64,
@@ -450,7 +450,11 @@ impl ScanIndexEntry {
 
     /// Number of sweeps actually stored.
     pub fn cached_sweep_count(&self) -> u32 {
-        self.cached_sweeps.len() as u32
+        self.cached_sweeps
+            .iter()
+            .map(|sweep| sweep.elevation_number)
+            .collect::<std::collections::HashSet<_>>()
+            .len() as u32
     }
 
     /// Latest radial collection timestamp (Unix seconds) across all cached

--- a/src/nexrad/decode/worker_api/ingest.rs
+++ b/src/nexrad/decode/worker_api/ingest.rs
@@ -532,11 +532,8 @@ pub fn worker_ingest_chunk(params: wasm_bindgen::JsValue) -> js_sys::Promise {
                 )
             });
 
-            // The worker pool serializes per-scan via the per-worker
-            // `CHUNK_ACCUM` thread-local, so we're the sole writer for this
-            // scan key. `upsert_scan` internally dispatches first-write vs
-            // merge against the existing entry; `scan_touches` is seeded
-            // only on the first write.
+            // The accumulator serializes this worker's chunk stream only.
+            // IndexedDB serializes the cross-worker/tab scan mutation.
             let header = ScanHeader {
                 scan: scan_key,
                 vcp: accum_vcp,

--- a/tests/idb.rs
+++ b/tests/idb.rs
@@ -17,6 +17,8 @@
 //!   builds the index entry across multiple `upsert_scan` calls; each call
 //!   must leave the manifest consistent with the blobs actually in storage.
 //! - **Eviction**: ordering by `scan_touches`, missing-touch sorts first.
+//! - **Cross-instance mutation**: independent store handles serialize the
+//!   same scan without losing elevations or inflating replacement accounting.
 //!
 //! Each test runs in its own IndexedDB database (via
 //! `IndexedDbStore::with_database_name`) so siblings don't collide.
@@ -318,6 +320,149 @@ async fn upsert_incremental_keeps_manifest_and_blobs_in_agreement() {
                 sweep.elevation_number,
                 product
             );
+        }
+    }
+}
+
+#[wasm_bindgen_test]
+async fn concurrent_upserts_retain_each_elevation() {
+    let db_name = fresh_db_name();
+    let first = IndexedDbStore::with_database_name(db_name.clone());
+    let second = IndexedDbStore::with_database_name(db_name);
+    first.open().await.unwrap();
+    second.open().await.unwrap();
+    let scan = scan_key("KDMX", 1700000000000);
+    let first_header = header(scan.clone());
+    let second_header = header(scan.clone());
+    let first_upload = upload(1, &[("reflectivity", 100)]);
+    let second_upload = upload(2, &[("velocity", 80)]);
+
+    let (first_result, second_result) = futures_util::future::join(
+        first.upsert_scan(&first_header, &[first_upload]),
+        second.upsert_scan(&second_header, &[second_upload]),
+    )
+    .await;
+    first_result.unwrap();
+    second_result.unwrap();
+
+    let entry = first.scan_availability(&scan).await.unwrap().unwrap();
+    assert_eq!(entry.cached_sweeps.len(), 2);
+    assert_eq!(entry.cached_sweep_count(), 2);
+    assert_eq!(entry.total_size_bytes, 180);
+    assert_eq!(
+        first
+            .get_sweep(&sweep_key(&scan, 1, "reflectivity"))
+            .await
+            .unwrap()
+            .unwrap()
+            .byte_length(),
+        100
+    );
+    assert_eq!(
+        first
+            .get_sweep(&sweep_key(&scan, 2, "velocity"))
+            .await
+            .unwrap()
+            .unwrap()
+            .byte_length(),
+        80
+    );
+}
+
+#[wasm_bindgen_test]
+async fn retry_and_replacement_are_idempotent_and_accounted_by_delta() {
+    let store = fresh_store();
+    let scan = scan_key("KDMX", 1700000000000);
+    let first = upload(1, &[("reflectivity", 100)]);
+    store
+        .upsert_scan(&header(scan.clone()), std::slice::from_ref(&first))
+        .await
+        .unwrap();
+    store
+        .upsert_scan(&header(scan.clone()), std::slice::from_ref(&first))
+        .await
+        .unwrap();
+    let entry = store.scan_availability(&scan).await.unwrap().unwrap();
+    assert_eq!(entry.cached_sweeps.len(), 1);
+    assert_eq!(entry.total_size_bytes, 100);
+
+    store
+        .upsert_scan(&header(scan.clone()), &[upload(1, &[("reflectivity", 40)])])
+        .await
+        .unwrap();
+    let entry = store.scan_availability(&scan).await.unwrap().unwrap();
+    assert_eq!(entry.cached_sweeps.len(), 1);
+    assert_eq!(entry.total_size_bytes, 40);
+    assert_eq!(store.total_cache_size().await.unwrap(), 40);
+
+    store
+        .upsert_scan(&header(scan.clone()), &[upload(1, &[("velocity", 20)])])
+        .await
+        .unwrap();
+    let entry = store.scan_availability(&scan).await.unwrap().unwrap();
+    assert_eq!(entry.cached_sweeps.len(), 1);
+    assert_eq!(
+        entry.cached_sweeps[0].cached_products,
+        vec!["reflectivity", "velocity"]
+    );
+    assert_eq!(entry.total_size_bytes, 60);
+}
+
+#[wasm_bindgen_test]
+async fn concurrent_upsert_and_delete_leave_a_serializable_scan() {
+    let db_name = fresh_db_name();
+    let writer = IndexedDbStore::with_database_name(db_name.clone());
+    let deleter = IndexedDbStore::with_database_name(db_name);
+    writer.open().await.unwrap();
+    deleter.open().await.unwrap();
+    let scan = scan_key("KDMX", 1700000000000);
+    writer
+        .upsert_scan(
+            &header(scan.clone()),
+            &[upload(1, &[("reflectivity", 100)])],
+        )
+        .await
+        .unwrap();
+
+    let next_header = header(scan.clone());
+    let next_upload = upload(2, &[("velocity", 80)]);
+    let (upsert, delete) = futures_util::future::join(
+        writer.upsert_scan(&next_header, &[next_upload]),
+        deleter.delete_scan(&scan),
+    )
+    .await;
+    upsert.unwrap();
+    delete.unwrap();
+
+    match writer.scan_availability(&scan).await.unwrap() {
+        None => {
+            assert!(writer.read_touch(&scan).await.unwrap().is_none());
+            assert!(writer
+                .get_sweep(&sweep_key(&scan, 1, "reflectivity"))
+                .await
+                .unwrap()
+                .is_none());
+            assert!(writer
+                .get_sweep(&sweep_key(&scan, 2, "velocity"))
+                .await
+                .unwrap()
+                .is_none());
+        }
+        Some(entry) => {
+            assert_eq!(entry.cached_sweeps.len(), 1);
+            assert_eq!(entry.cached_sweeps[0].elevation_number, 2);
+            assert_eq!(entry.total_size_bytes, 80);
+            assert!(writer.read_touch(&scan).await.unwrap().is_some());
+            assert!(writer
+                .get_sweep(&sweep_key(&scan, 1, "reflectivity"))
+                .await
+                .unwrap()
+                .is_none());
+            assert!(writer
+                .get_sweep(&sweep_key(&scan, 2, "velocity"))
+                .await
+                .unwrap()
+                .is_some());
         }
     }
 }


### PR DESCRIPTION
## Summary
- serialize scan upserts, deletes, and touches in callback-chained IndexedDB readwrite transactions shared by workers and tabs
- merge manifests by durable elevation/product identity, preserve additive product membership, and account for actual replacement byte deltas
- add cross-instance upsert and upsert/delete race coverage; bump the ephemeral cache schema to v6

## Testing
- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --bin nexrad-workbench`
- `CHROMEDRIVER=/usr/bin/chromedriver cargo test --test idb` *(blocked: `/usr/bin/chromedriver` is not installed in this environment; the test binary compiled successfully)*

Closes #189