### PR TITLE
Use phosphor broadcast icon for live stream text

### DIFF
--- a/src/ui/activity_chip.rs
+++ b/src/ui/activity_chip.rs
@@ -32,7 +32,7 @@ fn glyph_icon(glyph: ActivityGlyph) -> &'static str {
         ActivityGlyph::Check => icons::CHECK_CIRCLE,
         ActivityGlyph::ArrowDown => icons::ARROW_DOWN,
         ActivityGlyph::Gear => icons::GEAR,
-        ActivityGlyph::Wave => icons::WAVE_SINE,
+        ActivityGlyph::Wave => icons::BROADCAST,
         ActivityGlyph::Pause => icons::PAUSE,
     }
 }

--- a/src/ui/mobile/tabs.rs
+++ b/src/ui/mobile/tabs.rs
@@ -308,7 +308,7 @@ fn render_stream_health(ui: &mut egui::Ui, live: &crate::subsystem::Live) {
         return;
     }
     let resp = ui.label(
-        RichText::new(format!("{} stalled", egui_phosphor::regular::WAVE_SINE))
+        RichText::new(format!("{} stalled", egui_phosphor::regular::BROADCAST))
             .size(10.0)
             .monospace()
             .color(crate::ui::colors::live::ACQUIRING),

--- a/src/ui/mobile/tabs.rs
+++ b/src/ui/mobile/tabs.rs
@@ -308,7 +308,12 @@ fn render_stream_health(ui: &mut egui::Ui, live: &crate::subsystem::Live) {
         return;
     }
     let resp = ui.label(
-        RichText::new(format!("{} stalled", egui_phosphor::regular::BROADCAST))
+        RichText::new(egui_phosphor::regular::BROADCAST)
+            .size(10.0)
+            .color(crate::ui::colors::live::ACQUIRING),
+    );
+    ui.label(
+        RichText::new("stalled")
             .size(10.0)
             .monospace()
             .color(crate::ui::colors::live::ACQUIRING),

--- a/src/ui/playback_controls.rs
+++ b/src/ui/playback_controls.rs
@@ -691,7 +691,7 @@ fn render_stream_activity(ui: &mut egui::Ui, state: &AppState, live: &crate::sub
         color
     };
 
-    let text = format!("{} {detail}", egui_phosphor::regular::WAVE_SINE);
+    let text = format!("{} {detail}", egui_phosphor::regular::BROADCAST);
     let resp = ui.label(RichText::new(text).size(11.0).monospace().color(color));
     if let Some(hover) = status.hover_text() {
         resp.on_hover_text(hover);

--- a/src/ui/playback_controls.rs
+++ b/src/ui/playback_controls.rs
@@ -691,8 +691,12 @@ fn render_stream_activity(ui: &mut egui::Ui, state: &AppState, live: &crate::sub
         color
     };
 
-    let text = format!("{} {detail}", egui_phosphor::regular::BROADCAST);
-    let resp = ui.label(RichText::new(text).size(11.0).monospace().color(color));
+    let resp = ui.label(
+        RichText::new(egui_phosphor::regular::BROADCAST)
+            .size(11.0)
+            .color(color),
+    );
+    ui.label(RichText::new(detail).size(11.0).monospace().color(color));
     if let Some(hover) = status.hover_text() {
         resp.on_hover_text(hover);
     }


### PR DESCRIPTION
## Summary
- Replace the missing `WAVE_SINE` glyph (tofu block) next to live stream status text with `BROADCAST`, the same Phosphor icon already used on LIVE badges.
- Covers the desktop stream-activity chip, the ambient activity chip's streaming state, and the mobile stall readout.

Fixes #141

## Test plan
- [ ] Start live streaming and confirm the countdown reads as a broadcast icon + `next in ~Ns`, not a hollow square
- [ ] Confirm the red LIVE badge still uses the same broadcast glyph
- [ ] On mobile, stall the stream and confirm `stalled` uses the same icon