### PR TITLE
Reset settings without wiping cache or events

### DIFF
--- a/src/app/command_dispatch.rs
+++ b/src/app/command_dispatch.rs
@@ -6,7 +6,7 @@
 //! 1. **Immediate state mutation** — flips a flag or mutates `AppState`
 //!    directly (e.g. `PauseQueue`, `OpenAlert`).
 //! 2. **Async side-effect** — spawns a future via `spawn_local`
-//!    (e.g. `WipeAll`, `CheckEviction`).
+//!    (e.g. `CheckEviction`).
 //! 3. **Deferred fan-out** — recorded on [`CommandOutcome`] so the
 //!    `update()` loop can run the work after worker results land
 //!    (`pump_queue`).
@@ -149,7 +149,7 @@ pub(crate) fn dispatch_state_only(
         //   LocateMeForSite ... browser geolocation
         //   SubmitZip ......... network geocode lookup
         //   ClearCache ........ IDB clear + GPU texture wipe
-        //   WipeAll ........... spawn_local IDB/localStorage wipe + reload
+        //   ResetSettings ..... localStorage reset + reload
         //   CheckEviction ..... spawn_local IDB eviction
         //   RefreshTimeline ... IDB cache-load channel (needs egui ctx)
         //   StartLive ......... opens the realtime stream (needs egui ctx)
@@ -163,7 +163,7 @@ pub(crate) fn dispatch_state_only(
         | Intent::LocateMeForSite
         | Intent::SubmitZip(_)
         | Intent::ClearCache
-        | Intent::WipeAll
+        | Intent::ResetSettings
         | Intent::CheckEviction
         | Intent::RefreshTimeline { .. }
         | Intent::StartLive
@@ -432,7 +432,7 @@ impl WorkbenchApp {
 
             // ---- Storage lifecycle ------------------------------------
             Intent::ClearCache => self.handle_clear_cache(ctx),
-            Intent::WipeAll => self.handle_wipe_all(),
+            Intent::ResetSettings => self.handle_reset_settings(),
             Intent::CheckEviction => self.handle_check_eviction(ctx),
 
             // ---- Timeline ---------------------------------------------
@@ -575,19 +575,36 @@ impl WorkbenchApp {
         }
     }
 
-    fn handle_wipe_all(&mut self) {
-        let facade = self.acquisition.coordinator.facade().clone();
-        wasm_bindgen_futures::spawn_local(async move {
-            if let Err(e) = facade.clear_all().await {
-                log::error!("Failed to clear IndexedDB: {}", e);
-            }
-            if let Some(window) = web_sys::window() {
-                if let Ok(Some(storage)) = window.local_storage() {
-                    let _ = storage.clear();
+    fn handle_reset_settings(&mut self) {
+        let Some(window) = web_sys::window() else {
+            return;
+        };
+        let Ok(Some(storage)) = window.local_storage() else {
+            log::error!("Unable to access localStorage while resetting settings");
+            return;
+        };
+        let Ok(len) = storage.length() else {
+            log::error!("Unable to read localStorage length while resetting settings");
+            return;
+        };
+        let mut keys = Vec::with_capacity(len as usize);
+        for i in 0..len {
+            match storage.key(i) {
+                Ok(Some(key)) => keys.push(key),
+                Ok(None) => {}
+                Err(e) => {
+                    log::error!("Failed to enumerate localStorage keys: {:?}", e);
+                    return;
                 }
-                let _ = window.location().reload();
             }
-        });
+        }
+        for key in crate::state::SavedEvents::keys_to_reset(keys) {
+            if let Err(e) = storage.remove_item(&key) {
+                log::error!("Failed to remove setting {key}: {:?}", e);
+                return;
+            }
+        }
+        let _ = window.location().reload();
     }
 
     fn handle_refresh_timeline(&mut self, ctx: &egui::Context, auto_position: bool) {
@@ -850,7 +867,7 @@ mod dispatch_tests {
             Intent::LocateMeForSite,
             Intent::SubmitZip("50309".to_string()),
             Intent::ClearCache,
-            Intent::WipeAll,
+            Intent::ResetSettings,
             Intent::CheckEviction,
             Intent::RefreshTimeline {
                 auto_position: true,

--- a/src/core/intent.rs
+++ b/src/core/intent.rs
@@ -52,8 +52,8 @@ pub(crate) enum Intent {
     ClearLoop,
     /// Check and run eviction after a storage operation.
     CheckEviction,
-    /// Wipe all data (IndexedDB + localStorage) and reload.
-    WipeAll,
+    /// Reset local settings and preferences while preserving saved events, then reload.
+    ResetSettings,
     /// Pause the acquisition queue.
     PauseQueue,
     /// Resume the acquisition queue.

--- a/src/state/saved_events.rs
+++ b/src/state/saved_events.rs
@@ -29,7 +29,14 @@ pub(crate) struct SavedEvents {
 }
 
 impl SavedEvents {
-    const STORAGE_KEY: &'static str = "nexrad_saved_events";
+    pub(crate) const STORAGE_KEY: &'static str = "nexrad_saved_events";
+
+    /// localStorage keys a settings reset should delete. Saved events stay.
+    pub(crate) fn keys_to_reset(keys: impl IntoIterator<Item = String>) -> Vec<String> {
+        keys.into_iter()
+            .filter(|key| key != Self::STORAGE_KEY)
+            .collect()
+    }
 
     /// Load saved events from localStorage.
     pub(crate) fn load() -> Self {
@@ -136,6 +143,24 @@ mod coverage_tests {
     #[wasm_bindgen_test]
     fn default_is_empty() {
         assert!(SavedEvents::default().events.is_empty());
+    }
+
+    #[wasm_bindgen_test]
+    fn settings_reset_keeps_saved_events_key() {
+        let keys = vec![
+            "nexrad_user_preferences".to_string(),
+            SavedEvents::STORAGE_KEY.to_string(),
+            "nexrad_storage_settings".to_string(),
+            "nexrad_volume_KDMX".to_string(),
+        ];
+        assert_eq!(
+            SavedEvents::keys_to_reset(keys),
+            vec![
+                "nexrad_user_preferences".to_string(),
+                "nexrad_storage_settings".to_string(),
+                "nexrad_volume_KDMX".to_string(),
+            ]
+        );
     }
 
     #[wasm_bindgen_test]

--- a/src/subsystem/chrome.rs
+++ b/src/subsystem/chrome.rs
@@ -36,8 +36,8 @@ pub(crate) struct Chrome {
     pub shortcuts_help_visible: bool,
     /// Whether the site selection modal is open.
     pub site_modal_open: bool,
-    /// Whether the wipe-all-data confirmation modal is open.
-    pub wipe_modal_open: bool,
+    /// Whether the reset-settings confirmation modal is open.
+    pub reset_settings_modal_open: bool,
     /// When set, the range-download confirm modal is open and carries the
     /// pending `(start, end)` selection range to bulk-download on confirm.
     /// `Some` doubles as the open flag; the range is the modal's own snapshot,

--- a/src/ui/event_modal.rs
+++ b/src/ui/event_modal.rs
@@ -1,6 +1,6 @@
 //! Modal for creating, editing, and deleting saved events.
 //!
-//! Follows the same backdrop + centered window pattern as site_modal and wipe_modal.
+//! Follows the same backdrop + centered window pattern as site_modal and reset_settings_modal.
 
 use crate::state::AppState;
 use chrono::{TimeZone, Utc};

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -51,13 +51,13 @@ use super::left_panel::LeftPanelLayer;
 use super::mobile::{MobileChromeLayer, MobileSettingsModalLayer, MobileTopBarLayer};
 use super::mping_modal::MpingModalLayer;
 use super::range_download_modal::RangeDownloadModalLayer;
+use super::reset_settings_modal::ResetSettingsModalLayer;
 use super::right_panel::RightPanelLayer;
 use super::scan_inspector::ScanInspectorLayer;
 use super::shortcuts::ShortcutsHelpLayer;
 use super::site_modal::SiteModalLayer;
 use super::top_bar::TopBarLayer;
 use super::vcp_forecast_modal::VcpForecastModalLayer;
-use super::wipe_modal::WipeModalLayer;
 use crate::state::AppState;
 use crate::subsystem::{Acquisition, Chrome, Derived, Diagnostics, Live, Playback, Timeline};
 use crate::ui::modal_states::ModalStates;
@@ -169,7 +169,7 @@ pub(crate) fn render_layout(is_mobile: bool, ctx: &mut LayoutCtx) {
             // Modals: same set as desktop, in z-order.
             &SiteModalLayer,           // z=10
             &ShortcutsHelpLayer,       // z=20
-            &WipeModalLayer,           // z=30
+            &ResetSettingsModalLayer,  // z=30
             &RangeDownloadModalLayer,  // z=35
             &ActivitySheetLayer,       // z=37
             &ScanInspectorLayer,       // z=38
@@ -189,7 +189,7 @@ pub(crate) fn render_layout(is_mobile: bool, ctx: &mut LayoutCtx) {
             // Modals: same set as mobile, in z-order.
             &SiteModalLayer,           // z=10
             &ShortcutsHelpLayer,       // z=20
-            &WipeModalLayer,           // z=30
+            &ResetSettingsModalLayer,  // z=30
             &RangeDownloadModalLayer,  // z=35
             &ActivitySheetLayer,       // z=37
             &ScanInspectorLayer,       // z=38

--- a/src/ui/mobile/mod.rs
+++ b/src/ui/mobile/mod.rs
@@ -107,7 +107,7 @@ fn any_overlay_open(
         || chrome.site_modal_open
         || chrome.activity_sheet_open
         || chrome.scan_inspector.is_some()
-        || chrome.wipe_modal_open
+        || chrome.reset_settings_modal_open
         || chrome.range_download_modal.is_some()
         || chrome.vcp_forecast_open
         || chrome.event_modal_open

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -35,6 +35,7 @@ mod mping_modal;
 mod overflow_menu;
 mod playback_controls;
 mod range_download_modal;
+mod reset_settings_modal;
 mod right_panel;
 mod scan_inspector;
 mod shortcuts;
@@ -44,7 +45,6 @@ mod timeline;
 mod top_bar;
 mod vcp_forecast_modal;
 mod vcp_forecast_serialize;
-mod wipe_modal;
 
 pub(crate) use canvas::render_canvas_with_geo;
 pub(crate) use event_modal::EventModalState;

--- a/src/ui/reset_settings_modal.rs
+++ b/src/ui/reset_settings_modal.rs
@@ -1,14 +1,14 @@
-//! Confirmation modal for wiping all application data.
+//! Confirmation modal for restoring the default settings.
 //!
-//! Clears IndexedDB stores, localStorage, and reloads the page.
+//! Clears localStorage while retaining saved events, then reloads the page.
 
 use super::layout::{Layer, LayerKind, LayoutCtx};
 use crate::state::AppState;
 use eframe::egui::{self, Color32, RichText, Vec2};
 
-pub(super) struct WipeModalLayer;
+pub(super) struct ResetSettingsModalLayer;
 
-impl Layer for WipeModalLayer {
+impl Layer for ResetSettingsModalLayer {
     fn kind(&self) -> LayerKind {
         LayerKind::Modal
     }
@@ -16,25 +16,25 @@ impl Layer for WipeModalLayer {
         30
     }
     fn visible(&self, ctx: &LayoutCtx) -> bool {
-        ctx.chrome.wipe_modal_open
+        ctx.chrome.reset_settings_modal_open
     }
     fn render(&self, ctx: &mut LayoutCtx) {
-        draw_wipe_modal(ctx.ctx, ctx.state, ctx.chrome);
+        draw_reset_settings_modal(ctx.ctx, ctx.state, ctx.chrome);
     }
 }
 
-fn draw_wipe_modal(
+fn draw_reset_settings_modal(
     ctx: &egui::Context,
     state: &mut AppState,
     chrome: &mut crate::subsystem::Chrome,
 ) {
-    if super::modal_helper::modal_backdrop(ctx, "wipe_modal_backdrop", 180) {
-        chrome.wipe_modal_open = false;
+    if super::modal_helper::modal_backdrop(ctx, "reset_settings_modal_backdrop", 180) {
+        chrome.reset_settings_modal_open = false;
         return;
     }
 
     // Modal window
-    egui::Window::new("Reset Application")
+    egui::Window::new("Reset Settings")
         .collapsible(false)
         .resizable(false)
         .anchor(egui::Align2::CENTER_CENTER, Vec2::ZERO)
@@ -43,17 +43,19 @@ fn draw_wipe_modal(
         .show(ctx, |ui| {
             ui.add_space(8.0);
 
-            ui.label(RichText::new("This will permanently delete all application data:").strong());
+            ui.label(
+                RichText::new("Restore all settings and preferences to their defaults?").strong(),
+            );
 
             ui.add_space(8.0);
 
-            ui.label("  \u{2022} All cached radar data (IndexedDB)");
-            ui.label("  \u{2022} Settings and preferences (localStorage)");
+            ui.label("  \u{2022} Settings and preferences");
+            ui.label("  \u{2022} Saved events and cached radar data will be kept");
 
             ui.add_space(8.0);
 
             ui.label(
-                RichText::new("The page will reload after reset.")
+                RichText::new("The page will reload after resetting settings.")
                     .weak()
                     .italics(),
             );
@@ -64,17 +66,17 @@ fn draw_wipe_modal(
 
             ui.horizontal(|ui| {
                 if ui.button("Cancel").clicked() {
-                    chrome.wipe_modal_open = false;
+                    chrome.reset_settings_modal_open = false;
                 }
 
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                     let reset_btn = ui.add(
-                        egui::Button::new(RichText::new("Reset Everything").color(Color32::WHITE))
+                        egui::Button::new(RichText::new("Reset Settings").color(Color32::WHITE))
                             .fill(Color32::from_rgb(200, 60, 60)),
                     );
                     if reset_btn.clicked() {
-                        chrome.wipe_modal_open = false;
-                        state.push_command(crate::core::Intent::WipeAll);
+                        chrome.reset_settings_modal_open = false;
+                        state.push_command(crate::core::Intent::ResetSettings);
                     }
                 });
             });

--- a/src/ui/right_panel.rs
+++ b/src/ui/right_panel.rs
@@ -791,11 +791,13 @@ pub(super) fn render_storage_section(
             ui.add_space(4.0);
 
             if ui
-                .button("Reset App")
-                .on_hover_text("Wipe all data and settings, then reload")
+                .button("Reset Settings")
+                .on_hover_text(
+                    "Restore default settings while keeping saved events and cached data",
+                )
                 .clicked()
             {
-                chrome.wipe_modal_open = true;
+                chrome.reset_settings_modal_open = true;
             }
         });
 }


### PR DESCRIPTION
## Summary
- Replaces the full-app wipe with a **Reset Settings** control next to Clear Cache
- Restores default preferences while keeping saved events and cached radar data
- Reloads after confirmation so the app boots with factory settings

## Test plan
- [ ] Open Storage, confirm **Reset Settings** sits beside Clear Cache
- [ ] Confirm the modal says saved events and cache are kept
- [ ] Change a preference (theme, quota, layers), save an event, then reset
- [ ] After reload, settings are defaults and the saved event is still there
- [ ] Clear Cache still only deletes cached radar data

Closes #133