### PR TITLE
Derive stream stall from expected sweep projection

### DIFF
--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -281,8 +281,9 @@ mode — it is a tether state.
 - **Streaming visibility:** all live surfaces project one per-frame
   `LiveStatus` view-model, so "is data actually arriving?" reads the same
   everywhere. The transport activity chip carries the moving part —
-  "receiving · 12", "next in ~40s · 12", or an amber "stalled — no data for
-  2:00" — the tethered now-cap carries the countdown ("◉ LIVE · 12s"), and
+   "receiving · 12", "waiting for 2.4° · expected in ~40s", or an amber
+   "stalled — 2.4° is late" — the tethered now-cap carries the countdown
+   ("◉ LIVE · 12s"), and
   pulsing is reserved for data genuinely moving (connecting/receiving), never
   for a routine wait.
 - **Idle-stop:** while detached, background streaming auto-stops after **60 min**

--- a/src/core/live_mode.rs
+++ b/src/core/live_mode.rs
@@ -95,11 +95,65 @@ impl LivePhase {
     }
 }
 
-/// How long a `WaitingForChunk` phase may run before the stream reads as
-/// stalled rather than merely between chunks. NEXRAD chunks land every ~10-15 s;
-/// four times the upper end is late enough to mean something is wrong without
-/// crying wolf on a slow volume.
-const STREAM_STALL_SECS: f64 = 60.0;
+/// How long `AcquiringLock` may run before a connect that never completes
+/// reads as stalled.
+const CONNECT_STALL_SECS: f64 = 60.0;
+
+/// Grace after the expected sweep's projected availability before a
+/// `WaitingForChunk` phase reads as stalled. Multi-minute filtered VCP
+/// gaps stay in `Waiting` until this window after the eligible sweep
+/// was supposed to be in S3.
+pub(crate) const EXPECTED_SWEEP_STALL_SECS: f64 = 30.0;
+
+/// The next eligible sweep the stream is waiting for, derived from the
+/// VCP projection for the active filter. `None` elevation is a volume
+/// Start chunk (no cut yet).
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub(crate) struct ExpectedSweep {
+    /// 1-based elevation number. `None` for a volume Start chunk.
+    pub elevation_number: Option<u8>,
+    /// Elevation angle in degrees when known (display only).
+    pub elevation_angle: Option<f32>,
+    /// Projected S3 availability (Unix seconds).
+    pub available_at_secs: f64,
+}
+
+impl ExpectedSweep {
+    /// Resolve the next eligible sweep from `plan` when it was built for
+    /// `active_filter`. A filter mismatch (stale plan after the user
+    /// changed elevation) yields `None` so status cannot stay stalled on
+    /// the previous target.
+    pub(crate) fn from_plan(
+        plan: &crate::core::StreamingPlan,
+        active_filter: crate::core::StreamingFilter,
+    ) -> Option<Self> {
+        if plan.filter != active_filter {
+            return None;
+        }
+        let target = plan.next_target()?;
+        let available_at_secs = target.projected.as_ref()?.available_at_secs;
+        Some(Self {
+            elevation_number: target.elevation_number.map(|n| n as u8),
+            elevation_angle: None,
+            available_at_secs,
+        })
+    }
+
+    /// Whether `now_secs` is strictly after projected availability plus
+    /// `grace_secs`. Equality is still waiting.
+    pub(crate) fn is_late(self, now_secs: f64, grace_secs: f64) -> bool {
+        now_secs > self.available_at_secs + grace_secs
+    }
+
+    /// Compact identity for waiting/stalled copy.
+    pub(crate) fn label(self) -> String {
+        match (self.elevation_angle, self.elevation_number) {
+            (Some(angle), _) => format!("{angle:.1}°"),
+            (None, Some(n)) => format!("el {n}"),
+            (None, None) => "next volume".to_string(),
+        }
+    }
+}
 
 /// Whether the live stream is actually pulling data right now.
 ///
@@ -130,19 +184,21 @@ impl StreamActivity {
     }
 }
 
-/// Derive the stream's activity from the live phase and how long it has sat
-/// there. Pure.
+/// Derive the stream's activity from the live phase, connect elapsed
+/// time, and — while waiting — the projected next eligible sweep. Pure.
 pub(crate) fn derive_stream_activity(
     phase: LivePhase,
     phase_elapsed_secs: f64,
-    stall_after_secs: f64,
+    connect_stall_after_secs: f64,
+    expected: Option<&ExpectedSweep>,
+    now_secs: f64,
 ) -> StreamActivity {
     match phase {
         LivePhase::Idle => StreamActivity::Off,
         LivePhase::Error => StreamActivity::Stalled,
         LivePhase::AcquiringLock => {
             // A connect that never completes is a stall, not a connect.
-            if phase_elapsed_secs > stall_after_secs {
+            if phase_elapsed_secs > connect_stall_after_secs {
                 StreamActivity::Stalled
             } else {
                 StreamActivity::Connecting
@@ -150,7 +206,10 @@ pub(crate) fn derive_stream_activity(
         }
         LivePhase::Streaming => StreamActivity::Receiving,
         LivePhase::WaitingForChunk => {
-            if phase_elapsed_secs > stall_after_secs {
+            // Stall only when the filter's next eligible sweep is late.
+            // No projection (or a just-changed filter) stays Waiting so
+            // a normal multi-minute gap cannot read as stalled.
+            if expected.is_some_and(|e| e.is_late(now_secs, EXPECTED_SWEEP_STALL_SECS)) {
                 StreamActivity::Stalled
             } else {
                 StreamActivity::Waiting
@@ -160,9 +219,19 @@ pub(crate) fn derive_stream_activity(
 }
 
 impl LiveModeState {
-    /// This frame's [`StreamActivity`], using the shared stall threshold.
-    pub(crate) fn stream_activity(&self, now: f64) -> StreamActivity {
-        derive_stream_activity(self.phase, self.phase_elapsed_secs(now), STREAM_STALL_SECS)
+    /// This frame's [`StreamActivity`] from phase + the expected sweep.
+    pub(crate) fn stream_activity(
+        &self,
+        now: f64,
+        expected: Option<&ExpectedSweep>,
+    ) -> StreamActivity {
+        derive_stream_activity(
+            self.phase,
+            self.phase_elapsed_secs(now),
+            CONNECT_STALL_SECS,
+            expected,
+            now,
+        )
     }
 }
 
@@ -835,52 +904,131 @@ mod tests {
 
     // ── derive_stream_activity: orthogonal to the tether ──
 
+    fn expected(available_at_secs: f64) -> ExpectedSweep {
+        ExpectedSweep {
+            elevation_number: Some(1),
+            elevation_angle: Some(0.5),
+            available_at_secs,
+        }
+    }
+
+    fn activity(
+        phase: LivePhase,
+        phase_elapsed_secs: f64,
+        expected: Option<&ExpectedSweep>,
+        now_secs: f64,
+    ) -> StreamActivity {
+        derive_stream_activity(
+            phase,
+            phase_elapsed_secs,
+            CONNECT_STALL_SECS,
+            expected,
+            now_secs,
+        )
+    }
+
     #[wasm_bindgen_test]
     fn activity_maps_each_phase() {
         let fresh = 1.0;
         assert_eq!(
-            derive_stream_activity(LivePhase::Idle, fresh, STREAM_STALL_SECS),
+            activity(LivePhase::Idle, fresh, None, 0.0),
             StreamActivity::Off
         );
         assert_eq!(
-            derive_stream_activity(LivePhase::AcquiringLock, fresh, STREAM_STALL_SECS),
+            activity(LivePhase::AcquiringLock, fresh, None, 0.0),
             StreamActivity::Connecting
         );
         assert_eq!(
-            derive_stream_activity(LivePhase::Streaming, fresh, STREAM_STALL_SECS),
+            activity(LivePhase::Streaming, fresh, None, 0.0),
             StreamActivity::Receiving
         );
         assert_eq!(
-            derive_stream_activity(LivePhase::WaitingForChunk, fresh, STREAM_STALL_SECS),
+            activity(LivePhase::WaitingForChunk, fresh, None, 0.0),
             StreamActivity::Waiting
         );
         assert_eq!(
-            derive_stream_activity(LivePhase::Error, fresh, STREAM_STALL_SECS),
+            activity(LivePhase::Error, fresh, None, 0.0),
             StreamActivity::Stalled
         );
     }
 
     #[wasm_bindgen_test]
-    fn waiting_past_the_threshold_reads_as_stalled() {
-        // The distinction the user actually needs: "between chunks" vs "nothing
-        // is coming". Both are non-Receiving, so a static indicator conflates
-        // them.
+    fn waiting_stays_waiting_until_projected_completion_plus_grace() {
+        let exp = expected(1000.0);
+        // Long phase elapsed is a normal filtered VCP gap, not a stall.
         assert_eq!(
-            derive_stream_activity(LivePhase::WaitingForChunk, STREAM_STALL_SECS, 60.0),
+            activity(LivePhase::WaitingForChunk, 180.0, Some(&exp), 1000.0),
             StreamActivity::Waiting
         );
         assert_eq!(
-            derive_stream_activity(LivePhase::WaitingForChunk, STREAM_STALL_SECS + 0.1, 60.0),
+            activity(
+                LivePhase::WaitingForChunk,
+                210.0,
+                Some(&exp),
+                1000.0 + EXPECTED_SWEEP_STALL_SECS
+            ),
+            StreamActivity::Waiting
+        );
+        assert_eq!(
+            activity(
+                LivePhase::WaitingForChunk,
+                210.1,
+                Some(&exp),
+                1000.0 + EXPECTED_SWEEP_STALL_SECS + 0.1
+            ),
             StreamActivity::Stalled
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn waiting_without_expected_sweep_never_stalls() {
+        assert_eq!(
+            activity(LivePhase::WaitingForChunk, 999.0, None, 10_000.0),
+            StreamActivity::Waiting
         );
     }
 
     #[wasm_bindgen_test]
     fn a_connect_that_never_completes_reads_as_stalled() {
         assert_eq!(
-            derive_stream_activity(LivePhase::AcquiringLock, 999.0, 60.0),
+            activity(LivePhase::AcquiringLock, 999.0, None, 0.0),
             StreamActivity::Stalled
         );
+    }
+
+    #[wasm_bindgen_test]
+    fn expected_sweep_from_plan_uses_filter_and_availability() {
+        use crate::core::StreamingFilter;
+        let plan = StreamingPlan::with_projected_target_for_test(
+            StreamingFilter::Elevation(3),
+            Some(3),
+            1500.0,
+        );
+        let hit = ExpectedSweep::from_plan(&plan, StreamingFilter::Elevation(3)).unwrap();
+        assert_eq!(hit.elevation_number, Some(3));
+        assert_eq!(hit.available_at_secs, 1500.0);
+
+        assert!(
+            ExpectedSweep::from_plan(&plan, StreamingFilter::Elevation(1)).is_none(),
+            "stale plan after a filter change must not keep the old target"
+        );
+        assert!(ExpectedSweep::from_plan(&plan, StreamingFilter::All).is_none());
+
+        let unprojected = StreamingPlan::with_next_target_key_for_test(Some((0, 1)));
+        assert!(
+            ExpectedSweep::from_plan(&unprojected, StreamingFilter::All).is_none(),
+            "a target without projected times is not yet an expectation"
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn expected_sweep_from_plan_names_start_chunk_without_elevation() {
+        use crate::core::StreamingFilter;
+        let plan =
+            StreamingPlan::with_projected_target_for_test(StreamingFilter::All, None, 2000.0);
+        let hit = ExpectedSweep::from_plan(&plan, StreamingFilter::All).unwrap();
+        assert_eq!(hit.elevation_number, None);
+        assert_eq!(hit.label(), "next volume");
     }
 
     #[wasm_bindgen_test]
@@ -901,10 +1049,10 @@ mod tests {
         let mut s = LiveModeState::new();
         s.start(0.0);
         s.start_streaming(10.0);
-        assert_eq!(s.stream_activity(10.5), StreamActivity::Receiving);
+        assert_eq!(s.stream_activity(10.5, None), StreamActivity::Receiving);
         // Nothing about detaching touches the phase.
         s.detached_since = Some(10.5);
-        assert_eq!(s.stream_activity(10.5), StreamActivity::Receiving);
+        assert_eq!(s.stream_activity(10.5, None), StreamActivity::Receiving);
     }
 
     // ── is_active() truth table ──

--- a/src/core/live_status.rs
+++ b/src/core/live_status.rs
@@ -15,7 +15,7 @@
 //! A detached playhead over a healthy stream and a tethered one report the
 //! same activity; a tethered playhead over a stalled stream must say so.
 
-use crate::core::live_mode::LiveModeState;
+use crate::core::live_mode::{ExpectedSweep, LiveModeState, LivePhase};
 use crate::core::{format_lag, StreamActivity};
 
 /// The playhead's relationship to the live edge. Orthogonal to
@@ -46,9 +46,13 @@ pub(crate) struct LiveStatus {
     pub tether: LiveTether,
     /// Chunks received this session — the number that visibly ticks up.
     pub chunks_received: u32,
-    /// Seconds until the next chunk is expected in S3. `Some` only while
-    /// [`StreamActivity::Waiting`] — a stalled stream has no honest countdown.
+    /// Seconds until the next eligible sweep is expected in S3. `Some` only
+    /// while [`StreamActivity::Waiting`] — a stalled stream has no honest
+    /// countdown.
     pub countdown_secs: Option<f64>,
+    /// Next eligible sweep for the active filter. Present while waiting or
+    /// stalled so copy can name the expected cut.
+    pub expected_sweep: Option<ExpectedSweep>,
     /// Wall-now minus playhead — the "behind" readout. `Some` only while
     /// [`LiveTether::Detached`].
     pub lag_secs: Option<f64>,
@@ -56,7 +60,7 @@ pub(crate) struct LiveStatus {
     /// §11.3 data age). `None` before the first radial or when idle.
     pub data_age_secs: Option<f64>,
     /// Seconds spent in the current phase — feeds the connecting elapsed
-    /// readout and the stalled "no data for" duration.
+    /// readout.
     pub phase_elapsed_secs: f64,
 }
 
@@ -67,6 +71,7 @@ impl Default for LiveStatus {
             tether: LiveTether::None,
             chunks_received: 0,
             countdown_secs: None,
+            expected_sweep: None,
             lag_secs: None,
             data_age_secs: None,
             phase_elapsed_secs: 0.0,
@@ -81,6 +86,9 @@ pub(crate) struct LiveStatusInputs<'a> {
     /// From [`crate::subsystem::Live::countdown_remaining_secs`] (this frame's
     /// projection); already `None` outside `WaitingForChunk`.
     pub countdown_secs: Option<f64>,
+    /// Next eligible sweep from this frame's projection, already cleared
+    /// when the plan's filter does not match the current selection.
+    pub expected_sweep: Option<ExpectedSweep>,
     /// Whether the playhead rides the live edge (pinned or lookback).
     pub tethered: bool,
     pub playback_position_secs: f64,
@@ -92,11 +100,12 @@ pub(crate) fn derive_live_status(inputs: LiveStatusInputs<'_>) -> LiveStatus {
     let LiveStatusInputs {
         mode_state,
         countdown_secs,
+        expected_sweep,
         tethered,
         playback_position_secs,
         now_secs,
     } = inputs;
-    let activity = mode_state.stream_activity(now_secs);
+    let activity = mode_state.stream_activity(now_secs, expected_sweep.as_ref());
     let tether = if !mode_state.is_active() {
         LiveTether::None
     } else if tethered {
@@ -113,6 +122,10 @@ pub(crate) fn derive_live_status(inputs: LiveStatusInputs<'_>) -> LiveStatus {
         countdown_secs: (activity == StreamActivity::Waiting)
             .then_some(countdown_secs)
             .flatten(),
+        expected_sweep: (mode_state.phase == LivePhase::WaitingForChunk
+            && matches!(activity, StreamActivity::Waiting | StreamActivity::Stalled))
+        .then_some(expected_sweep)
+        .flatten(),
         lag_secs: (tether == LiveTether::Detached).then_some(now_secs - playback_position_secs),
         data_age_secs: if mode_state.is_active() {
             mode_state.last_radial_time_secs.map(|t| now_secs - t)
@@ -134,18 +147,23 @@ impl LiveStatus {
                 Some(format!("connecting… {}s", self.phase_elapsed_secs as i64))
             }
             StreamActivity::Receiving => Some(format!("receiving · {}", self.chunks_received)),
-            StreamActivity::Waiting => Some(match self.countdown_secs {
-                Some(s) => format!(
-                    "next in ~{}s · {}",
-                    s.max(0.0).ceil() as i64,
-                    self.chunks_received
+            StreamActivity::Waiting => {
+                let wait = self
+                    .expected_sweep
+                    .map(|e| format!("waiting for {}", e.label()))
+                    .unwrap_or_else(|| "waiting for next sweep".to_string());
+                Some(match self.countdown_secs {
+                    Some(s) => format!("{wait} · expected in ~{}s", s.max(0.0).ceil() as i64),
+                    None => wait,
+                })
+            }
+            StreamActivity::Stalled => Some(match self.expected_sweep {
+                Some(e) => format!("stalled — {} is late", e.label()),
+                None => format!(
+                    "stalled — no data for {}",
+                    format_lag(self.phase_elapsed_secs)
                 ),
-                None => format!("waiting · {}", self.chunks_received),
             }),
-            StreamActivity::Stalled => Some(format!(
-                "stalled — no data for {}",
-                format_lag(self.phase_elapsed_secs)
-            )),
         }
     }
 
@@ -155,8 +173,12 @@ impl LiveStatus {
             StreamActivity::Off => None,
             StreamActivity::Connecting => Some("Connecting to the live feed"),
             StreamActivity::Receiving => Some("Receiving live data now"),
-            StreamActivity::Waiting => Some("Stream healthy — waiting for the next chunk"),
-            StreamActivity::Stalled => Some("No data has arrived for a while"),
+            StreamActivity::Waiting => Some("Waiting for the next expected sweep"),
+            StreamActivity::Stalled => Some(if self.expected_sweep.is_some() {
+                "Expected sweep is late — change elevation or stop streaming"
+            } else {
+                "No data has arrived for a while"
+            }),
         }
     }
 
@@ -183,10 +205,23 @@ mod coverage_tests {
         s
     }
 
+    fn expected(
+        elevation_number: Option<u8>,
+        angle: Option<f32>,
+        available_at_secs: f64,
+    ) -> ExpectedSweep {
+        ExpectedSweep {
+            elevation_number,
+            elevation_angle: angle,
+            available_at_secs,
+        }
+    }
+
     fn inputs(mode_state: &LiveModeState) -> LiveStatusInputs<'_> {
         LiveStatusInputs {
             mode_state,
             countdown_secs: None,
+            expected_sweep: None,
             tethered: false,
             playback_position_secs: 0.0,
             now_secs: 0.0,
@@ -299,15 +334,112 @@ mod coverage_tests {
 
     #[wasm_bindgen_test]
     fn countdown_suppressed_once_stalled() {
-        // 61s into WaitingForChunk → stalled; an overdue countdown is a lie.
+        // Expected sweep 31s late → stalled; an overdue countdown is a lie.
         let s = state_in_phase(LivePhase::WaitingForChunk, 1000.0);
         let status = derive_live_status(LiveStatusInputs {
             countdown_secs: Some(5.0),
+            expected_sweep: Some(expected(Some(1), Some(0.5), 1030.0)),
             now_secs: 1061.0,
             ..inputs(&s)
         });
         assert_eq!(status.activity, StreamActivity::Stalled);
         assert_eq!(status.countdown_secs, None);
+    }
+
+    #[wasm_bindgen_test]
+    fn long_filtered_gap_stays_waiting_before_grace() {
+        // 3 minutes into the phase, but the eligible sweep is still 40s out.
+        let s = state_in_phase(LivePhase::WaitingForChunk, 1000.0);
+        let status = derive_live_status(LiveStatusInputs {
+            countdown_secs: Some(40.0),
+            expected_sweep: Some(expected(Some(3), Some(2.4), 1220.0)),
+            now_secs: 1180.0,
+            ..inputs(&s)
+        });
+        assert_eq!(status.activity, StreamActivity::Waiting);
+        assert_eq!(status.countdown_secs, Some(40.0));
+        assert_eq!(
+            status.detail_text().as_deref(),
+            Some("waiting for 2.4° · expected in ~40s")
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn stall_starts_strictly_after_projected_completion_plus_grace() {
+        let s = state_in_phase(LivePhase::WaitingForChunk, 1000.0);
+        let exp = expected(Some(3), Some(2.4), 1100.0);
+        let at_boundary = derive_live_status(LiveStatusInputs {
+            expected_sweep: Some(exp),
+            now_secs: 1130.0,
+            ..inputs(&s)
+        });
+        assert_eq!(at_boundary.activity, StreamActivity::Waiting);
+
+        let late = derive_live_status(LiveStatusInputs {
+            expected_sweep: Some(exp),
+            now_secs: 1130.1,
+            ..inputs(&s)
+        });
+        assert_eq!(late.activity, StreamActivity::Stalled);
+        assert_eq!(
+            late.detail_text().as_deref(),
+            Some("stalled — 2.4° is late")
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn filter_change_clears_stalled_when_expectation_is_dropped() {
+        let s = state_in_phase(LivePhase::WaitingForChunk, 1000.0);
+        let stalled = derive_live_status(LiveStatusInputs {
+            expected_sweep: Some(expected(Some(3), Some(2.4), 1000.0)),
+            now_secs: 1100.0,
+            ..inputs(&s)
+        });
+        assert_eq!(stalled.activity, StreamActivity::Stalled);
+
+        let after_filter = derive_live_status(LiveStatusInputs {
+            expected_sweep: None,
+            now_secs: 1100.0,
+            ..inputs(&s)
+        });
+        assert_eq!(after_filter.activity, StreamActivity::Waiting);
+        assert_eq!(
+            after_filter.detail_text().as_deref(),
+            Some("waiting for next sweep")
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn arrival_clears_stalled_when_phase_leaves_waiting() {
+        let mut s = state_in_phase(LivePhase::WaitingForChunk, 1000.0);
+        let stalled = derive_live_status(LiveStatusInputs {
+            expected_sweep: Some(expected(Some(1), Some(0.5), 1000.0)),
+            now_secs: 1100.0,
+            ..inputs(&s)
+        });
+        assert_eq!(stalled.activity, StreamActivity::Stalled);
+
+        s.phase = LivePhase::Streaming;
+        s.phase_started_at = Some(1100.0);
+        let receiving = derive_live_status(LiveStatusInputs {
+            expected_sweep: Some(expected(Some(2), Some(1.5), 1120.0)),
+            now_secs: 1100.0,
+            ..inputs(&s)
+        });
+        assert_eq!(receiving.activity, StreamActivity::Receiving);
+        assert_eq!(receiving.expected_sweep, None);
+    }
+
+    #[wasm_bindgen_test]
+    fn stop_clears_stalled() {
+        let s = LiveModeState::default();
+        let off = derive_live_status(LiveStatusInputs {
+            expected_sweep: Some(expected(Some(1), Some(0.5), 1000.0)),
+            now_secs: 1100.0,
+            ..inputs(&s)
+        });
+        assert_eq!(off.activity, StreamActivity::Off);
+        assert_eq!(off.detail_text(), None);
     }
 
     // ── data age ──
@@ -371,36 +503,59 @@ mod coverage_tests {
     }
 
     #[wasm_bindgen_test]
-    fn detail_text_waiting_shows_countdown_ceil() {
-        let mut s = state_in_phase(LivePhase::WaitingForChunk, 100.0);
-        s.chunks_received = 12;
+    fn detail_text_waiting_shows_sweep_and_countdown_ceil() {
+        let s = state_in_phase(LivePhase::WaitingForChunk, 100.0);
         let status = derive_live_status(LiveStatusInputs {
             countdown_secs: Some(39.2),
+            expected_sweep: Some(expected(Some(3), Some(2.4), 141.0)),
             now_secs: 101.0,
             ..inputs(&s)
         });
-        assert_eq!(status.detail_text().as_deref(), Some("next in ~40s · 12"));
+        assert_eq!(
+            status.detail_text().as_deref(),
+            Some("waiting for 2.4° · expected in ~40s")
+        );
     }
 
     #[wasm_bindgen_test]
     fn detail_text_waiting_without_eta_falls_back() {
-        let mut s = state_in_phase(LivePhase::WaitingForChunk, 100.0);
-        s.chunks_received = 3;
+        let s = state_in_phase(LivePhase::WaitingForChunk, 100.0);
         let status = derive_live_status(LiveStatusInputs {
             now_secs: 101.0,
             ..inputs(&s)
         });
-        assert_eq!(status.detail_text().as_deref(), Some("waiting · 3"));
+        assert_eq!(
+            status.detail_text().as_deref(),
+            Some("waiting for next sweep")
+        );
     }
 
     #[wasm_bindgen_test]
-    fn detail_text_stalled_names_the_silence() {
-        // 2 minutes into WaitingForChunk → "no data for 2:00".
+    fn detail_text_stalled_names_the_late_sweep() {
         let s = state_in_phase(LivePhase::WaitingForChunk, 1000.0);
+        let status = derive_live_status(LiveStatusInputs {
+            expected_sweep: Some(expected(Some(3), None, 1000.0)),
+            now_secs: 1120.0,
+            ..inputs(&s)
+        });
+        assert_eq!(
+            status.detail_text().as_deref(),
+            Some("stalled — el 3 is late")
+        );
+        assert_eq!(
+            status.hover_text(),
+            Some("Expected sweep is late — change elevation or stop streaming")
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn detail_text_connect_stall_keeps_generic_silence() {
+        let s = state_in_phase(LivePhase::AcquiringLock, 1000.0);
         let status = derive_live_status(LiveStatusInputs {
             now_secs: 1120.0,
             ..inputs(&s)
         });
+        assert_eq!(status.activity, StreamActivity::Stalled);
         assert_eq!(
             status.detail_text().as_deref(),
             Some("stalled — no data for 2:00")
@@ -451,14 +606,19 @@ mod coverage_tests {
 
     #[wasm_bindgen_test]
     fn hover_text_present_for_every_active_activity() {
-        for (phase, elapsed) in [
-            (LivePhase::AcquiringLock, 1.0),
-            (LivePhase::Streaming, 1.0),
-            (LivePhase::WaitingForChunk, 1.0),
-            (LivePhase::WaitingForChunk, 999.0), // stalled
+        for (phase, elapsed, expected_sweep) in [
+            (LivePhase::AcquiringLock, 1.0, None),
+            (LivePhase::Streaming, 1.0, None),
+            (LivePhase::WaitingForChunk, 1.0, None),
+            (
+                LivePhase::WaitingForChunk,
+                999.0,
+                Some(expected(Some(1), Some(0.5), 1000.0)),
+            ),
         ] {
             let s = state_in_phase(phase, 1000.0);
             let status = derive_live_status(LiveStatusInputs {
+                expected_sweep,
                 now_secs: 1000.0 + elapsed,
                 ..inputs(&s)
             });

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -99,7 +99,8 @@ pub(crate) use domain::worker::{
 pub(crate) use effect::{Effect, LocationResult, LocationSource};
 pub(crate) use geo_layers::GeoLayer;
 pub(crate) use live_mode::{
-    should_stop_for_detached_idle, LiveExitReason, LiveModeState, LivePhase, StreamActivity,
+    should_stop_for_detached_idle, ExpectedSweep, LiveExitReason, LiveModeState, LivePhase,
+    StreamActivity,
 };
 pub(crate) use live_radar_model::LiveRadarModel;
 pub(crate) use live_status::{derive_live_status, LiveStatus, LiveStatusInputs, LiveTether};

--- a/src/core/streaming_plan.rs
+++ b/src/core/streaming_plan.rs
@@ -94,11 +94,9 @@ pub(crate) struct ChunkProjectionInfo {
 /// this object.
 #[derive(Clone, Debug)]
 pub(crate) struct StreamingPlan {
-    /// Active filter at plan-build time. Diagnostic only — consumers
-    /// already know the active filter via the streaming channel; this
-    /// is preserved so a captured plan (e.g. for a per-chunk arrival
-    /// stat) carries enough context to be interpreted standalone.
-    #[allow(dead_code)] // Doc above: diagnostic context so captured plans read standalone.
+    /// Active filter at plan-build time. Status derivation compares this
+    /// against the current selection so a stale plan cannot keep a
+    /// previous elevation's stall after the user changes the filter.
     pub filter: StreamingFilter,
     /// Wall-clock time (Unix seconds) the plan was built. Lets consumers
     /// reason about plan staleness without threading `now` through every
@@ -365,6 +363,46 @@ impl StreamingPlan {
             next_volume_chunks: next,
             current_volume_end_collection_secs: None,
             next_target_key,
+        }
+    }
+
+    /// Test plan whose `next_target()` has projected availability.
+    #[cfg(test)]
+    pub(crate) fn with_projected_target_for_test(
+        filter: StreamingFilter,
+        elevation_number: Option<usize>,
+        available_at_secs: f64,
+    ) -> Self {
+        let seq = 1;
+        StreamingPlan {
+            filter,
+            built_at_secs: 0.0,
+            revision: 0,
+            current_volume_chunks: vec![ChunkProjectionInfo {
+                sequence: seq,
+                elevation_number,
+                azimuth_rate_dps: 0.0,
+                chunk_index_in_sweep: 0,
+                chunks_in_sweep: 3,
+                projected: Some(ChunkProjectedTimes {
+                    collection_time_secs: available_at_secs,
+                    available_at_secs,
+                    poll_at_secs: available_at_secs,
+                    physics_breakdown: crate::core::timing::PhysicsBreakdown {
+                        case: crate::core::timing::IntervalCase::IntraSweep,
+                        total_secs: 0.0,
+                        chunk_duration_secs: None,
+                        inter_sweep_gap_secs: None,
+                        waveform_penalty_secs: None,
+                    },
+                    stats_n: 0,
+                    scheduler_path: crate::core::timing::SchedulerPath::Physics,
+                    bucket: None,
+                }),
+            }],
+            next_volume_chunks: None,
+            current_volume_end_collection_secs: None,
+            next_target_key: Some((0, seq)),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -629,10 +629,7 @@ impl WorkbenchApp {
             recent_requests: &self.state.recent_network_requests,
             cache_size_bytes: stats.cache_size_bytes,
             streaming: self.live.mode_state.is_active(),
-            stream_activity: self
-                .live
-                .mode_state
-                .stream_activity(self.state.frame_now.secs()),
+            stream_activity: self.live.frame_status.activity,
             sheet_open: self.chrome.activity_sheet_open,
             dev: self
                 .state
@@ -913,6 +910,7 @@ impl eframe::App for WorkbenchApp {
             playback: &self.playback.state,
             archive_boundaries: &self.timeline.shadow_scan_boundaries,
             now: self.state.frame_now,
+            elevation_selection: &self.state.viz_state.elevation_selection,
         });
         self.state.refresh_mobile_mode(ctx);
 

--- a/src/subsystem/live.rs
+++ b/src/subsystem/live.rs
@@ -16,7 +16,8 @@
 use crate::core::projection::{new_shared_engine, Projection, SharedProjectionEngine};
 use crate::core::PlaybackState;
 use crate::core::RadarTimeline;
-use crate::core::{LiveModeState, LiveRadarModel};
+use crate::core::{ElevationSelection, StreamingFilter};
+use crate::core::{ExpectedSweep, LiveModeState, LiveRadarModel};
 use crate::nexrad::RealtimeChannel;
 use crate::state::AppMode;
 
@@ -31,6 +32,9 @@ pub(crate) struct LiveRefreshInputs<'a> {
     pub archive_boundaries: &'a [crate::core::ScanBoundary],
     /// This frame's wall clock (from `AppState::frame_now`).
     pub now: crate::core::FrameNow,
+    /// Current elevation selection — compared against the plan filter so a
+    /// just-changed cut cannot keep the previous sweep's stall.
+    pub elevation_selection: &'a ElevationSelection,
 }
 
 /// Owner of the real-time streaming pipeline and the derived
@@ -179,9 +183,30 @@ impl Live {
                 .is_some(),
         );
         // Last: the status snapshot reads the projection adopted above.
+        let active_filter = StreamingFilter::from(inputs.elevation_selection);
+        let mut expected_sweep = self
+            .frame_projection
+            .as_ref()
+            .and_then(|p| ExpectedSweep::from_plan(&p.plan, active_filter));
+        if let (Some(exp), Some(scan)) = (
+            expected_sweep.as_mut(),
+            self.frame_projection
+                .as_ref()
+                .and_then(|p| p.live_scan.as_ref()),
+        ) {
+            if let Some(n) = exp.elevation_number {
+                exp.elevation_angle = scan
+                    .sweeps
+                    .iter()
+                    .chain(scan.next_scan_ghost.iter().flat_map(|g| g.sweeps.iter()))
+                    .find(|s| s.elevation_number == n)
+                    .map(|s| s.elevation_angle);
+            }
+        }
         self.frame_status = crate::core::derive_live_status(crate::core::LiveStatusInputs {
             mode_state: &self.mode_state,
             countdown_secs: self.countdown_remaining_secs(now),
+            expected_sweep,
             tethered: playhead_live,
             playback_position_secs: inputs.playback.playback_position(),
             now_secs: now,


### PR DESCRIPTION
Fixes #142.

The live stream used a fixed 60s silence timer, so a selected elevation with a normal multi-minute VCP gap showed **Stalled** while the app was correctly waiting.

Status now comes from the active filter's next eligible sweep:

- **Waiting** until that sweep's projected S3 availability
- **Stalled** only after availability + 30s
- Cleared immediately when the expected data arrives, the filter changes, or streaming stops

Waiting/stalled copy names the expected sweep and distinguishes an expected wait from a late cut. Decision logic and tests stay in the headless core; the UI only projects `LiveStatus`.

Local `cargo test --bin nexrad-workbench` OOMs in this environment; please rely on CI for the wasm suite. `cargo fmt` and `cargo clippy --all-targets -- -D warnings` are clean.