### PR TITLE
Add privacy-friendly usage analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,20 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="apple-mobile-web-app-title" content="NEXRAD">
 
+    <!-- Privacy-friendly aggregate pageview analytics. Include the host in the
+         recorded path so the custom and GitHub Pages domains remain distinct,
+         and keep PR preview traffic out of the production dashboard. -->
+    <script>
+        window.goatcounter = {
+            no_onload: window.location.pathname.indexOf('/pr-preview/') !== -1,
+            path: function (path) { return window.location.host + path; }
+        };
+    </script>
+    <script data-goatcounter="https://danielway.goatcounter.com/count"
+            async src="https://gc.zgo.at/count.v5.js"
+            crossorigin="anonymous"
+            integrity="sha384-atnOLvQb9t+jTSipvd75X2yginT4PjVbqDdlJAmxMm+wYElFmeR6EmLP5bYeoRVQ"></script>
+
     <link data-trunk rel="rust" data-wasm-opt="2" />
     <link data-trunk rel="copy-file" href="worker.js" />
     <link data-trunk rel="copy-file" href="service-worker.js" />

--- a/service-worker.js
+++ b/service-worker.js
@@ -57,6 +57,10 @@ self.addEventListener('activate', (event) => {
 // for COEP instead of 'require-corp' so cross-origin resources (AWS S3, NOAA)
 // don't need to send Cross-Origin-Resource-Policy headers of their own.
 function withIsolationHeaders(response) {
+  // Opaque no-CORS responses (such as analytics beacons) have status 0 and
+  // cannot be reconstructed. COEP: credentialless allows them as-is.
+  if (response.type === 'opaque') return response;
+
   const headers = new Headers(response.headers);
   headers.set('Cross-Origin-Opener-Policy', 'same-origin');
   headers.set('Cross-Origin-Embedder-Policy', 'credentialless');


### PR DESCRIPTION
## Summary

- add GoatCounter aggregate pageview analytics using the configured `danielway` site
- prefix recorded paths with the hostname so the custom and GitHub Pages deployments remain distinguishable
- exclude PR preview traffic from automatic pageview counts
- pin GoatCounter `count.v5.js` with the published SRI hash
- allow opaque analytics beacon responses through the cross-origin isolation service worker

## GoatCounter documentation

- [Getting started](https://www.goatcounter.com/help/start)
- [Track multiple domains/sites](https://www.goatcounter.com/help/domains)
- [Skip staging/beta sites](https://www.goatcounter.com/help/skip-dev)
- [Use SRI with count.js](https://www.goatcounter.com/help/countjs-versions)

## Verification

- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --bin nexrad-workbench` (2,185 passed)
- `node --check service-worker.js`
- verified the downloaded `count.v5.js` SHA-384 digest matches GoatCounter documentation

`trunk build` was not run locally because Trunk is not installed; the PR workflow will run the production build.